### PR TITLE
Add beforeVisit and afterVisit hooks

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -44,9 +44,17 @@ export default {
     clearInterval(this.progressBar)
   },
 
+  beforeVisit() {
+    this.showProgressBar()
+  },
+
+  afterVisit() {
+    this.hideProgressBar()
+  },
+
   visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false } = {}) {
     this.hideModal()
-    this.showProgressBar()
+    this.beforeVisit()
 
     if (this.cancelToken) {
       this.cancelToken.cancel(this.cancelToken)
@@ -89,7 +97,7 @@ export default {
         this.setState(page, replace)
         this.setPage(page).then(() => {
           this.setScroll(preserveScroll)
-          this.hideProgressBar()
+          this.afterVisit()
         })
       }
     })

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -10,7 +10,7 @@ export default {
   progressBar: null,
   modal: null,
 
-  init(page, setPage) {
+  init(page, setPage, beforeVisit = null, afterVisit = null) {
     this.version = page.version
     this.setPage = setPage
 
@@ -19,6 +19,11 @@ export default {
     } else {
       this.setPage(page)
       this.setState(page)
+    }
+
+    if(beforeVisit && afterVisit) {
+      this.beforeVisit = beforeVisit
+      this.afterVisit = afterVisit
     }
 
     window.addEventListener('popstate', this.restoreState.bind(this))


### PR DESCRIPTION
To be able to overwrite nprogess as loading indicator as mentioned in https://github.com/inertiajs/inertia/issues/9  this PR moves nprogess to `beforeVisit` and  `afterVisit` hooks and make it accessible through `Inertia.init`