### PR TITLE
Use the interchangeably clearTimeout instead of clearInterval

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -39,7 +39,7 @@ export default {
 
   hideProgressBar() {
     nprogress.done()
-    clearInterval(this.progressBar)
+    clearTimeout(this.progressBar)
   },
 
   visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false } = {}) {


### PR DESCRIPTION
Thank you for this awesome framework, finally no more SPA worries. 👍🏻

This PR is just a little convention change...

> It's worth noting that the pool of IDs used by setInterval() and setTimeout() are shared, which means you can technically use clearInterval() and clearTimeout() interchangeably. However, for clarity, you should avoid doing so.

Source: [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval)