### PR TITLE
Replace axios with fetch ponyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "author": "Jonathan Reinink",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.18.0",
     "nprogress": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Jonathan Reinink",
   "license": "MIT",
   "dependencies": {
-    "nprogress": "^0.2.0"
+    "nprogress": "^0.2.0",
+    "unfetch-abortable": "0.0.1"
   },
   "devDependencies": {
     "eslint": "^5.15.3"

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -75,7 +75,9 @@ export default {
         ...this.version ? { 'X-Inertia-Version': this.version } : {},
       },
     }).then(response => {
-      if (this.isInertiaResponse(response)) {
+      if (response.status === 409 && response.headers.has('x-inertia-location')) {
+        return this.hardVisit(true, response.headers.get('x-inertia-location'))
+      } else if (this.isInertiaResponse(response)) {
         return response.json()
       } else {
         response.text().then(data => this.showModal(data))
@@ -83,12 +85,6 @@ export default {
     }).catch(error => {
       if (error.name === 'AbortError') {
         return
-      } else if (error.response.status === 409 && error.response.headers.has('x-inertia-location')) {
-        return this.hardVisit(true, error.response.headers.get('x-inertia-location'))
-      } else if (this.isInertiaResponse(error.response)) {
-        return error.response.json()
-      } else if (error.response) {
-        error.response.text().then(data => this.showModal(data))
       } else {
         return Promise.reject(error)
       }

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -1,3 +1,4 @@
+import fetch, { AbortController } from 'unfetch-abortable'
 import nprogress from 'nprogress'
 
 export default {
@@ -60,7 +61,7 @@ export default {
 
     this.abortController = new AbortController()
 
-    return window.fetch(url, {
+    return fetch(url, {
       method: method,
       ...this.hasBody(method) ? { body: JSON.stringify(data) } : {},
       signal: this.abortController.signal,


### PR DESCRIPTION
Hey @reinink and co. I’ve been checking out Inertia recently and really liking it!

One thing that I’d love to see is for the bundle cost to come down a little bit 🔬. I’d like to suggest replacing `axios` with something more lightweight: [`unfetch-abortable`](https://github.com/bradlc/unfetch-abortable) is a fork of [`unfetch`](https://github.com/developit/unfetch/) with support for [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).

To compare the size of the options I created a UMD bundle for each, using [`microbundle`](https://github.com/developit/microbundle):

```
microbundle --entry src/index.js --format umd --external none

With axios
----
inertia.umd.js       19408 B
inertia.umd.js.gz     6959 B
inertia.umd.js.br     6193 B


With unfetch-abortable
----
inertia.umd.js       10072 B (-48%)
inertia.umd.js.gz     3776 B (-46%)
inertia.umd.js.br     3306 B (-47%)
```

It’s worth noting that I have used `unfetch-abortable` for wider browser support. If you remove the import (`src/inertia.js` line 1) the rest of the code works great in browsers that natively support `fetch` and `AbortController` 🎉

Is this something you would be open to? Let me know what you think. Thanks!