### PR TITLE
visit: return setPage

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -85,7 +85,7 @@ export default {
       if (page) {
         this.version = page.version
         this.setState(page, replace)
-        this.setPage(page).then(() => {
+        return this.setPage(page).then(() => {
           this.setScroll(preserveScroll)
           this.hideProgressBar()
         })


### PR DESCRIPTION
👋 This PR adds a `return` at the end of a `visit` so that the promise resolves only once navigation is complete.

Consider the following example:

```js
this.$inertia.visit('/').then(() => {
  console.log('Navigated!')
})
```

### Before

The `visit` promise resolves before the navigation is complete:

![Kapture 2019-05-05 at 19 24 17](https://user-images.githubusercontent.com/2615508/57198641-ffc89f80-6f6c-11e9-96e7-8f2252642fc8.gif)

### After

The `visit` promise resolves once the navigation is complete:

![Kapture 2019-05-05 at 19 32 04](https://user-images.githubusercontent.com/2615508/57198646-0525ea00-6f6d-11e9-958d-c4517898f49a.gif)
