### PR TITLE
Fix reload signature

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -122,7 +122,7 @@ export default {
     return this.visit(url, { ...options, replace: true })
   },
 
-  reload(url, options = {}) {
+  reload(options = {}) {
     return this.replace(window.location.href, options)
   },
 


### PR DESCRIPTION
The `url` variable isn't used and both  the [`inertia-vue` docs](https://github.com/inertiajs/inertia-vue/blame/master/readme.md#L150) and the [`inertia-react` docs ](https://github.com/inertiajs/inertia-react/blame/master/readme.md#L152)reference the `reload` method with only an `options` object.