### PR TITLE
Set the page before hiding the progress bar

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -82,13 +82,15 @@ export default {
         return Promise.reject(error)
       }
     }).then(page => {
-      this.hideProgressBar()
       if (page) {
         this.version = page.version
         this.setState(page, replace)
         return this.setPage(page).then(() => {
           this.setScroll(preserveScroll)
+          this.hideProgressBar()
         })
+      } else {
+        this.hideProgressBar()
       }
     })
   },


### PR DESCRIPTION
Hi again. This is a quick fix for an issue with the progress bar where it is hiding before navigation is complete.

### Before

![Kapture 2019-05-09 at 22 23 39](https://user-images.githubusercontent.com/2615508/57487868-86e98080-72a9-11e9-8801-b415d02caade.gif)

### After

![Kapture 2019-05-09 at 22 25 17](https://user-images.githubusercontent.com/2615508/57487874-8cdf6180-72a9-11e9-9cfa-f545aa6f6869.gif)