### PR TITLE
Fix unwanted intermediate pages

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -52,6 +52,9 @@ export default {
 
     this.cancelToken = axios.CancelToken.source()
 
+    let visitId = {}
+    this.visitId = visitId
+
     return axios({
       method: method,
       url: url,
@@ -85,9 +88,11 @@ export default {
       if (page) {
         this.version = page.version
         this.setState(page, replace)
-        return this.setPage(page).then(() => {
-          this.setScroll(preserveScroll)
-          this.hideProgressBar()
+        return this.setPage(page, () => visitId === this.visitId).then(didUpdate => {
+          if (didUpdate) {
+            this.setScroll(preserveScroll)
+            this.hideProgressBar()
+          }
         })
       } else {
         this.hideProgressBar()

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -10,7 +10,9 @@ export default {
 
   init(page, setPage) {
     this.version = page.version
-    this.setPage = setPage
+    this.setPage = (page, token = this.createToken()) => {
+      return setPage(page, () => token === this.token)
+    }
 
     if (window.history.state && this.navigationType() === 'back_forward') {
       this.setPage(window.history.state)
@@ -42,6 +44,12 @@ export default {
     clearTimeout(this.progressBar)
   },
 
+  createToken() {
+    let token = {}
+    this.token = token
+    return token
+  },
+
   visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false } = {}) {
     this.hideModal()
     this.showProgressBar()
@@ -52,8 +60,7 @@ export default {
 
     this.cancelToken = axios.CancelToken.source()
 
-    let visitId = {}
-    this.visitId = visitId
+    let token = this.createToken()
 
     return axios({
       method: method,
@@ -88,7 +95,7 @@ export default {
       if (page) {
         this.version = page.version
         this.setState(page, replace)
-        return this.setPage(page, () => visitId === this.visitId).then(didUpdate => {
+        return this.setPage(page, token).then(didUpdate => {
           if (didUpdate) {
             this.setScroll(preserveScroll)
             this.hideProgressBar()


### PR DESCRIPTION
This is a tricky one! 🤔 Might need a bit of discussion

First of all here is the problem in action:

![Kapture 2019-05-09 at 22 49 31](https://user-images.githubusercontent.com/2615508/57489743-e4cc9700-72ae-11e9-9783-b96da022239d.gif)

### Steps to reproduce:

1. Open [pingcrm](https://github.com/inertiajs/pingcrm) in Firefox
2. Click on `Organizations`
3. As soon as the address bar changes to `/organizations` click on `Contacts`
4. See that the Organizations page is visible briefly

> **Note:** Weirdly, I cannot reproduce this in Chrome. Also, you may need to throttle the network to see what’s going on

### Why does this happen?

When `visit` is called any inflight request is cancelled using an axios cancel token, causing the previous `visit` to reject. All good! **But this only cancels the initial request to the backend.** If we initiate a new visit _after_ the axios request has resolved but _before_ `setPage` has resolved then the initial visit will still resolve successfully and render. In theory you could even end up on the first page that you clicked on if it takes longer to resolve than the second!

### What’s the fix?

There’s probably a few ways to fix this, and this might not be the best so other ideas are welcome.

~~When `visit` is called an object is created (`visitId`) that acts as a unique ID for the visit. This is also stored against `this.visitId`. We can then compare `visitId` to `this.visitId` to determine if the current visit is the most recent.~~

> ~~**Note:** there are a few ways this could be done. For example, instead of an object we could use the axios promise, or a timestamp, as a unique ID~~

I have updated the PR to include a wrapper around `setPage` instead, so it covers `restoreState` as well. Each `setPage` call has a token which is compared against the current "active" token to determine if the component should update or not.

> **Note:** I don’t think `token` is a good name for this but couldn’t think of anything else

Once `this.setPage` is called it’s out of our hands. That goes off, resolves the component, and renders it. So we pass a second argument, `shouldUpdate`, which can be used to verify that it’s still ok to render. There is a [companion PR](https://github.com/inertiajs/inertia-vue/pull/28) which implements this for `inertia-vue`.

Any thoughts?