### PR TITLE
Replace instead of push initial state

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -16,7 +16,7 @@ export default {
       this.setPage(window.history.state)
     } else {
       this.setPage(page)
-      this.setState(page)
+      this.setState(page, true)
     }
 
     window.addEventListener('popstate', this.restoreState.bind(this))


### PR DESCRIPTION
This avoids creating an additional history entry on intial load.

For example, currently if you open an Inertia app in a new window/tab you need to hit back _twice_ to leave.