### PR TITLE
Replace instead of push remembered state

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -149,7 +149,7 @@ export default {
     this.setState({
       ...window.history.state,
       cache: { ...window.history.state.cache, [key]: data }
-    })
+    }, true)
   },
 
   restore(key = 'default') {


### PR DESCRIPTION
Currently when you `remember` something a new history entry is created. For example, when filling out a form on pingcrm, you end up with a load of entries for the same URL 🙈