### PR TITLE
Allow passing query parameters for GET requests

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -55,7 +55,8 @@ export default {
     return axios({
       method: method,
       url: url,
-      data: data,
+      data: method.toLowerCase() === 'get' ? {} : data,
+      params: method.toLowerCase() === 'get' ? data : {},
       cancelToken: this.cancelToken.token,
       headers: {
         'Accept': 'text/html, application/xhtml+xml',


### PR DESCRIPTION
Right now it's not possible to pass query parameters to `Inertia.visit`, as the `data` variable gets passed as `data` to axios - which is only for actual POST/PUT/etc. data.
This PR allows making use of the data object, in case of a GET request.