### PR TITLE
Replace axios with window.fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "author": "Jonathan Reinink",
   "license": "MIT",
   "dependencies": {
-    "nprogress": "^0.2.0",
-    "unfetch-abortable": "0.0.1"
+    "nprogress": "^0.2.0"
   },
   "devDependencies": {
     "eslint": "^5.15.3"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "author": "Jonathan Reinink",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.18.0",
     "nprogress": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Jonathan Reinink",
   "license": "MIT",
   "dependencies": {
-    "nprogress": "^0.2.0"
+    "nprogress": "^0.2.0",
+    "unfetch-abortable": "0.0.1"
   },
   "devDependencies": {
     "eslint": "^5.15.3"

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -75,7 +75,9 @@ export default {
         ...this.version ? { 'X-Inertia-Version': this.version } : {},
       },
     }).then(response => {
-      if (this.isInertiaResponse(response)) {
+      if (response.status === 409 && response.headers.has('x-inertia-location')) {
+        return this.hardVisit(true, response.headers.get('x-inertia-location'))
+      } else if (this.isInertiaResponse(response)) {
         return response.json()
       } else {
         response.text().then(data => this.showModal(data))
@@ -83,12 +85,6 @@ export default {
     }).catch(error => {
       if (error.name === 'AbortError') {
         return
-      } else if (error.response.status === 409 && error.response.headers.has('x-inertia-location')) {
-        return this.hardVisit(true, error.response.headers.get('x-inertia-location'))
-      } else if (this.isInertiaResponse(error.response)) {
-        return error.response.json()
-      } else if (error.response) {
-        error.response.text().then(data => this.showModal(data))
       } else {
         return Promise.reject(error)
       }

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -1,4 +1,3 @@
-import fetch, { AbortController } from 'unfetch-abortable'
 import nprogress from 'nprogress'
 
 export default {
@@ -61,7 +60,7 @@ export default {
 
     this.abortController = new AbortController()
 
-    return fetch(url, {
+    return window.fetch(url, {
       method: method,
       ...this.hasBody(method) ? { body: JSON.stringify(data) } : {},
       signal: this.abortController.signal,

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -1,3 +1,4 @@
+import fetch, { AbortController } from 'unfetch-abortable'
 import nprogress from 'nprogress'
 
 export default {
@@ -60,7 +61,7 @@ export default {
 
     this.abortController = new AbortController()
 
-    return window.fetch(url, {
+    return fetch(url, {
       method: method,
       ...this.hasBody(method) ? { body: JSON.stringify(data) } : {},
       signal: this.abortController.signal,


### PR DESCRIPTION
As discussed in #19, this PR replaces `axios` with browser-native `fetch` and `AbortController`, significantly reducing the size of Inertia for those that don’t use `axios` elsewhere in their app.

Out-of-the-box browser support is reduced to [those that support `fetch` and `AbortController`](https://caniuse.com/#feat=abortcontroller), but users can polyfill these to increase support. If that feels like it’s burdening the user too much, you could provide a build with polyfills included, or something like that.