### PR TITLE
Add option to preserve (local) state

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -66,7 +66,7 @@ export default {
     return this.visitId
   },
 
-  visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false } = {}) {
+  visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false, preserveState = false } = {}) {
     this.startProgressBar()
     this.cancelActiveVisits()
     let visitId = this.createVisitId()
@@ -105,7 +105,7 @@ export default {
       }
     }).then(page => {
       if (page) {
-        this.setPage(page, visitId, replace, preserveScroll)
+        this.setPage(page, visitId, replace, preserveScroll, preserveState)
       }
     })
   },
@@ -118,13 +118,13 @@ export default {
     }
   },
 
-  setPage(page, visitId = this.createVisitId(), replace = false, preserveScroll = false) {
+  setPage(page, visitId = this.createVisitId(), replace = false, preserveScroll = false, preserveState = false) {
     this.incrementProgressBar()
     return this.resolveComponent(page.component).then(component => {
       if (visitId === this.visitId) {
         this.version = page.version
         this.setState(page, replace)
-        this.updatePage(component, page.props)
+        this.updatePage(component, page.props, preserveState)
         this.setScroll(preserveScroll)
         this.stopProgressBar()
       }
@@ -159,15 +159,15 @@ export default {
     return this.replace(window.location.href, options)
   },
 
-  post(url, data = {}, options = {}) {
+  post(url, data = {}, options = { preserveState: true }) {
     return this.visit(url, { ...options, method: 'post', data })
   },
 
-  put(url, data = {}, options = {}) {
+  put(url, data = {}, options = { preserveState: true }) {
     return this.visit(url, { ...options, method: 'put', data })
   },
 
-  patch(url, data = {}, options = {}) {
+  patch(url, data = {}, options = { preserveState: true }) {
     return this.visit(url, { ...options, method: 'patch', data })
   },
 

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -124,7 +124,7 @@ export default {
       if (visitId === this.visitId) {
         this.version = page.version
         this.setState(page, replace)
-        this.updatePage(component, page.props, preserveState)
+        this.updatePage(component, page.props, { preserveState })
         this.setScroll(preserveScroll)
         this.stopProgressBar()
       }

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -151,24 +151,24 @@ export default {
     }
   },
 
-  replace(url, options = { preserveState: true }) {
-    return this.visit(url, { ...options, replace: true })
+  replace(url, options = {}) {
+    return this.visit(url, { preserveState: true, ...options, replace: true })
   },
 
   reload(options = {}) {
     return this.replace(window.location.href, options)
   },
 
-  post(url, data = {}, options = { preserveState: true }) {
-    return this.visit(url, { ...options, method: 'post', data })
+  post(url, data = {}, options = {}) {
+    return this.visit(url, { preserveState: true, ...options, method: 'post', data })
   },
 
-  put(url, data = {}, options = { preserveState: true }) {
-    return this.visit(url, { ...options, method: 'put', data })
+  put(url, data = {}, options = {}) {
+    return this.visit(url, { preserveState: true, ...options, method: 'put', data })
   },
 
-  patch(url, data = {}, options = { preserveState: true }) {
-    return this.visit(url, { ...options, method: 'patch', data })
+  patch(url, data = {}, options = {}) {
+    return this.visit(url, { preserveState: true, ...options, method: 'patch', data })
   },
 
   delete(url, options = {}) {

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -151,7 +151,7 @@ export default {
     }
   },
 
-  replace(url, options = {}) {
+  replace(url, options = { preserveState: true }) {
     return this.visit(url, { ...options, replace: true })
   },
 


### PR DESCRIPTION
This adds a new `preserveState` option to Inertia, which is intended to be used by the adapters to either force a component rerender, or allow them to maintain any existing local state. Currently the adapters _do preserve state_, but that's often not preferred, especially for `GET` requests. This change makes this more of a "first class" feature.

The preserve state default is based on the method type, as follows:

- `visit()`: `{ preserveState: false }`
- `replace()`: `{ preserveState: true }`
- `post()`: `{ preserveState: true }`
- `put()`: `{ preserveState: true }`
- `patch()`: `{ preserveState: true }`
- `delete()`: `{ preserveState: false }`

These defaults can be changed on a per visit basis:

```js
// Preserve on GET (defaults to false)
this.$inertia.visit('/url', { preserveState: true })

// Do not preserve on POST (defaults to true)
this.$inertia.post('/url', data, { preserveState: false })
```

Closes #17