### PR TITLE
Refactor TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,71 +4,75 @@ declare namespace Inertia {
   interface PageProps {}
 
   interface Page<CustomPageProps extends PageProps = {}> {
-    component: string
-    props: CustomPageProps
-    url: string
-    version: string | null
+    component: string;
+    props: CustomPageProps;
+    url: string;
+    version: string | null;
   }
 
   type SpecificVisitOptions = Pick<
     VisitOptions,
-    'preserveScroll' | 'preserveState' | 'replace'
-  >
+    "preserveScroll" | "preserveState" | "replace"
+  >;
 
   type SpecificVisit = (
     url: string,
-    data?: VisitOptions['data'],
+    data?: VisitOptions["data"],
     options?: SpecificVisitOptions
-  ) => Promise<void>
+  ) => Promise<void>;
 
-  type ReloadOptions = ReplaceOptions
+  type ReloadOptions = ReplaceOptions;
 
-  type RememberData = object
+  type RememberData = object;
 
-  type ReplaceOptions = Pick<VisitOptions, 'data' | 'method' | 'preserveScroll'>
+  type ReplaceOptions = Pick<
+    VisitOptions,
+    "data" | "method" | "preserveScroll"
+  >;
 
   interface VisitOptions {
-    data?: object
-    method?: string
-    preserveScroll?: boolean
-    preserveState?: boolean
-    replace?: boolean
+    data?: object;
+    method?: string;
+    preserveScroll?: boolean;
+    preserveState?: boolean;
+    replace?: boolean;
   }
 
   interface UpdatePageOptions {
-    preserveState: VisitOptions['preserveState']
+    preserveState: VisitOptions["preserveState"];
   }
 
   interface Inertia {
-    delete: SpecificVisit
-    init: <Component, CustomPageProps extends PagePropsBeforeTransform = {}>(
-      arguments: {
-        initialPage: Page<CustomPageProps>
-        resolveComponent: (name: string) => Promise<Component>
-        updatePage: (
-          component: Component,
-          props: CustomPageProps,
-          options: UpdatePageOptions
-        ) => void
-      }
-    ) => void
-    patch: SpecificVisit
-    post: SpecificVisit
-    put: SpecificVisit
-    reload: (options?: ReloadOptions) => Promise<void>
-    remember: (data: RememberData, key?: string) => void
-    replace: (url: string, options?: ReplaceOptions) => Promise<void>
-    restore: (key?: string) => RememberData
-    visit: (url: string, options?: VisitOptions) => Promise<void>
+    delete: SpecificVisit;
+    init: <
+      Component,
+      CustomPageProps extends PagePropsBeforeTransform = {}
+    >(arguments: {
+      initialPage: Page<CustomPageProps>;
+      resolveComponent: (name: string) => Promise<Component>;
+      updatePage: (
+        component: Component,
+        props: CustomPageProps,
+        options: UpdatePageOptions
+      ) => void;
+    }) => void;
+    patch: SpecificVisit;
+    post: SpecificVisit;
+    put: SpecificVisit;
+    reload: (options?: ReloadOptions) => Promise<void>;
+    remember: (data: RememberData, key?: string) => void;
+    replace: (url: string, options?: ReplaceOptions) => Promise<void>;
+    restore: (key?: string) => RememberData;
+    visit: (url: string, options?: VisitOptions) => Promise<void>;
   }
 
-  type shouldIntercept = (event: MouseEvent | KeyboardEvent) => boolean
+  type shouldIntercept = (event: MouseEvent | KeyboardEvent) => boolean;
 }
 
-declare module 'inertia' {
-  export const shouldIntercept: Inertia.shouldIntercept
+declare module "inertia" {
+  export const shouldIntercept: Inertia.shouldIntercept;
 
-  const _default: Inertia.Inertia
+  const _default: Inertia.Inertia;
 
-  export default _default
+  export default _default;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,24 +9,24 @@ declare namespace Inertia {
     url: string
     version: string | null
   }
-  
+
   type SpecificVisitOptions = Pick<
     VisitOptions,
     'preserveScroll' | 'preserveState' | 'replace'
   >
-  
+
   type SpecificVisit = (
     url: string,
     data?: VisitOptions['data'],
     options?: SpecificVisitOptions
   ) => Promise<void>
-  
+
   type ReloadOptions = ReplaceOptions
-  
+
   type RememberData = object
-  
+
   type ReplaceOptions = Pick<VisitOptions, 'data' | 'method' | 'preserveScroll'>
-  
+
   interface VisitOptions {
     data?: object
     method?: string
@@ -34,7 +34,7 @@ declare namespace Inertia {
     preserveState?: boolean
     replace?: boolean
   }
-  
+
   interface UpdatePageOptions {
     preserveState: VisitOptions['preserveState']
   }
@@ -61,7 +61,7 @@ declare namespace Inertia {
     restore: (key?: string) => RememberData
     visit: (url: string, options?: VisitOptions) => Promise<void>
   }
-  
+
   type shouldIntercept = (event: MouseEvent | KeyboardEvent) => boolean
 }
 
@@ -69,6 +69,6 @@ declare module 'inertia' {
   export const shouldIntercept: Inertia.shouldIntercept
 
   const _default: Inertia.Inertia
-  
+
   export default _default
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,65 +1,74 @@
-interface PageProps {}
+declare namespace Inertia {
+  interface PagePropsBeforeTransform {}
 
-interface Page<CustomPageProps extends PageProps = {}> {
-  component: string
-  props: CustomPageProps
-  url: string
-  version: string | null
+  interface PageProps {}
+
+  interface Page<CustomPageProps extends PageProps = {}> {
+    component: string
+    props: CustomPageProps
+    url: string
+    version: string | null
+  }
+  
+  type SpecificVisitOptions = Pick<
+    VisitOptions,
+    'preserveScroll' | 'preserveState' | 'replace'
+  >
+  
+  type SpecificVisit = (
+    url: string,
+    data?: VisitOptions['data'],
+    options?: SpecificVisitOptions
+  ) => Promise<void>
+  
+  type ReloadOptions = ReplaceOptions
+  
+  type RememberData = object
+  
+  type ReplaceOptions = Pick<VisitOptions, 'data' | 'method' | 'preserveScroll'>
+  
+  interface VisitOptions {
+    data?: object
+    method?: string
+    preserveScroll?: boolean
+    preserveState?: boolean
+    replace?: boolean
+  }
+  
+  interface UpdatePageOptions {
+    preserveState: VisitOptions['preserveState']
+  }
+
+  interface Inertia {
+    delete: SpecificVisit
+    init: <Component, CustomPageProps extends PagePropsBeforeTransform = {}>(
+      arguments: {
+        initialPage: Page<CustomPageProps>
+        resolveComponent: (name: string) => Promise<Component>
+        updatePage: (
+          component: Component,
+          props: CustomPageProps,
+          options: UpdatePageOptions
+        ) => void
+      }
+    ) => void
+    patch: SpecificVisit
+    post: SpecificVisit
+    put: SpecificVisit
+    reload: (options?: ReloadOptions) => Promise<void>
+    remember: (data: RememberData, key?: string) => void
+    replace: (url: string, options?: ReplaceOptions) => Promise<void>
+    restore: (key?: string) => RememberData
+    visit: (url: string, options?: VisitOptions) => Promise<void>
+  }
+  
+  type shouldIntercept = (event: MouseEvent | KeyboardEvent) => boolean
 }
 
-type SpecificVisitOptions = Pick<
-  VisitOptions,
-  'preserveScroll' | 'preserveState' | 'replace'
->
-type SpecificVisit = (
-  url: string,
-  data?: VisitOptions['data'],
-  options?: SpecificVisitOptions
-) => Promise<void>
+declare module 'inertia' {
+  export const shouldIntercept: Inertia.shouldIntercept
 
-type ReloadOptions = ReplaceOptions
-
-type RememberData = object
-
-type ReplaceOptions = Pick<VisitOptions, 'data' | 'method' | 'preserveScroll'>
-
-interface VisitOptions {
-  data?: object
-  method?: string
-  preserveScroll?: boolean
-  preserveState?: boolean
-  replace?: boolean
+  const _default: Inertia.Inertia
+  
+  export default _default
 }
-
-interface UpdatePageOptions {
-  preserveState: VisitOptions['preserveState']
-}
-interface InitArguments<Component, CustomPageProps extends PageProps = {}> {
-  initialPage: Page<CustomPageProps>
-  resolveComponent: (name: string) => Promise<Component>
-  updatePage: (
-    component: Component,
-    props: CustomPageProps,
-    options: UpdatePageOptions
-  ) => void
-}
-
-interface Inertia {
-  delete: SpecificVisit
-  init: <Component, CustomPageProps extends PageProps = {}>(
-    arguments: InitArguments<Component, CustomPageProps>
-  ) => void
-  patch: SpecificVisit
-  post: SpecificVisit
-  put: SpecificVisit
-  reload: (options?: ReloadOptions) => Promise<void>
-  remember: (data: RememberData, key?: string) => void
-  replace: (url: string, options?: ReplaceOptions) => Promise<void>
-  restore: (key?: string) => RememberData
-  visit: (url: string, options?: VisitOptions) => Promise<void>
-}
-
-declare function shouldIntercept(event: MouseEvent | KeyboardEvent): boolean
-
-export default Inertia
-export { Page, PageProps, shouldIntercept }


### PR DESCRIPTION
Unfortunately the initial implementation of the types didn't work out too good in practice.

Refactors I had to do to get things working:

- Use `namespace`s
- Use `module`s

Other changes:

- Simplified a few abstractions
- Reworked `PagePropsBeforeTransform` and `PageProps`

They're far from perfect, but they're working now. Will revisit later. Apparently typing libraries is very fragile, so I don't really want to make any further changes until we have some sort of test environment up.