### PR TITLE
Allow customizing request headers

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -45,7 +45,7 @@ export default {
     return this.visitId
   },
 
-  visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false, preserveState = false } = {}) {
+  visit(url, { method = 'get', data = {}, headers = {}, replace = false, preserveScroll = false, preserveState = false } = {}) {
     Progress.start()
     this.cancelActiveVisits()
     let visitId = this.createVisitId()
@@ -61,6 +61,7 @@ export default {
         'X-Requested-With': 'XMLHttpRequest',
         'X-Inertia': true,
         ...(this.version ? { 'X-Inertia-Version': this.version } : {}),
+        ...headers,
       },
     }).then(response => {
       if (this.isInertiaResponse(response)) {


### PR DESCRIPTION
This will allow users to customize request headers when using Inertia to send requests.

One of uses for this is to set "Content-Type" header to "multipart/form-data" when uploading files using `FormData` object. This particular case has been mention here: https://github.com/inertiajs/inertia-vue/issues/48

Cheers 🙂 