### PR TITLE
Replace nprogress by nanobar

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "typings": "index.d.ts",
   "dependencies": {
     "axios": "^0.18.0",
-    "nprogress": "^0.2.0"
+    "nanobar": "^0.4.2"
   },
   "devDependencies": {
     "eslint": "^5.15.3"

--- a/src/progress.js
+++ b/src/progress.js
@@ -1,6 +1,6 @@
-import Nprogress from 'nprogress'
+import Nanobar from 'nanobar'
 
-Nprogress.configure({ showSpinner: false })
+const nanobar = new Nanobar()
 
 export default {
   delay: null,
@@ -11,14 +11,13 @@ export default {
 
     this.delay = setTimeout(() => {
       this.loading = true
-      Nprogress.set(0)
-      Nprogress.start()
+      nanobar.go(10)
     }, 250)
   },
 
   increment() {
     if (this.loading) {
-      Nprogress.inc(0.4)
+      nanobar.go(50)
     }
   },
 
@@ -26,7 +25,7 @@ export default {
     clearTimeout(this.delay)
 
     if (this.loading) {
-      Nprogress.done()
+      nanobar.go(100)
       this.loading = false
     }
   },


### PR DESCRIPTION
Nanobar solves inertiajs/inertia#10. It injects the CSS needed to display the bar. The CSS classes can be easily customized. It is just ~720b after compression.