### PR TITLE
Pass initial window hash to initialPage

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -16,6 +16,7 @@ export default {
     if (window.history.state && this.navigationType() === 'back_forward') {
       this.setPage(window.history.state)
     } else {
+      initialPage.url += window.location.hash;
       this.setPage(initialPage)
     }
 


### PR DESCRIPTION
Since the `initialPage` gets generated on the server side, it will never contain the current window hash. This currently results in some unwanted behavior.

When you open: `http://localhost/view#something` you will end up at `http://localhost/view` without the current hash.

This PR adds it to the initial page so that you can retain the hash.