### PR TITLE
Add support for partial reloads

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -62,7 +62,10 @@ export default {
         Accept: 'text/html, application/xhtml+xml',
         'X-Requested-With': 'XMLHttpRequest',
         'X-Inertia': true,
-        ...(only ? { 'X-Inertia-Only': only.join(',') } : {}),
+        ...(only ? {
+          'X-Inertia-Partial-Component': this.page.component,
+          'X-Inertia-Partial-Data': only.join(','),
+        } : {}),
         ...(this.version ? { 'X-Inertia-Version': this.version } : {}),
       },
     }).then(response => {


### PR DESCRIPTION
This PR adds support for partial reloads (#60). **This is still a work-in-progress.**

Partial reloads allow you to make subsequent visits to the _same page_ and only request a subset of the props (data) from the server. You do this with a new `only` option on visits.

```js
Inertia.reload({ only: ['users'] });
```

This requires coordination server-side to return only the subset of data. To do this Inertia passes along a new `X-Inertia-Only` header which includes a comma separated list of data keys that will returned. For example:

```php
X-Inertia-Only: users
```

When the server returns a subset of the data from the server, Inertia automatically merges it with the full page object from the previous request that's already in memory.

You can see the Laravel implementation of this here: https://github.com/inertiajs/inertia-laravel/pull/50

## Limiting partial page loads

Currently the `only` option is available for all visit types (not only `reload`) because it was easiest to implement it that way. I don't really see a way to make partial loading not working when going to other pages, so it probably makes sense to limit this. Or, maybe we just throw an exception if you try to make a partial request to a different URL. This still needs to be figured out.

At first I thought we'd just use `Inertia.reload()`. However, that only does `GET` requests. I could see you potentially doing partial reloads on `POST`, `PUT`, `PATCH` and `DELETE`.

Then again, doing this with non-`GET` requests is actually pretty dark territory. It means that the front-end has to know which endpoint the server will redirect to, and that actually could be different depending on the result. For example, on a form validation error it would return to the same page, but maybe on success it redirects to the index. That would mean it's now has the `X-Inertia-Only` header when navigating to a different page. Not good.

I think it probably makes the most sense to simply include the current page component name in the header as well. For example:

```php
X-Inertia-Only: [Users/Index,users]
```

My fear is that even a GET request could end up redirecting elsewhere...for whatever reason. For example, the user gets logged out. Or their permission change. Or SOMETHING. Now suddenly they are doing a partial reload on a different page.

If we include the page component name in the header, we can make sure we only implement it if the final page component is the same. That also means we don't have to limit it to `Inertia.reload()`, since it will literally only work if the final endpoint uses the same page component.

Closes #60.