### PR TITLE
Preserve state on hard visit

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -16,6 +16,9 @@ export default {
 
     if (window.history.state && this.navigationType() === 'back_forward') {
       this.setPage(window.history.state)
+    } else if (window.localStorage.getItem('inertia.hardVisit')) {
+      window.localStorage.removeItem('inertia.hardVisit')
+      this.setPage(initialPage, { preserveState: true })
     } else {
       initialPage.url += window.location.hash;
       this.setPage(initialPage)
@@ -94,12 +97,14 @@ export default {
           page.props = { ...this.page.props, ...page.props }
         }
 
-        return this.setPage(page, visitId, replace, preserveScroll, preserveState)
+        return this.setPage(page, { visitId, replace, preserveScroll, preserveState })
       }
     })
   },
 
   hardVisit(replace, url) {
+    window.localStorage.setItem('inertia.hardVisit', true)
+
     if (replace) {
       window.location.replace(url)
     } else {
@@ -107,7 +112,7 @@ export default {
     }
   },
 
-  setPage(page, visitId = this.createVisitId(), replace = false, preserveScroll = false, preserveState = false) {
+  setPage(page, { visitId = this.createVisitId(), replace = false, preserveScroll = false, preserveState = false } = {}) {
     this.page = page
     Progress.increment()
     return Promise.resolve(this.resolveComponent(page.component)).then(component => {

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -16,8 +16,8 @@ export default {
 
     if (window.history.state && this.navigationType() === 'back_forward') {
       this.setPage(window.history.state)
-    } else if (window.localStorage.getItem('inertia.hardVisit')) {
-      window.localStorage.removeItem('inertia.hardVisit')
+    } else if (window.sessionStorage.getItem('inertia.hardVisit')) {
+      window.sessionStorage.removeItem('inertia.hardVisit')
       this.setPage(initialPage, { preserveState: true })
     } else {
       initialPage.url += window.location.hash;
@@ -103,7 +103,7 @@ export default {
   },
 
   hardVisit(replace, url) {
-    window.localStorage.setItem('inertia.hardVisit', true)
+    window.sessionStorage.setItem('inertia.hardVisit', true)
 
     if (replace) {
       window.location.replace(url)


### PR DESCRIPTION
Right now when Inertia detects an asset version change, it does a hard visit (full page reload) to force update the assets. During this process it must maintain both server-side and client-side state.

Server-side "state" includes any flash messages or validation errors. The Inertia middleware solves this by [reflashing the values](https://github.com/inertiajs/inertia-laravel/blob/master/src/Middleware.php#L21) automatically.

Client-side state also needs to be preserved. This PR updates Inertia to do this. The challenge is, by default, on a hard page reload, Inertia will not restore state. This is to match default browser behaviour.

To get around this, Inertia creates a temporary `inertia.hardVisit` boolean in local storage. If that value exists on reload, it will restore remembered state just like a normal back/forward navigation.

Note in this video how Inertia is remembering 1) the flash message, 2) validation errors, 3) local form values across a **full page reload**. 🎊 

![2019-08-12 09 40 07](https://user-images.githubusercontent.com/882133/62869180-4f91d200-bce5-11e9-9b42-060dc741c791.gif)
