### PR TITLE
Modernize typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,74 +1,69 @@
-declare namespace Inertia {
-  interface PagePropsBeforeTransform {}
+declare global {
+  // These open interfaces may be extended in an application-specific manner via
+  // declaration merging / interface augmentation.
+  namespace Inertia {
+    interface PagePropsBeforeTransform {}
 
-  interface PageProps {}
-
-  interface Page<CustomPageProps extends PageProps = PageProps> {
-    component: string;
-    props: CustomPageProps;
-    url: string;
-    version: string | null;
+    interface PageProps {}
   }
+}
 
-  type VisitOptions = {
-    method?: string;
-    preserveScroll?: boolean;
-    preserveState?: boolean;
-    replace?: boolean;
-    only?: Array<string>;
-  };
+export type PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform
+export type PageProps = Inertia.PageProps
 
-  interface Inertia {
-    init: <
-      Component,
-      CustomPageProps extends PagePropsBeforeTransform = PagePropsBeforeTransform
+export interface Page<CustomPageProps extends PageProps = PageProps> {
+  component: string
+  props: CustomPageProps
+  url: string
+  version: string | null
+}
+
+type VisitOptions = {
+  method?: string
+  preserveScroll?: boolean
+  preserveState?: boolean
+  replace?: boolean
+  only?: string[]
+}
+
+interface Inertia {
+  init: <
+    Component,
+    CustomPageProps extends PagePropsBeforeTransform = PagePropsBeforeTransform
     >(arguments: {
-      initialPage: Page<CustomPageProps>;
-      resolveComponent: (name: string) => Component | Promise<Component>;
-      updatePage: (
-        component: Component,
-        props: CustomPageProps,
-        options: {
-          preserveState: boolean;
-        }
-      ) => void;
-    }) => void;
+    initialPage: Page<CustomPageProps>
+    resolveComponent: (name: string) => Component | Promise<Component>
+    updatePage: (
+      component: Component,
+      props: CustomPageProps,
+      options: {
+        preserveState: boolean
+      }
+    ) => void
+  }) => void
 
-    visit: (
-      url: string,
-      options?: VisitOptions & { data?: object }
-    ) => Promise<void>;
+  visit: (
+    url: string,
+    options?: VisitOptions & { data?: object }
+  ) => Promise<void>
 
-    patch: (
-      url: string,
-      data?: object,
-      options?: VisitOptions
-    ) => Promise<void>;
+  patch: (url: string, data?: object, options?: VisitOptions) => Promise<void>
 
-    post: (url: string, data?: object, options?: VisitOptions) => Promise<void>;
+  post: (url: string, data?: object, options?: VisitOptions) => Promise<void>
 
-    put: (url: string, data?: object, options?: VisitOptions) => Promise<void>;
+  put: (url: string, data?: object, options?: VisitOptions) => Promise<void>
 
-    delete: (
-      url: string,
-      data?: object,
-      options?: VisitOptions
-    ) => Promise<void>;
+  delete: (url: string, data?: object, options?: VisitOptions) => Promise<void>
 
-    reload: (options?: VisitOptions) => Promise<void>;
+  reload: (options?: VisitOptions) => Promise<void>
 
-    replace: (url: string, options?: VisitOptions) => Promise<void>;
+  replace: (url: string, options?: VisitOptions) => Promise<void>
 
-    remember: (data: object, key?: string) => void;
+  remember: (data: object, key?: string) => void
 
-    restore: (key?: string) => object;
-  }
-
-  type shouldIntercept = (event: MouseEvent | KeyboardEvent) => boolean;
+  restore: (key?: string) => object
 }
 
-declare module "@inertiajs/inertia" {
-  export const Inertia: Inertia.Inertia;
+export const Inertia: Inertia
 
-  export const shouldIntercept: Inertia.shouldIntercept;
-}
+export const shouldIntercept: (event: MouseEvent | KeyboardEvent) => boolean


### PR DESCRIPTION
After coming across [`@types/express-serve-static-core`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/express-serve-static-core/index.d.ts), I finally found a way of not needing to declare a module (which is an ES5 way of doing things).

Right now we just export the same things like we do in [index.js](https://github.com/inertiajs/inertia/blob/master/src/index.js).
We also export `PagePropsBeforeTransform`, `PageProps` and `Page`, since they're used in the `inertia-react` adapter.
All other types aren't exported anymore and stay private.

`PagePropsBeforeTransform` and `PageProps` can still be overwritten globally via declaration merging/interface augmentation.

I think @sebastiandedeyne should check this out in his practice project to see if everything still works like expected (I think it does), since I don't have access to that project.