### PR TITLE
Merge query parameters when calling reload

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -149,12 +149,25 @@ export default {
     }
   },
 
+  mergeQueryParameters(dataToMerge = {}) {
+    let urlSearchParams = new URLSearchParams(window.location.search)
+    let queryParameters = {}
+
+    for(let parameter of urlSearchParams.entries()) {
+      const [key, value] = parameter
+      merged[key] = value
+    }
+
+    return Object.assign(queryParameters, dataToMerge)
+  },
+
   replace(url, options = {}) {
     return this.visit(url, { preserveState: true, ...options, replace: true })
   },
 
   reload(options = {}) {
-    return this.replace(window.location.href, options)
+    options.data = this.mergeQueryParameters(options.data)
+    return this.replace(window.location.origin + window.location.pathname, options)
   },
 
   post(url, data = {}, options = {}) {

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -155,7 +155,7 @@ export default {
 
     for(let parameter of urlSearchParams.entries()) {
       const [key, value] = parameter
-      merged[key] = value
+      queryParameters[key] = value
     }
 
     return Object.assign(queryParameters, dataToMerge)

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -166,7 +166,7 @@ export default {
   },
 
   reload(options = {}) {
-    options.data = this.mergeQueryParameters(options.data)
+    options.data = this.mergeQueryParameters(options.data || {})
     return this.replace(window.location.origin + window.location.pathname, options)
   },
 


### PR DESCRIPTION
This PR is a proposed way to fix the issue #65.

When a user calls the `reload` method, it calls the `mergeQueryParameters` method and sets the result to the `data` option.

The `mergeQueryParameters` simply creates an object based upon the current query parameters and merges them with the parameters provided by the user.

The `reload` method has then been changed so that rather than passing the full url including query parameters, it constructs the url itself using the origin and the pathname. 