### PR TITLE
setScroll add html to query selector

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -128,7 +128,7 @@ export default {
 
   setScroll(preserveScroll) {
     if (!preserveScroll) {
-      document.querySelectorAll('body,[scroll-region]')
+      document.querySelectorAll('html,body,[scroll-region]')
         .forEach(region => region.scrollTo(0, 0))
     }
   },


### PR DESCRIPTION
Some browsers apply the "overall" scroll to document.documentElement (the <html> element) and others to document.body (the <body> element). For compatibility with both, you have to apply the scrolling to both.