### PR TITLE
add box-sizing: border-box to modal

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -12,6 +12,7 @@ export default {
     this.modal.style.width = '100vw'
     this.modal.style.height = '100vh'
     this.modal.style.padding = '50px'
+    this.modal.style.boxSizing = 'border-box'
     this.modal.style.backgroundColor = 'rgba(0, 0, 0, .6)'
     this.modal.style.zIndex = 200000
     this.modal.addEventListener('click', () => this.hide())


### PR DESCRIPTION
When using inertia with no styling framework, the width of the modal is bigger extends past the right hand side of the screen. 99% of modern web apply `box-sizing: border-box;` to all elements and so this is not noticeable, but when no CSS reset styles are used, this display issue is present.