### PR TITLE
Add class to modal

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -8,6 +8,7 @@ export default {
     page.querySelectorAll('a').forEach(a => a.setAttribute('target', '_top'))
 
     this.modal = document.createElement('div')
+    this.modal.classList.add('inertia-unrecognised-response-modal')
     this.modal.style.position = 'fixed'
     this.modal.style.width = '100vw'
     this.modal.style.height = '100vh'


### PR DESCRIPTION
Add ability to customize the modal by targeting it using `inertia-unrecognised-response-modal` css class.

Sometime, it will triggered on production env, this way I can make it full screen instead of a modal.