### PR TITLE
Support lazy preserveState & preserveScroll evaluation

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -117,6 +117,9 @@ export default {
     Progress.increment()
     return Promise.resolve(this.resolveComponent(page.component)).then(component => {
       if (visitId === this.visitId) {
+        preserveState = typeof preserveState === 'function' ? preserveState(page.props) : preserveState
+        preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page.props) : preserveScroll
+        
         this.version = page.version
         this.setState(page, replace, preserveState)
         this.updatePage(component, page.props, { preserveState })


### PR DESCRIPTION
Closes https://github.com/inertiajs/inertia/issues/74

In our app we wan't to set `preserveState` to `false` on successful form submits, and `true` when there are validation errors. The amount of code we need for this is pretty insane, this completely solves the problem.

If this gets accepted, I'll PR the necessary documentation and typing changes.