### PR TITLE
Let user add any Axios config

### DIFF
--- a/src/inertia.js
+++ b/src/inertia.js
@@ -50,7 +50,7 @@ export default {
     return this.visitId
   },
 
-  visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false, preserveState = false, only = [], onUploadProgress = null } = {}) {
+  visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false, preserveState = false, only = [], config = {} } = {}) {
     Progress.start()
     this.cancelActiveVisits()
     let visitId = this.createVisitId()
@@ -61,7 +61,7 @@ export default {
       data: method.toLowerCase() === 'get' ? {} : data,
       params: method.toLowerCase() === 'get' ? data : {},
       cancelToken: this.cancelToken.token,
-      onUploadProgress,
+      ...config,
       headers: {
         Accept: 'text/html, application/xhtml+xml',
         'X-Requested-With': 'XMLHttpRequest',

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -50,7 +50,7 @@ export default {
     return this.visitId
   },
 
-  visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false, preserveState = false, only = [] } = {}) {
+  visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false, preserveState = false, only = [], onUploadProgress = null } = {}) {
     Progress.start()
     this.cancelActiveVisits()
     let visitId = this.createVisitId()
@@ -61,6 +61,7 @@ export default {
       data: method.toLowerCase() === 'get' ? {} : data,
       params: method.toLowerCase() === 'get' ? data : {},
       cancelToken: this.cancelToken.token,
+      onUploadProgress,
       headers: {
         Accept: 'text/html, application/xhtml+xml',
         'X-Requested-With': 'XMLHttpRequest',
@@ -119,7 +120,7 @@ export default {
       if (visitId === this.visitId) {
         preserveState = typeof preserveState === 'function' ? preserveState(page.props) : preserveState
         preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page.props) : preserveScroll
-        
+
         this.version = page.version
         this.setState(page, replace, preserveState)
         this.updatePage(component, page.props, { preserveState })


### PR DESCRIPTION
Today I needed a way to track progress of file uploads with Inertia.
I came across @reinink's comment [here](https://github.com/inertiajs/inertia/pull/29#issuecomment-518215064), but looks like it wasn't implemented yet.

So here it is, tried and tested!

Usage:
```javascript
Inertia.post('/path/to/upload', data, {
   onUploadProgress(e) {
      const percentCompleted = Math.round((e.loaded * 100) / e.total);
      console.log(`${percentCompleted}% uploaded`);
    },
})
```