### PR TITLE
add inertiaBeforeVisit

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import { string } from "postcss-selector-parser"
-
 declare global {
   // These open interfaces may be extended in an application-specific manner via
   // declaration merging / interface augmentation.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { string } from "postcss-selector-parser"
+
 declare global {
   // These open interfaces may be extended in an application-specific manner via
   // declaration merging / interface augmentation.
@@ -5,6 +7,13 @@ declare global {
     interface PagePropsBeforeTransform {}
 
     interface PageProps {}
+  }
+
+  interface Window {
+    inertiaBeforeVisit:
+      | undefined
+      | string
+      | ((url: string, options: VisitOptions & { data?: object }) => void);
   }
 }
 

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -51,8 +51,18 @@ export default {
   },
 
   visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false, preserveState = false, only = [] } = {}) {
-    if (method === 'get' && window.inertiaBeforeVisit && !window.confirm(window.inertiaBeforeVisit)) {
-      return Promise.resolve()
+    if (window.inertiaBeforeVisit) {
+      if (typeof window.inertiaBeforeVisit === 'function') {
+        const needsConfirm = window.inertiaBeforeVisit(url, {method, data, replace, preserveScroll, preserveState, only})
+
+        if (needsConfirm && !window.confirm(needsConfirm)) {
+          return Promise.resolve()
+        }
+      }
+
+      if (typeof window.inertiaBeforeVisit === 'string' && !window.confirm(window.inertiaBeforeVisit)) {
+        return Promise.resolve()
+      }
     }
 
     Progress.start()
@@ -161,7 +171,7 @@ export default {
   },
 
   replace(url, options = {}) {
-    return this.visit(url, { preserveState: true, ...options, replace: true })
+    return this.visit(url, { preserveState: true, ...options, replace: true, withoutConfirm: true })
   },
 
   reload(options = {}) {

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -51,6 +51,10 @@ export default {
   },
 
   visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false, preserveState = false, only = [] } = {}) {
+    if (method === 'get' && window.inertiaBeforeVisit && !window.confirm(window.inertiaBeforeVisit)) {
+      return Promise.resolve()
+    }
+
     Progress.start()
     this.cancelActiveVisits()
     let visitId = this.createVisitId()
@@ -119,7 +123,7 @@ export default {
       if (visitId === this.visitId) {
         preserveState = typeof preserveState === 'function' ? preserveState(page.props) : preserveState
         preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page.props) : preserveScroll
-        
+
         this.version = page.version
         this.setState(page, replace, preserveState)
         this.updatePage(component, page.props, { preserveState })

--- a/src/inertia.js
+++ b/src/inertia.js
@@ -171,7 +171,7 @@ export default {
   },
 
   replace(url, options = {}) {
-    return this.visit(url, { preserveState: true, ...options, replace: true, withoutConfirm: true })
+    return this.visit(url, { preserveState: true, ...options, replace: true })
   },
 
   reload(options = {}) {


### PR DESCRIPTION
This PR addresses the issue discussed in https://github.com/inertiajs/inertia-vue/issues/86. If the user has set a value for `window.inertiaBeforeVisit`, an `Inertia.visit()` call will trigger a browser confirm popup, allowing the user to cancel the navigation action. This fills in the gap where `window.onbeforeunload` doesn't work in an Inertia application for obvious reasons.

The value for `window.inertiaBeforeVisit` can also be a function, which will receive all the parameters that `Inertia.visit` was called with (url and options). If the function returns a falsey value, the navigation action will continue. If the function returns a truthy value, it will display this return value in a confirm popup. In general, the function would return something like `Are you sure you want to leave?`, which will trigger the confirm popup with this message.

~~If you're interested in merging this, let me know and I'll add the proper typings for it.~~ [done](https://github.com/inertiajs/inertia/pull/152/files#diff-b52768974e6bc0faccb7d4b75b162c99R10-R15)

## Alternative solution
This could also be made to work with an event that is fired on the window or the document the moment `Inertia.visit()` is called. The user can then `.preventDefault()` the event to cancel the navigation.

Something like this:

```JS
visit(…) {
  const visitEvent = new CustomEvent('inertia-visit', { details: { url, options: { method, data, replace, preserveScroll, preserveState, only } } })
  document.dispatchEvent(visitEvent)

  if (visitEvent.defaultPrevented) {
    return Promise.resolve()
  }
```

## Usage (React)
**as a function**
```JS
useEffect(() => {
    window.inertiaBeforeVisit = (url, options) => {
        if (options.method === 'get') {
            return 'Are you sure you want to leave this page?';
        }
    };

    return () => (window.inertiaBeforeVisit = undefined);
}, []);
```

**as a string**
```JS
useEffect(() => {
    window.inertiaBeforeVisit = 'Are you sure you want to leave the page?';

    return () => (window.inertiaBeforeVisit = undefined);
}, []);
```

**slightly more advanced and useful**
```JS
useEffect(() => {
    window.inertiaBeforeVisit = (url, options) => {
        if (!formValuesAreDirty) {
            return false;
        }

        if (options.method === 'get') {
            return 'Are you sure you want to leave without saving?';
        }
    };

    return () => (window.inertiaBeforeVisit = undefined);
}, [formValuesAreDirty]);
```

In Vue, something similar should work with a watcher.
