### PR TITLE
Improvements to persistent scrolling feature

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -4,7 +4,6 @@ import modal from './modal'
 import progress from './progress'
 
 export default {
-  saveScrollPositions: null,
   onRegionScroll: null,
   resolveComponent: null,
   updatePage: null,
@@ -27,21 +26,20 @@ export default {
       this.setPage(initialPage)
     }
 
-    this.saveScrollPositions = () => {
-      this.setState({
-        ...window.history.state,
-        scrollRegions: Array.prototype.slice.call(this.scrollRegions()).map(region => {
-          return {
-            top: region.scrollTop,
-            left: region.scrollLeft,
-          }
-        }),
-      })
-    }
-
-    this.onRegionScroll = debounce(this.saveScrollPositions, 100)
-
     window.addEventListener('popstate', this.restoreState.bind(this))
+    this.onRegionScroll = debounce(this.saveScrollPositions, 100)
+  },
+
+  saveScrollPositions() {
+    this.setState({
+      ...window.history.state,
+      scrollRegions: Array.prototype.slice.call(this.scrollRegions()).map(region => {
+        return {
+          top: region.scrollTop,
+          left: region.scrollLeft,
+        }
+      }),
+    })
   },
 
   navigationType() {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -27,7 +27,7 @@ export default {
     }
 
     window.addEventListener('popstate', this.restoreState.bind(this))
-    this.onRegionScroll = debounce(this.saveScrollPositions, 100)
+    this.onRegionScroll = debounce(() => this.saveScrollPositions(), 100)
   },
 
   saveScrollPositions() {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -185,12 +185,15 @@ export default {
           this.version = this.page.version
           this.setState(this.page)
           this.updatePage(component, this.page.props, { preserveState: false }).then(() => {
-            if (this.page.scrollRegions) {
-              this.scrollRegions().forEach((region, index) => {
+            this.scrollRegions().forEach((region, index) => {
+              region.scrollTop = 0
+              region.scrollLeft = 0
+
+              if (this.page.scrollRegions) {
                 region.scrollTop = this.page.scrollRegions[index].top
                 region.scrollLeft = this.page.scrollRegions[index].left
-              })
-            }
+              }
+            })
           })
           progress.stop()
         }


### PR DESCRIPTION
Didn't manage to get this done in time, but here you go :)

- Removes unnecessary save call
- Prevents event listener from being triggered immediately by changing the definition order
- Save current position directly before page navigation change (without a debounced delay)