### PR TITLE
feat(inertia-vue): add `renderInertia` render function

### DIFF
--- a/packages/inertia-vue/.eslintrc.js
+++ b/packages/inertia-vue/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     es6: true,
   },
   extends: ['eslint:recommended'],
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',

--- a/packages/inertia-vue/src/index.js
+++ b/packages/inertia-vue/src/index.js
@@ -1,2 +1,3 @@
 export { default as InertiaApp } from './app'
 export { default as InertiaLink } from './link'
+export { renderInertia } from './renderInertia'

--- a/packages/inertia-vue/src/renderInertia.js
+++ b/packages/inertia-vue/src/renderInertia.js
@@ -1,0 +1,29 @@
+import inertia from './app'
+
+const defaultConfig = {
+  resolve: null,
+  app: null,
+  path: 'Pages',
+}
+
+/**
+ * Returns an Inertia-ready render function.
+ */
+export function renderInertia(options) {
+  const { path, app, resolve } = {
+    ...defaultConfig,
+    ...options,
+  }
+
+  const { dataset } = app ?? document.getElementById('app')
+
+  return (h) =>
+    h(inertia, {
+      props: {
+        initialPage: JSON.parse(dataset.page),
+        resolveComponent: async (component) => {
+          return (await resolve(`${path}/${component}`)).default
+        },
+      },
+    })
+}


### PR DESCRIPTION
This PR adds a `renderInertia` export from `@inertia/inertia-vue` that is syntactic sugar for initializing Inertia with Vue.

Currently, we do it this way: 

```js
import Vue from 'vue'
import { InertiaApp } from '@inertiajs/inertia-vue'

Vue.use(InertiaApp)

const app = document.getElementById('app')

new Vue({
  render: h => h(InertiaApp, {
    props: {
      initialPage: JSON.parse(app.dataset.page),
      resolveComponent: name => require(`./Pages/${name}`).default,
      // resolveComponent: name => import(`./Pages/${name}`).then(module => module.default), // code-splitting
    },
  }),
}).$mount(app)
```

This PR makes it possible to do it this way:

```js
import Vue from 'vue'
import { InertiaApp, renderInertia } from '@inertiajs/inertia-vue'

Vue.use(InertiaApp)

new Vue({
  render: renderInertia({
    resolve: (name) => require(`@/${name}`), // or "import" for code-splitting
  }),
}).$mount('#app')

```

This is a shorter way of initializing Inertia, which gets rid of things that should basically never change from app to app:

— Retrieving the `app` element
— Getting the `page` data from the `app`'s `dataset`
— Writing the actual render function

The `renderInertia` function takes an object as a parameter:

```js
const defaultConfig = {
  resolve: null,
  app: null,
  path: 'Pages',
}
```

— `resolve` must be a function that return the component
— `path` is the path to the page components
— `app` is the element from which the initial `page` dataset will be extracted

Only `resolve` is required, the other are optional.

Initially, I wanted to get rid of `require`/`import` altogether, but it doesn't seem to be easily possible, so this is the best I could do for reducing the initial boilerplate without removing `new Vue`.
