### PR TITLE
Pass Vue scoped slots

### DIFF
--- a/packages/inertia-vue/src/app.js
+++ b/packages/inertia-vue/src/app.js
@@ -44,6 +44,7 @@ export default {
       const child = h(this.component, {
         key: this.key,
         props: this.props,
+        scopedSlots: this.$scopedSlots,
       })
 
       if (this.component.layout) {


### PR DESCRIPTION
Excuse the huge number of changes in this PR.

### tl;dr

This PR lets you pass along slots from your layout. [It's what this tweet was referring to](https://twitter.com/reinink/status/1300484695323443201).

### More Context

This would be useful when you need to pass along non-Inertia Vue stuff.

My use case is wanting to add Inertia to an app that's currently a standard Laravel app returning Blade views. We have an addon ecosystem where third party developers can be returning views into our admin panel. We wanted a way to convert as much as possible to Inertia, but allow non-Inertia responses to keep working as they did pre-Inertia.

There's a handful of things you need to change about how you wire up Inertia. We talked about trying to streamline this eventually, but we can leave that for a separate PR.

1. Rather than using the `@inertia` directive you'd need to manually put the div in your layout.
2. Rather than using a div, it would need to be another Vue component. When the root Vue instance mounts to the page, it would normally completely replace the element, losing any child elements. By using a component, the slot content can be maintained.
3. The component would be where your Inertia wiring would go instead of your main js file.
4. Your Vue installation needs to include the template compiler.

``` blade
{{-- layout with a single slot --}}
<inertia-wrapper id="app" :page="{{ json_encode($page) }}">
  <div>The default slot</div>
</inertia-wrapper>
```
``` blade
{{-- layout with multiple slots --}}
<inertia-wrapper id="app" :page="{{ json_encode($page) }}">
  <template v-slot:default>
    <div>The default slot</div>
  </template>
  <template v-slot:custom="slotProps">
    <div>A named slot {{ slotProps.foo }}</div>
  </template>
</inertia-wrapper>
```

``` js
// app.js
import { InertiaApp } from '@inertiajs/inertia-vue'
import Vue from 'vue'
import InertiaWrapper from './InertiaWrapper'

Vue.use(InertiaApp)

const app = document.getElementById('app')

new Vue({
  components: {
    InertiaWrapper
  }
}).$mount(app)
```

``` vue
// InertiaWrapper.vue
<script>
import { InertiaApp } from '@inertiajs/inertia-vue'

export default {

    props: {
        page: Object
    },

    render(h) {
        return h(InertiaApp, {
            props: {
                initialPage: this.page,
                resolveComponent: name => require(`./Pages/${name}`).default,
            },
            scopedSlots: this.$scopedSlots
        });
    }

}
</script>
```

```vue
// A page, like Dashboard.vue
<template>
  <div>
    <slot />
    <slot name="custom" :foo="bar" />
  </div>
</template>

<script>
export default {
  data() {
    return {
      bar: 'baz'
    }
  }
}
</script>
```