### PR TITLE
[Vue] Feature: Shorthand nested layouts (array syntax)

### DIFF
--- a/packages/inertia-vue/src/app.js
+++ b/packages/inertia-vue/src/app.js
@@ -50,6 +50,11 @@ export default {
       if (this.component.layout) {
         if (typeof this.component.layout === 'function') {
           return this.component.layout(h, child)
+        } else if (Array.isArray(this.component.layout)) {
+          return this.component.layout
+            .concat(child)
+            .reverse()
+            .reduce((child, layout) => h(layout, [child]))
         }
 
         return h(this.component.layout, [child])


### PR DESCRIPTION
This PR introduces a simpler way to define multi-level (persistent) layouts by using the array syntax

![Untitled](https://user-images.githubusercontent.com/1752195/92314231-882dd900-efd5-11ea-8507-7b73bd1c1503.png)


## Usage: 
```
layout: [Foo, Bar, Baz]
```

## Example result:

<img width="358" alt="Screenshot 2020-09-05 at 22 47 53" src="https://user-images.githubusercontent.com/1752195/92313241-d89f3980-efc9-11ea-95d0-9dcef00bd2ed.png">

Behaviour is as expected:
- When switching between two different pages that have the same exact layout stack, the layouts are all persisted. 
- When switching between two pages that share a portion of the same layout stack, only the portion until the first discrepancy is persisted, and the remainder will be re-rendered.

## Additional examples

| Situation | Outcome |
|:------|:------|
| `layout: []` | Only renders the Page  |
| `layout: [Foo]` | Same as `layout: Foo` |
| `layout: [Foo, Bar, Baz, Bar]` |  Layout 'Bar' is rendered twice, as two separate instances |
| `layout: [Foo, Bar, Bar, Baz]` | Layout 'Bar' is rendered twice in a row, as two separate instances |