### PR TITLE
Feature: Ability to define custom headers on a per-request basis

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -68,7 +68,7 @@ export default {
     return this.visitId
   },
 
-  visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false, preserveState = false, only = [] } = {}) {
+  visit(url, { method = 'get', data = {}, replace = false, preserveScroll = false, preserveState = false, only = [], headers = {}} = {}) {
     progress.start()
     this.cancelActiveVisits()
     this.saveScrollPositions()
@@ -81,6 +81,7 @@ export default {
       params: method.toLowerCase() === 'get' ? data : {},
       cancelToken: this.cancelToken.token,
       headers: {
+        ...headers,
         Accept: 'text/html, application/xhtml+xml',
         'X-Requested-With': 'XMLHttpRequest',
         'X-Inertia': true,


### PR DESCRIPTION
This PR allows the user to set additional (custom) request headers on a request-by-request basis.
It checks whether the 'headers' object is set on the request 'options', and if it is, combines it with Inertia's headers.

Do note that Inertia's headers take priority and cannot be overwritten.

Usage:
- `this.$inertia.visit({ headers: { 'Custom-Header': 'value' }})`
- `this.$inertia.post('/endpoint', { 'id': 1 }, { headers: { 'Custom-Header': 'value' } })`
- ... (etc.)