### PR TITLE
[Svelte] Add support for persistent layout

### DIFF
--- a/packages/inertia-svelte/src/App.svelte
+++ b/packages/inertia-svelte/src/App.svelte
@@ -20,11 +20,11 @@
     },
   })
 
-  $: page = $store.component && h($store.component.default, $store.props)
+  $: child = $store.component && h($store.component.default, $store.props)
   $: layout = $store.component && $store.component.layout
   $: components = layout
-    ? layout.name === 'layout' ? layout(h, page) : h(layout, [page])
-    : page
+    ? h(layout, {}, [child])
+    : child
 </script>
 
 <Render {...components} />

--- a/packages/inertia-svelte/src/App.svelte
+++ b/packages/inertia-svelte/src/App.svelte
@@ -23,7 +23,9 @@
   $: child = $store.component && h($store.component.default, $store.props)
   $: layout = $store.component && $store.component.layout
   $: components = layout
-    ? h(layout, {}, [child])
+    ? Array.isArray(layout)
+      ? layout.concat(child).reverse().reduce((child, layout) => h(layout, {}, [child]))
+      : h(layout, {}, [child])
     : child
 </script>
 

--- a/packages/inertia-svelte/src/App.svelte
+++ b/packages/inertia-svelte/src/App.svelte
@@ -1,6 +1,7 @@
 <script>
   import { Inertia } from '@inertiajs/inertia'
   import store from './store'
+  import Render, { h } from './Render.svelte'
 
   export let
     initialPage,
@@ -18,8 +19,12 @@
       }))
     },
   })
+
+  $: page = $store.component && h($store.component.default, $store.props)
+  $: layout = $store.component && $store.component.layout
+  $: components = layout
+    ? layout.name === 'layout' ? layout(h, page) : h(layout, [page])
+    : page
 </script>
 
-{#each [$store.key] as key (key)}
-<svelte:component this={$store.component} {...$store.props} />
-{/each}
+<Render {...components} />

--- a/packages/inertia-svelte/src/Render.svelte
+++ b/packages/inertia-svelte/src/Render.svelte
@@ -1,14 +1,5 @@
 <script context="module">
   export const h = (component, props, children) => {
-    if (props && Array.isArray(props) && !children) {
-      children = props
-      props = null
-    }
-
-    if (children && ! Array.isArray(children)) {
-      children = [children]
-    }
-
     return {
       component,
       ...(props ? { props } : {}),
@@ -21,15 +12,11 @@
   export let component
   export let props = {}
   export let children = []
-
-  $: normalizedChildren = component && children.map(child => {
-    return typeof child === 'function' ? h(child) : child
-  })
 </script>
 
 {#if component}
   <svelte:component this={component} {...props}>
-    {#each normalizedChildren as child}
+    {#each children as child}
       <svelte:self {...child} />
     {/each}
   </svelte:component>

--- a/packages/inertia-svelte/src/Render.svelte
+++ b/packages/inertia-svelte/src/Render.svelte
@@ -1,0 +1,36 @@
+<script context="module">
+  export const h = (component, props, children) => {
+    if (props && Array.isArray(props) && !children) {
+      children = props
+      props = null
+    }
+
+    if (children && ! Array.isArray(children)) {
+      children = [children]
+    }
+
+    return {
+      component,
+      ...(props ? { props } : {}),
+      ...(children ? { children } : {})
+    }
+  }
+</script>
+
+<script>
+  export let component
+  export let props = {}
+  export let children = []
+
+  $: normalizedChildren = component && children.map(child => {
+    return typeof child === 'function' ? h(child) : child
+  })
+</script>
+
+{#if component}
+  <svelte:component this={component} {...props}>
+    {#each normalizedChildren as child}
+      <svelte:self {...child} />
+    {/each}
+  </svelte:component>
+{/if}


### PR DESCRIPTION
In order to support the same flexibility as the other adapter, I had to create a basic `h` function that can be used in two ways:

```js
/* 1 */ h(Layout, { title: 'Homepage' }, [page])
/* 2 */ h(Layout, [page])
```

Merging this PR is a breaking change. It requires that the `resolveComponent` closure passed to `InertiaApp` returns the page module and not just the default export.

```diff
import { InertiaApp } from '@inertiajs/inertia-svelte'

const app = document.getElementById('app')

new InertiaApp({
  target: app,
  props: {
    initialPage: JSON.parse(app.dataset.page),
    resolveComponent: name =>
-      import(`@/Pages/${name}.svelte`).then(module => module.default),
+      import(`@/Pages/${name}.svelte`),
  },
})
```

Page components can then declare the desired layout inside the `<script context="module">` block:

```svelte
<script context="module">
  import Layout from '@/Shared/Layout.svelte'
  export const layout = (h, page) => h(Layout, { title: 'Homepage' }, [page])
</script>
```

Here the `h` function can be used in any way described above.

Alternatively you also simply assign the layout component to the `layout` export:

```svelte
<script context="module">
  import Layout from '@/Shared/Layout.svelte'
  export const layout = Layout
</script>
```

The Svelte version of the PingCRM has a [persistent-layout](https://github.com/inertiajs/pingcrm-svelte/tree/persistent-layout) branch that can be used for testing this feature.