### PR TITLE
[Svelte] Add use:inertia directive

### DIFF
--- a/packages/inertia-svelte/package.json
+++ b/packages/inertia-svelte/package.json
@@ -17,6 +17,6 @@
   },
   "peerDependencies": {
     "@inertiajs/inertia": "^0.2.0",
-    "svelte": "^3.8.0"
+    "svelte": "^3.20.0"
   }
 }

--- a/packages/inertia-svelte/src/Link.svelte
+++ b/packages/inertia-svelte/src/Link.svelte
@@ -14,8 +14,6 @@
     only = [],
     headers = {}
 
-  $: props = (({ data, href, method, preserveScroll, preserveState, replace, only, headers, ...rest }) => rest)($$props)
-
   function visit(event) {
     dispatch('click', event)
 
@@ -35,6 +33,6 @@
   }
 </script>
 
-<a {...props} href={href} on:click={visit}>
+<a {...$$restProps} {href} on:click={visit}>
   <slot />
 </a>

--- a/packages/inertia-svelte/src/index.js
+++ b/packages/inertia-svelte/src/index.js
@@ -1,4 +1,5 @@
 export { default as InertiaApp } from './App.svelte'
 export { default as InertiaLink } from './Link.svelte'
+export { default as inertia } from './link'
 export { default as page } from './page'
 export { default as remember } from './remember'

--- a/packages/inertia-svelte/src/link.js
+++ b/packages/inertia-svelte/src/link.js
@@ -1,0 +1,29 @@
+import { Inertia, shouldIntercept } from '@inertiajs/inertia'
+import { createEventDispatcher } from 'svelte'
+
+export default (node, options = {}) => {
+  const dispatch = createEventDispatcher()
+
+  function visit(event) {
+    dispatch('click', event)
+
+    const href = node.href || options.href
+
+    if (!href) {
+      throw new Error('Option "href" is required')
+    }
+
+    if (shouldIntercept(event)) {
+      event.preventDefault()
+      Inertia.visit(href, options)
+    }
+  }
+
+  node.addEventListener('click', visit)
+
+  return {
+    destroy() {
+      node.removeEventListener('click', visit)
+    }
+  }
+}


### PR DESCRIPTION
The `use:inertia` directive can be used instead of the `InertiaLink` component to add Inertia behavior to any element in the DOM.

```svelte
<script>
  import { inertia } from '@inertiajs/inertia-svelte'
</script>

<a href="/users" use:inertia>Users</a>

<button
  use:inertia={{ href: '/users/100', method: 'post', data: { '_method': 'delete' }}}
  class="btn-indigo"
  on:click={() => alert('User deleted')}>
  Delete
</button>

<a
  href="/users/100"
  use:inertia={{ method: 'post', data: { '_method': 'put', 'visited': true }}}>
  Visited
</a>
```