### PR TITLE
Add v-inertia directive

### DIFF
--- a/packages/inertia-vue/src/app.js
+++ b/packages/inertia-vue/src/app.js
@@ -1,4 +1,5 @@
 import { Inertia } from '@inertiajs/inertia'
+import Directive from './directive'
 import Link from './link'
 import Remember from './remember'
 
@@ -68,5 +69,6 @@ export default {
     Object.defineProperty(Vue.prototype, '$page', { get: () => app.props })
     Vue.mixin(Remember)
     Vue.component('InertiaLink', Link)
+    Vue.directive('inertia', Directive)
   },
 }

--- a/packages/inertia-vue/src/directive.js
+++ b/packages/inertia-vue/src/directive.js
@@ -11,7 +11,7 @@ export default {
 
       const method = binding.arg || 'get'
       const options = (binding.value || {}).options || {}
-      const data = (binding.value || {}).data || (! options ? binding.value : {})
+      const data = (binding.value || {}).data || (Object.keys(options).length === 0 ? binding.value : {})
       const url = ((vnode.data || {}).attrs || {}).href || (binding.value || {}).href || (binding.value || {}).url
 
       if (method === 'replace') {

--- a/packages/inertia-vue/src/directive.js
+++ b/packages/inertia-vue/src/directive.js
@@ -1,0 +1,36 @@
+import { Inertia, shouldIntercept } from '@inertiajs/inertia'
+
+export default {
+  bind(el, binding, vnode) {
+    el.addEventListener('click', event => {
+      if (!shouldIntercept(event)) {
+        return
+      }
+
+      event.preventDefault()
+
+      const method = binding.arg || 'get'
+      const options = (binding.value || {}).options || {}
+      const data = (binding.value || {}).data || (! options ? binding.value : {})
+      const url = ((vnode.data || {}).attrs || {}).href || (binding.value || {}).href || (binding.value || {}).url
+
+      if (method === 'replace') {
+        Inertia.replace(url, options)
+      } else if (method === 'reload') {
+        Inertia.reload(options)
+      } else if (['post', 'put', 'patch'].indexOf(method) > -1) {
+        Inertia[method](url, data, options)
+      } else if (method === 'delete') {
+        Inertia.delete(url, options)
+      } else {
+        Inertia.visit(url, {
+          ...options,
+          method,
+          data,
+        })
+      }
+
+      return false
+    })
+  },
+}


### PR DESCRIPTION

![Screenshot 2020-09-09 at 20 09 21](https://user-images.githubusercontent.com/1752195/92638674-eeb73d80-f2da-11ea-86fa-415311c90f2b.png)

Usage:

- `<a href="/link" v-inertia>Click me!</a>`
- `<a href="/logout v-inertia:post>Logout</a>`
- `<a href="/update" v-inertia:patch="{ title: form.title }>Save Changes</a>`
- `<a href="/" v-inertia="{ options: { ... } }">Visit with request options</a>`

Under the hood, this feature uses the existing [request methods](https://inertiajs.com/requests), and acts as an alternative for `<inertia-link>`. 