### PR TITLE
[inertia-vue] Fix remember key of this binding

### DIFF
--- a/packages/inertia-vue/src/remember.js
+++ b/packages/inertia-vue/src/remember.js
@@ -19,7 +19,7 @@ export default {
     }
 
     const stateKey = this.$options.remember.key instanceof Function
-      ? this.$options.remember.key()
+      ? this.$options.remember.key.call(this)
       : this.$options.remember.key
 
     const restored = Inertia.restore(stateKey)


### PR DESCRIPTION
I follow the documentation [Multiple components](https://inertiajs.com/local-state-caching#multiple-components) to set the remember key:

```js
  remember: {
    data: ['form'],
    key: () => `Post/Edit:${this.post.id}`,
  },
```

But it return an error:

![inertia-remember-bug](https://user-images.githubusercontent.com/38133356/92989235-5c46b200-f505-11ea-94b4-0ea9edc7259f.jpg)

I found is the `this` binding problem, this PR fixes it.

After using this PR to fix, arrow function cannot be used, can work with the following usage:

```js
  remember: {
    data: ['form'],
    key() {
      return `Post/Edit:${this.post.id}`
    },
  },
```
