### PR TITLE
feat(vue): Inject Props

### DIFF
--- a/packages/inertia-vue/src/app.js
+++ b/packages/inertia-vue/src/app.js
@@ -19,6 +19,10 @@ export default {
       type: Function,
       default: props => props,
     },
+    injectProps: {
+      type: Boolean,
+      default: () => false,
+    }
   },
   data() {
     return {
@@ -41,6 +45,10 @@ export default {
   },
   render(h) {
     if (this.component) {
+
+      if (this.injectProps)
+        this.component.props = Object.keys(this.props);
+
       const child = h(this.component, {
         key: this.key,
         props: this.props,


### PR DESCRIPTION
Add option to auto inject props on pages.

```js
// ./app.js
new Vue({
    render: h => h(InertiaApp, {
        props: {
            initialPage: JSON.parse(app.dataset.page),
            resolveComponent: name => require(`./Pages/${name}`).default,
            injectProps: true
        },
    }),
}).$mount(app)
```

![image](https://user-images.githubusercontent.com/9212274/93026178-d3b33900-f60c-11ea-9aaf-1915bf1b3699.png)

![image](https://user-images.githubusercontent.com/9212274/93026189-df066480-f60c-11ea-8200-09b5323f05b2.png)

