### PR TITLE
Restore lazy evaluation of preserveScroll and preserveState

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -204,10 +204,10 @@ export default {
     return Promise.resolve(this.resolveComponent(page.component)).then(component => {
       if (visitId === this.visitId) {
         preserveState = typeof preserveState === 'function' ? preserveState(page.props) : preserveState
-        preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page.props) : preserveScroll
         replace = replace || page.url === `${window.location.pathname}${window.location.search}`
         replace ? this.replaceState(page, preserveState) : this.pushState(page)
         this.updatePage(component, page.props, { preserveState }).then(() => {
+          preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page.props) : preserveScroll
           if (!preserveScroll) {
             this.resetScrollPositions()
           }

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -203,8 +203,8 @@ export default {
     this.page = page
     return Promise.resolve(this.resolveComponent(page.component)).then(component => {
       if (visitId === this.visitId) {
-        preserveState = typeof preserveState === 'function' ? preserveState(page.props) : preserveState
-        preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page.props) : preserveScroll
+        preserveState = typeof preserveState === 'function' ? preserveState(page) : preserveState
+        preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page) : preserveScroll
         replace = replace || page.url === `${window.location.pathname}${window.location.search}`
         replace ? this.replaceState(page, preserveState) : this.pushState(page)
         this.updatePage(component, page.props, { preserveState }).then(() => {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -203,6 +203,8 @@ export default {
     this.page = page
     return Promise.resolve(this.resolveComponent(page.component)).then(component => {
       if (visitId === this.visitId) {
+        preserveState = typeof preserveState === 'function' ? preserveState(page.props) : preserveState
+        preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page.props) : preserveScroll
         replace = replace || page.url === `${window.location.pathname}${window.location.search}`
         replace ? this.replaceState(page, preserveState) : this.pushState(page)
         this.updatePage(component, page.props, { preserveState }).then(() => {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -204,10 +204,10 @@ export default {
     return Promise.resolve(this.resolveComponent(page.component)).then(component => {
       if (visitId === this.visitId) {
         preserveState = typeof preserveState === 'function' ? preserveState(page.props) : preserveState
+        preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page.props) : preserveScroll
         replace = replace || page.url === `${window.location.pathname}${window.location.search}`
         replace ? this.replaceState(page, preserveState) : this.pushState(page)
         this.updatePage(component, page.props, { preserveState }).then(() => {
-          preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page.props) : preserveScroll
           if (!preserveScroll) {
             this.resetScrollPositions()
           }


### PR DESCRIPTION
Re-implements #135 / #74 (removed [here](https://github.com/inertiajs/inertia/commit/6da241af975fae4f34f72986ca2eca765b18a4af#diff-e25ae5c7cf909bf9488eea033663bce8L120-L121)) to solve #229

