### PR TITLE
Add the ability to cancel a visit from the onStart() callback

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -118,7 +118,7 @@ export default {
     onSuccess = () => ({}),
   } = {}) {
     let visit = { url, ...arguments[1] }
-    if (onStart(visit) === false || !this.fireEvent('start', { cancelable: true, detail: { visit } } )) {
+    if (!this.fireEvent('start', { cancelable: true, detail: { visit } } ) || onStart(visit) === false) {
       this.fireEvent('finish')
       return
     }

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -120,6 +120,7 @@ export default {
     let visit = { url, ...arguments[1] }
     if (!this.fireEvent('start', { cancelable: true, detail: { visit } } ) || onStart(visit) === false) {
       this.fireEvent('finish')
+      onFinish()
       return
     }
     this.cancelActiveVisits()

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -118,7 +118,7 @@ export default {
     onSuccess = () => ({}),
   } = {}) {
     let visit = { url, ...arguments[1] }
-    if (!this.fireEvent('start', { cancelable: true, detail: { visit } } ) || onStart(visit) === false) {
+    if (onStart(visit) === false || !this.fireEvent('start', { cancelable: true, detail: { visit } } )) {
       return
     }
     this.cancelActiveVisits()

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -118,11 +118,10 @@ export default {
     onSuccess = () => ({}),
   } = {}) {
     let visit = { url, ...arguments[1] }
-    if (!this.fireEvent('start', { cancelable: true, detail: { visit } } )) {
+    if (onStart(visit) === false || !this.fireEvent('start', { cancelable: true, detail: { visit } } )) {
       this.fireEvent('finish')
       return
     }
-    onStart(visit)
     this.cancelActiveVisits()
     this.saveScrollPositions()
     let visitId = this.createVisitId()

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -119,8 +119,6 @@ export default {
   } = {}) {
     let visit = { url, ...arguments[1] }
     if (!this.fireEvent('start', { cancelable: true, detail: { visit } } ) || onStart(visit) === false) {
-      this.fireEvent('finish')
-      onFinish()
       return
     }
     this.cancelActiveVisits()


### PR DESCRIPTION
Right now visits can only be cancelled from the global `start` event. However, there are use-cases for wanting to do this on a per-visit basis, which this PR adds support for. 👍 

Example:

```js
this.$inertia.post(`/users/${user.id}`, {
  onStart: () => confirm('Are you sure you want to delete this user?'),
})
```