### PR TITLE
Add events to `use:inertia` directive

### DIFF
--- a/packages/inertia-svelte/src/Link.svelte
+++ b/packages/inertia-svelte/src/Link.svelte
@@ -1,8 +1,5 @@
 <script>
-  import { Inertia, shouldIntercept } from '@inertiajs/inertia'
-  import { createEventDispatcher } from 'svelte'
-
-  const dispatch = createEventDispatcher()
+  import inertia from './link'
 
   export let
     data = {},
@@ -13,26 +10,18 @@
     preserveState = false,
     only = [],
     headers = {}
-
-  function visit(event) {
-    dispatch('click', event)
-
-    if (shouldIntercept(event)) {
-      event.preventDefault()
-
-      Inertia.visit(href, {
-        data,
-        method,
-        preserveScroll,
-        preserveState,
-        replace,
-        only,
-        headers
-      })
-    }
-  }
 </script>
 
-<a {...$$restProps} {href} on:click={visit}>
+<a
+  use:inertia={{ ...$$props }}
+  {...$$restProps}
+  {href}
+  on:click
+  on:cancelToken
+  on:start
+  on:progress
+  on:finish
+  on:cancel
+  on:success>
   <slot />
 </a>

--- a/packages/inertia-svelte/src/link.js
+++ b/packages/inertia-svelte/src/link.js
@@ -4,6 +4,17 @@ import { createEventDispatcher } from 'svelte'
 export default (node, options = {}) => {
   const dispatch = createEventDispatcher()
 
+  options.onCancelToken = cancelToken => fireEvent('cancelToken', { detail: { cancelToken } })
+  options.onStart = visit => fireEvent('start', { cancelable: true, detail: { visit } })
+  options.onProgress = progress => fireEvent('progress', { detail: { progress } })
+  options.onFinish = () => fireEvent('finish')
+  options.onCancel = () => fireEvent('cancel')
+  options.onSuccess = page => fireEvent('success', { detail: { page } })
+
+  function fireEvent(name, eventOptions) {
+    return node.dispatchEvent(new CustomEvent(name, eventOptions))
+  }
+
   function visit(event) {
     dispatch('click', event)
 


### PR DESCRIPTION
I was able to replicate #235 on the `use:inertia` directive like so:

```svelte
<a
  href="/sample"
  use:inertia
  on:click={() => console.log('click')}
  on:cancelToken={event => console.log('cancelToken', event.detail.cancelToken)}
  on:start={event => console.log('start', event.detail.visit)}
  on:progress={event => console.log('progress', event.detail.progress)}
  on:finish={() => console.log('finish')}
  on:cancel={() => console.log('cancel')}
  on:success={event => console.log('success', event.detail.page)}>
  Sample link
</a>
```

Also works on the `InertiaLink` component:

```svelte
<InertiaLink
  href="/sample"
  on:click={() => console.log('click')}
  on:cancelToken={event => console.log('cancelToken', event.detail.cancelToken)}
  on:start={event => console.log('start', event.detail.visit)}
  on:progress={event => console.log('progress', event.detail.progress)}
  on:finish={() => console.log('finish')}
  on:cancel={() => console.log('cancel')}
  on:success={event => console.log('success', event.detail.page)}>
  Sample link
</InertiaLink>
```

The main difference is that these are not simple callbacks, but event listeners. In Svelte you can't access event listeners like props during runtime because they are processed by Svelte during compilation. The solution is to register `on*` callbacks that fire custom events on the DOM node.

The only issue so far is that I couldn't find a way to either return `false` or prevent the `on:start` event and forward that response back to the `onStart` callback internally.

This PR also removes logic that was duplicated on the `use:inertia` directive and `InertiaLink` component. Now the component uses the directive internally. Double win!
