### PR TITLE
Add get() method

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -244,6 +244,10 @@ export default {
     }
   },
 
+  get(url, data = {}, options = {}) {
+    return this.visit(url, { ...options, method: 'get', data })
+  },
+
   replace(url, options = {}) {
     return this.visit(url, { preserveState: true, ...options, replace: true })
   },


### PR DESCRIPTION
We currently have methods for `post()`, `put()`, `patch()` and `delete()`, but we don't have one for `get()`. Right now to do a GET visit you simply use `Inertia.visit()`. However, since people might expect a `get()` method to exist, this PR adds it. 👍 

```js
Inertia.get(url, data, options)
```