### PR TITLE
Updates visit options types and adds get() method type definition

### DIFF
--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -1,3 +1,5 @@
+import { CancelTokenSource } from "axios"
+
 declare global {
   // These open interfaces may be extended in an application-specific manner via
   // declaration merging / interface augmentation.
@@ -20,10 +22,17 @@ export interface Page<CustomPageProps extends PageProps = PageProps> {
 
 type VisitOptions = {
   method?: string
+  replace?: boolean
   preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
   preserveState?: boolean | ((props: Inertia.PageProps) => boolean)
-  replace?: boolean
   only?: string[]
+  headers?: object
+  onCancelToken?: (cancelToken: CancelTokenSource) => void
+  onStart?: (visit: VisitOptions & {url: string}) => void | boolean
+  onProgress?: (progress: any) => void // Cast to any, Axios doesn't have a type definition for this
+  onFinish?: () => void
+  onCancel?: () => void
+  onSuccess?: (page: Page) => void | Promise
 }
 
 interface Inertia {

--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -56,6 +56,8 @@ interface Inertia {
     options?: VisitOptions & { data?: object }
   ) => Promise<void>
 
+  get: (url: string, data?: object, options?: VisitOptions) => Promise<void>
+
   patch: (url: string, data?: object, options?: VisitOptions) => Promise<void>
 
   post: (url: string, data?: object, options?: VisitOptions) => Promise<void>

--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -29,7 +29,7 @@ type VisitOptions = {
   headers?: object
   onCancelToken?: (cancelToken: CancelTokenSource) => void
   onStart?: (visit: VisitOptions & {url: string}) => void | boolean
-  onProgress?: (progress: any) => void // Cast to any, Axios doesn't have a type definition for this
+  onProgress?: (progress: ProgressEvent) => void
   onFinish?: () => void
   onCancel?: () => void
   onSuccess?: (page: Page) => void | Promise<any>

--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -32,7 +32,7 @@ type VisitOptions = {
   onProgress?: (progress: any) => void // Cast to any, Axios doesn't have a type definition for this
   onFinish?: () => void
   onCancel?: () => void
-  onSuccess?: (page: Page) => void | Promise
+  onSuccess?: (page: Page) => void | Promise<any>
 }
 
 interface Inertia {


### PR DESCRIPTION
This PR updates the "manual visits" (https://inertiajs.com/manual-visits) options and method type definitions to match what's currently deployed.