### PR TITLE
Preserve url hash on navigation

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -126,10 +126,13 @@ export default {
     let visitId = this.createVisitId()
     onCancelToken(this.cancelToken)
 
+    const stringifiedUrl = url.toString()
+    const [, hash] = stringifiedUrl.split('#')
+
     return new Proxy(
       Axios({
         method,
-        url: url.toString(),
+        url: stringifiedUrl,
         data: method.toLowerCase() === 'get' ? {} : data,
         params: method.toLowerCase() === 'get' ? data : {},
         cancelToken: this.cancelToken.token,
@@ -143,6 +146,7 @@ export default {
             'X-Inertia-Partial-Data': only.join(','),
           } : {}),
           ...(this.page.version ? { 'X-Inertia-Version': this.page.version } : {}),
+          ...(hash ? { 'X-Inertia-Hash': '#' + hash } : {}),
         },
         onUploadProgress: progress => {
           progress.percentage = Math.round(progress.loaded / progress.total * 100)


### PR DESCRIPTION
This PR is an attempt at fixing https://github.com/inertiajs/inertia/issues/85.

It goes with its inertiajs/inertia-laravel counterpart: https://github.com/inertiajs/inertia-laravel/pull/155

It adds a new `X-Inertia-Hash` header which contains the hash part of the URL.

That header can later be re-appended to the URL by the API, so that the client-side URL is correct.

---

If you are happy with the proposed changes, here are a few things that will need to be done too:
- [ ] Support the same behavior in inertiajs/inertia-rails
- [ ] Update PingCRM to demonstrate this behavior

---

Feel free to suggest any improvement :)