### PR TITLE
Local event support

### DIFF
--- a/packages/inertia-svelte/src/Link.svelte
+++ b/packages/inertia-svelte/src/Link.svelte
@@ -1,5 +1,8 @@
 <script>
-  import inertia from './link'
+  import { Inertia, shouldIntercept } from '@inertiajs/inertia'
+  import { createEventDispatcher } from 'svelte'
+
+  const dispatch = createEventDispatcher()
 
   export let
     data = {},
@@ -9,19 +12,39 @@
     preserveScroll = false,
     preserveState = false,
     only = [],
-    headers = {}
+    headers = {},
+    onCancelToken = () => ({}),
+    onStart = () => ({}),
+    onProgress = () => ({}),
+    onFinish = () => ({}),
+    onCancel = () => ({}),
+    onSuccess = () => ({})
+
+  function visit(event) {
+    dispatch('click', event)
+
+    if (shouldIntercept(event)) {
+      event.preventDefault()
+
+      Inertia.visit(href, {
+        data,
+        method,
+        preserveScroll,
+        preserveState,
+        replace,
+        only,
+        headers,
+        onCancelToken,
+        onStart,
+        onProgress,
+        onFinish,
+        onCancel,
+        onSuccess
+      })
+    }
+  }
 </script>
 
-<a
-  use:inertia={{ ...$$props }}
-  {...$$restProps}
-  {href}
-  on:click
-  on:cancelToken
-  on:start
-  on:progress
-  on:finish
-  on:cancel
-  on:success>
+<a {...$$restProps} {href} on:click={visit}>
   <slot />
 </a>


### PR DESCRIPTION
This PR adds support for cancelable local events when using the `InertiaLink` component:
```js
import { inertia, page, InertiaLink } from '@inertiajs/inertia-svelte'

<InertiaLink
    href={route('organizations.edit', organization.id)}
    onStart={e => confirm('Are you sure you want to visit this page?')}
    class="px-6 py-4 flex items-center focus:text-indigo-500"
>
    Example link
</InertiaLink>
```

The unfortunate downside here is that it _does not_ work when using the `use:inertia` directive, because those are actual javascript Event Listeners that are attached to a DOM node, meaning that there's no return value to capture. Of course, for those scenarios, users can still do `preventDefault`, even in the Svelte way:

```js
<a 
    use:inertia
    href={route('organizations.edit', organization.id)}
    on:start|preventDefault={event => console.log(event)}
>
    Example directive-based link
</a>
```