### PR TITLE
[React] Update InertiaLink typings

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -30,12 +30,12 @@ interface InertiaLinkProps {
   preserveState?: boolean | ((props: Inertia.PageProps) => boolean)
   replace?: boolean
   only?: string[]
-  onCancelToken: (cancelToken: import('axios').CancelTokenSource) => void
-  onStart: () => void
-  onProgress: (progress: number) => void
-  onFinish: () => void
-  onCancel: () => void
-  onSuccess: () => void
+  onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
+  onStart?: () => void
+  onProgress?: (progress: number) => void
+  onFinish?: () => void
+  onCancel?: () => void
+  onSuccess?: () => void
 }
 
 type InertiaLink = React.FunctionComponent<


### PR DESCRIPTION
The event props on the `InertiaLink` component should be optional, as suggested by their default values here: https://github.com/inertiajs/inertia/blob/052009a78aafdadcc4f060cca74475995ab2c6cd/packages/inertia-react/src/Link.js#L17-L22

Right now, I'm getting a bunch of type errors on `InertiaLink` components, because I'm not assigning a value to all of these methods:

```
Type '{ children: string; href: string; className: string; }' is missing the following properties from type 'InertiaLinkProps': onCancelToken, onStart, onProgress, onFinish, and 2 more.ts(2740)
```