### PR TITLE
Use titlecase for named component exports

### DIFF
--- a/packages/inertia-react/src/index.js
+++ b/packages/inertia-react/src/index.js
@@ -1,4 +1,4 @@
-export { default as app, default as InertiaApp } from './App'
-export { default as link, default as InertiaLink } from './Link'
+export { default as App, default as app, default as InertiaApp } from './App'
+export { default as Link, default as link, default as InertiaLink } from './Link'
 export { default as usePage } from './usePage'
 export { default as useRememberedState } from './useRememberedState'

--- a/packages/inertia-svelte/src/index.js
+++ b/packages/inertia-svelte/src/index.js
@@ -1,5 +1,5 @@
-export { default as app, default as InertiaApp } from './App.svelte'
-export { default as link, default as InertiaLink } from './Link.svelte'
+export { default as App, default as app, default as InertiaApp } from './App.svelte'
+export { default as Link, default as link, default as InertiaLink } from './Link.svelte'
 export { default as inertia } from './link'
 export { default as page } from './page'
 export { default as remember } from './remember'

--- a/packages/inertia-vue/src/index.js
+++ b/packages/inertia-vue/src/index.js
@@ -1,2 +1,2 @@
-export { default as app, plugin, default as InertiaApp } from './app'
-export { default as link, default as InertiaLink } from './link'
+export { default as App, default as app, plugin, default as InertiaApp } from './app'
+export { default as Link, default as link, default as InertiaLink } from './link'

--- a/packages/inertia-vue3/src/index.js
+++ b/packages/inertia-vue3/src/index.js
@@ -1,2 +1,2 @@
-export { default as app, plugin, usePage } from './app'
-export { default as link } from './link'
+export { default as App, default as app, plugin, usePage } from './app'
+export { default as Link, default as link } from './link'


### PR DESCRIPTION
Fixes #255 

This PR adds titlecased named exports for the "app" and "link" components. This seems to be the standard with React, Vue.js and Svelte, and in fact is actually required with React (see #255).

Note, the old lowercase exports will still exists for backwards compatibility, but I'll update all the docs to use the new format, to encourage this "proper use". The lowercase versions will now be considered deprecated.