### PR TITLE
Preserve url hash on navigation

### DIFF
--- a/packages/inertia-react/.eslintrc.js
+++ b/packages/inertia-react/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
   extends: ['eslint:recommended', 'plugin:react/recommended'],
   parserOptions: {
     sourceType: 'module',
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
   },
   plugins: ['react-hooks'],
   rules: {
@@ -19,7 +19,7 @@ module.exports = {
   },
   settings: {
     react: {
-      version: 'detect'
-    }
-  }
+      version: 'detect',
+    },
+  },
 }

--- a/packages/inertia-react/package.json
+++ b/packages/inertia-react/package.json
@@ -21,9 +21,9 @@
   "devDependencies": {
     "@inertiajs/inertia": "^0.4.0",
     "@types/react": "^16.9.1",
-    "eslint": "^6.1.0",
+    "eslint": "^7.0.0",
     "eslint-plugin-react": "^7.14.3",
-    "eslint-plugin-react-hooks": "^1.7.0",
+    "eslint-plugin-react-hooks": "^4.0.0",
     "microbundle": "^0.12.0",
     "react": "^16.9.0"
   },

--- a/packages/inertia-svelte/.eslintrc.js
+++ b/packages/inertia-svelte/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   extends: ['eslint:recommended'],
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
   rules: {

--- a/packages/inertia-svelte/package.json
+++ b/packages/inertia-svelte/package.json
@@ -13,7 +13,7 @@
   "main": "src/index.js",
   "devDependencies": {
     "@inertiajs/inertia": "^0.4.0",
-    "eslint": "^6.1.0"
+    "eslint": "^7.0.0"
   },
   "peerDependencies": {
     "@inertiajs/inertia": "^0.4.0",

--- a/packages/inertia-vue/.eslintrc.js
+++ b/packages/inertia-vue/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   extends: ['eslint:recommended'],
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
   rules: {

--- a/packages/inertia-vue/package.json
+++ b/packages/inertia-vue/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@inertiajs/inertia": "^0.4.0",
-    "eslint": "^6.1.0",
+    "eslint": "^7.0.0",
     "microbundle": "^0.12.0",
     "vue": "^2.0.0"
   },

--- a/packages/inertia-vue3/.eslintrc.js
+++ b/packages/inertia-vue3/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   extends: ['eslint:recommended'],
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
   rules: {

--- a/packages/inertia-vue3/package.json
+++ b/packages/inertia-vue3/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@inertiajs/inertia": "^0.4.0",
-    "eslint": "^6.1.0",
+    "eslint": "^7.0.0",
     "microbundle": "^0.12.0",
     "vue": "^3.0.0"
   },

--- a/packages/inertia/.eslintrc.js
+++ b/packages/inertia/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   extends: ['eslint:recommended'],
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
   rules: {

--- a/packages/inertia/package.json
+++ b/packages/inertia/package.json
@@ -22,7 +22,7 @@
     "axios": "^0.19.0 || ^0.20.0"
   },
   "devDependencies": {
-    "eslint": "^6.1.0",
+    "eslint": "^7.0.0",
     "microbundle": "^0.12.0"
   }
 }

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -126,8 +126,7 @@ export default {
   },
 
   urlWithoutHash(url) {
-    const parts = url.href.split('#')
-    return parts[0]
+    return url.href.split('#')[0]
   },
 
   visit(url, {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -64,6 +64,7 @@ export default {
       region.scrollTop = 0
       region.scrollLeft = 0
     })
+    this.saveScrollPositions()
 
     if (window.location.hash) {
       const el = document.getElementById(window.location.hash.slice(1))
@@ -265,7 +266,7 @@ export default {
   },
 
   restoreState(event) {
-    if (event.state) {
+    if (event.state && event.state.component) {
       const page = this.transformProps(event.state)
       let visitId = this.createVisitId()
       return Promise.resolve(this.resolveComponent(page.component)).then(component => {
@@ -276,6 +277,8 @@ export default {
           })
         }
       })
+    } else {
+      this.resetScrollPositions()
     }
   },
 

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -20,7 +20,7 @@ export default {
 
   handleInitialPageVisit(page) {
     if (this.isBackForwardVisit()) {
-      this.handleBackForwardVisit()
+      this.handleBackForwardVisit(page)
     } else if (this.isLocationVisit()) {
       this.handleLocationVisit(page)
     } else {
@@ -87,7 +87,8 @@ export default {
       && window.performance.getEntriesByType('navigation')[0].type === 'back_forward'
   },
 
-  handleBackForwardVisit() {
+  handleBackForwardVisit(page) {
+    window.history.state.version = page.version
     this.setPage(window.history.state, { preserveScroll: true }).then(() => {
       this.restoreScrollPositions()
     })

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -302,7 +302,7 @@ export default {
         }
       })
     } else {
-      let url = this.normalizeUrl(this.page.url)
+      const url = this.normalizeUrl(this.page.url)
       url.hash = window.location.hash
       this.replaceState({ ...this.page, url: url.href })
       this.resetScrollPositions()

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -145,7 +145,6 @@ export default {
   },
 
   normalizeUrl(url) {
-    url = url.toString()
     try {
       return new URL(url)
     } catch (error) {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -128,7 +128,7 @@ export default {
   },
 
   isInertiaResponse(response) {
-    return response && response.headers['x-inertia']
+    return response.?headers['x-inertia']
   },
 
   cancelActiveVisits() {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -31,7 +31,7 @@ export default {
 
     this.fireEvent('navigate', { detail: { page: initialPage } })
 
-    window.addEventListener('popstate', this.restoreState.bind(this))
+    window.addEventListener('popstate', this.handlePopstateEvent.bind(this))
     document.addEventListener('scroll', debounce(this.handleScrollEvent.bind(this), 100), true)
   },
 
@@ -265,7 +265,7 @@ export default {
     }, '', page.url)
   },
 
-  restoreState(event) {
+  handlePopstateEvent(event) {
     if (event.state && event.state.component) {
       const page = this.transformProps(event.state)
       let visitId = this.createVisitId()

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -344,9 +344,7 @@ export default {
   },
 
   restore(key = 'default') {
-    if (window.history.state.rememberedState && window.history.state.rememberedState[key]) {
-      return window.history.state.rememberedState[key]
-    }
+    return window.history.state?.rememberedState?.[key]
   },
 
   fireEvent(name, options) {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -286,7 +286,7 @@ export default {
 
   handlePopstateEvent(event) {
     if (event.state !== null) {
-      let page = event.state
+      const page = event.state
       let visitId = this.createVisitId()
       return Promise.resolve(this.resolveComponent(page.component)).then(component => {
         if (visitId === this.visitId) {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -146,7 +146,11 @@ export default {
 
   normalizeUrl(url) {
     try {
-      return new URL(url)
+      if (url.startsWith('#')) {
+        return new URL(`${this.urlWithoutHash(window.location)}${url}`)
+      } else {
+        return new URL(url)
+      }
     } catch (error) {
       return new URL(`${window.location.origin}${url}`)
     }

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -67,10 +67,7 @@ export default {
     this.saveScrollPositions()
 
     if (window.location.hash) {
-      const el = document.getElementById(window.location.hash.slice(1))
-      if (el) {
-        el.scrollIntoView()
-      }
+      document.getElementById(window.location.hash.slice(1))?.scrollIntoView()
     }
   },
 

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -97,7 +97,10 @@ export default {
   locationVisit(url, preserveScroll) {
     try {
       window.sessionStorage.setItem('inertiaLocationVisit', JSON.stringify({ preserveScroll }))
-      window.location.href = url
+      window.location.href = url.href
+      if (this.urlWithoutHash(window.location).href === this.urlWithoutHash(url).href) {
+        window.location.reload()
+      }
     } catch (error) {
       return false
     }
@@ -236,7 +239,7 @@ export default {
           if (url.hash && !locationUrl.hash && this.urlWithoutHash(url).href === locationUrl.href) {
             locationUrl.hash = url.hash
           }
-          this.locationVisit(locationUrl.href, preserveScroll)
+          this.locationVisit(locationUrl, preserveScroll)
         } else if (error.response) {
           if (this.fireEvent('invalid', { cancelable: true, detail: { response: error.response } })) {
             modal.show(error.response.data)

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -339,9 +339,13 @@ export default {
   },
 
   remember(data, key = 'default') {
-    let page = { ...this.page }
-    page.rememberedState[key] = data
-    this.replaceState(page)
+    this.replaceState({
+      ...this.page,
+      rememberedState: {
+        ...this.page.rememberedState,
+        [key]: data,
+      },
+    })
   },
 
   restore(key = 'default') {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -231,14 +231,14 @@ export default {
   },
 
   setPage(page, { visitId = this.createVisitId(), replace = false, preserveScroll = false, preserveState = false } = {}) {
-    this.page = this.transformProps(page)
+    this.page = page
     return Promise.resolve(this.resolveComponent(page.component)).then(component => {
       if (visitId === this.visitId) {
         preserveState = typeof preserveState === 'function' ? preserveState(page) : preserveState
         preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page) : preserveScroll
         replace = replace || page.url === `${window.location.pathname}${window.location.search}`
         replace ? this.replaceState(page, preserveState) : this.pushState(page)
-        this.swapComponent({ component, page, preserveState }).then(() => {
+        this.swapComponent({ component, page: this.transformProps(page), preserveState }).then(() => {
           if (!preserveScroll) {
             this.resetScrollPositions()
           }
@@ -266,11 +266,11 @@ export default {
 
   handlePopstateEvent(event) {
     if (event.state && event.state.component) {
-      const page = this.transformProps(event.state)
+      const page = event.state
       let visitId = this.createVisitId()
       return Promise.resolve(this.resolveComponent(page.component)).then(component => {
         if (visitId === this.visitId) {
-          this.swapComponent({ component, page, preserveState: false }).then(() => {
+          this.swapComponent({ component, page: this.transformProps(page), preserveState: false }).then(() => {
             this.restoreScrollPositions(page)
             this.fireEvent('navigate', { detail: { page: page } })
           })

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -114,8 +114,8 @@ export default {
     const locationVisit = JSON.parse(window.sessionStorage.getItem('inertiaLocationVisit'))
     window.sessionStorage.removeItem('inertiaLocationVisit')
     page.url += window.location.hash
-    page.rememberedState = window.history.state ? window.history.state.rememberedState : {}
-    page.scrollRegions = window.history.state ? window.history.state.scrollRegions : []
+    page.rememberedState = window.history.state?.rememberedState ?? {}
+    page.scrollRegions = window.history.state?.scrollRegions ?? []
     this.setPage(page, { preserveScroll: locationVisit.preserveScroll }).then(() => {
       if (locationVisit.preserveScroll) {
         this.restoreScrollPositions()

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -128,7 +128,7 @@ export default {
   },
 
   isInertiaResponse(response) {
-    return response.?headers['x-inertia']
+    return response?.headers['x-inertia']
   },
 
   cancelActiveVisits() {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -277,6 +277,10 @@ export default {
         }
       })
     } else {
+      let url = this.normalizeUrl(this.page.url)
+      url.hash = window.location.hash
+      this.page.url = url.href
+      this.replaceState(this.page, true)
       this.resetScrollPositions()
     }
   },


### PR DESCRIPTION
This PR adds support for URL hashes in Inertia.js (which are currently very much broken).

## URL hashes when making Inertia visits

Currently it's not possible to make an Inertia visit that includes a hash in the URL. For example:

```html
<inertia-link url="/users#create">Create user</inertia-link>
```

This is because hashes are never sent from the browser to the server, which means when an Inertia response is received (which includes the `url` as part of the `page` object) and Inertia updates the history state with the new URL, the hash is gone.

We've been able to fix this by keeping track of the hash client-side, and appending it back on the URL when the Inertia response is received. Here's how:

1. When a request is made, we parse out the hash from the URL before making the request to the server.
2. When the response is received, we compare the intended URL with the response URL. If they match (meaning we ended up at the intended URL, and didn't get logged out or something), then we append the hash back to the URL (which causes it to be included in the URL when the history state is updated).
3. When we reset the scroll position, we check if a hash is set, and manually scroll to that location using the `Element.scrollIntoView()` method.

The nice thing about this change is that it's entirely made in Inertia core, and requires no adapter changes.

This is an alternative solution to #244.

## Same-page anchor links

Currently same-page anchor links are broken in Inertia. For example:

```html
<a url="#create">Create user</a>
<!-- ... -->
<h2 id="create">Create User</h2>
```

This is because anchor links add a new entry to the history state, however our current `popstate` handler doesn't account for them—rather it assumes that there will always be an `event.state` property present. This causes an error to be thrown when navigating history "anchor visits".

To solve this, I've updated the Inertia `popstate` handler to detect same-page anchor visits. When these occur, Inertia adds the current `page` from local memory to the history state. This allows anchor visits to have their own remember state (local state caching) and scroll positioning.


## Other changes

Here is a list of other changes that came as a result of the refactor to support hashes:

- Fixed scroll restoration for offsite back/forward visits.
- Fixed `sessionStorage` issues for browsers that have it disabled.
- Renamed "hard visits" to "location visits".
- Updated location visits to respect the `preserveScroll` option.
- Made the URL check when determining the history "replace" value less brittle.
- Removed prop transforming from `popstate` handler (to prevent double transforming).
- Split up large methods into smaller, better named methods.
- Improved overall code formatting.
- Fixed bug where same page location visits wouldn't cause a full page reload.