### PR TITLE
Fix promise deprecation warning

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -256,8 +256,12 @@ export default {
         onFinish()
       }), {
         get: function(target, prop) {
-          console.warn('Inertia.js visit promises have been deprecated and will be removed in a future release. Please use the new visit event callbacks instead.\n\nLearn more at https://inertiajs.com/manual-visits#promise-deprecation')
-          return target[prop].bind(target)
+          if (['then', 'catch', 'finally'].includes(prop)) {
+            console.warn('Inertia.js visit promises have been deprecated and will be removed in a future release. Please use the new visit event callbacks instead.\n\nLearn more at https://inertiajs.com/manual-visits#promise-deprecation')
+          }
+          return typeof target[prop] === 'function'
+            ? target[prop].bind(target)
+            : target[prop]
         },
       },
     )


### PR DESCRIPTION
Fixes #260

This PR updates the promise proxy used to show the deprecation warning for `then`, `catch` and `finally` calls. It also now only tries to bind the `target` if the property is a function.