### PR TITLE
Set link preserveState default based on method

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -27,7 +27,7 @@ interface InertiaLinkProps {
       | React.KeyboardEvent<HTMLAnchorElement>
   ) => void
   preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
-  preserveState?: boolean | ((props: Inertia.PageProps) => boolean)
+  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
   replace?: boolean
   only?: string[]
   onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void

--- a/packages/inertia-react/src/Link.js
+++ b/packages/inertia-react/src/Link.js
@@ -8,12 +8,12 @@ export default forwardRef(function InertiaLink({
   data = {},
   href,
   method = 'get',
-  onClick = noop,
   preserveScroll = false,
-  preserveState = false,
+  preserveState = null,
   replace = false,
   only = [],
   headers = {},
+  onClick = noop,
   onCancelToken = noop,
   onStart = noop,
   onProgress = noop,
@@ -33,7 +33,7 @@ export default forwardRef(function InertiaLink({
           data,
           method,
           preserveScroll,
-          preserveState,
+          preserveState: preserveState ?? (method !== 'get'),
           replace,
           only,
           headers,
@@ -50,7 +50,6 @@ export default forwardRef(function InertiaLink({
       data,
       href,
       method,
-      onClick,
       preserveScroll,
       preserveState,
       replace,
@@ -63,7 +62,7 @@ export default forwardRef(function InertiaLink({
       onFinish,
       onCancel,
       onSuccess,
-    ]
+    ],
   )
 
   return createElement('a', { ...props, href, ref, onClick: visit }, children)

--- a/packages/inertia-react/src/Link.js
+++ b/packages/inertia-react/src/Link.js
@@ -33,7 +33,7 @@ export default forwardRef(function InertiaLink({
           data,
           method,
           preserveScroll,
-          preserveState: preserveState ?? (method !== 'get'),
+          preserveState: preserveState ?? (method.toLowerCase() !== 'get'),
           replace,
           only,
           headers,

--- a/packages/inertia-svelte/src/Link.svelte
+++ b/packages/inertia-svelte/src/Link.svelte
@@ -24,7 +24,7 @@
         data,
         method,
         preserveScroll,
-        preserveState: preserveState !== null ? preserveState : (method !== 'get'),
+        preserveState: preserveState !== null ? preserveState : (method.toLowerCase() !== 'get'),
         replace,
         only,
         headers

--- a/packages/inertia-svelte/src/Link.svelte
+++ b/packages/inertia-svelte/src/Link.svelte
@@ -10,7 +10,7 @@
     method = 'get',
     replace = false,
     preserveScroll = false,
-    preserveState = false,
+    preserveState = null,
     only = [],
     headers = {}
 
@@ -24,7 +24,7 @@
         data,
         method,
         preserveScroll,
-        preserveState,
+        preserveState: preserveState !== null ? preserveState : (method !== 'get'),
         replace,
         only,
         headers

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -32,7 +32,7 @@ interface InertiaLinkProps {
   method?: string
   onClick?: (event: MouseEvent | KeyboardEvent) => void
   preserveScroll?: boolean
-  preserveState?: boolean
+  preserveState?: boolean | null
   replace?: boolean
 }
 

--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -67,7 +67,7 @@ export default {
               method: props.method,
               replace: props.replace,
               preserveScroll: props.preserveScroll,
-              preserveState: props.preserveState ?? (props.method !== 'get'),
+              preserveState: props.preserveState ?? (props.method.toLowerCase() !== 'get'),
               only: props.only,
               headers: props.headers,
               onCancelToken: data.on.cancelToken,

--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -67,7 +67,7 @@ export default {
               method: props.method,
               replace: props.replace,
               preserveScroll: props.preserveScroll,
-              preserveState: props.preserveState !== null ? props.preserveState : (props.method !== 'get'),
+              preserveState: props.preserveState ?? (props.method !== 'get'),
               only: props.only,
               headers: props.headers,
               onCancelToken: data.on.cancelToken,

--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -25,7 +25,7 @@ export default {
     },
     preserveState: {
       type: Boolean,
-      default: false,
+      default: null,
     },
     only: {
       type: Array,
@@ -67,7 +67,7 @@ export default {
               method: props.method,
               replace: props.replace,
               preserveScroll: props.preserveScroll,
-              preserveState: props.preserveState,
+              preserveState: props.preserveState !== null ? props.preserveState : (props.method !== 'get'),
               only: props.only,
               headers: props.headers,
               onCancelToken: data.on.cancelToken,

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -25,7 +25,7 @@ export default {
     },
     preserveState: {
       type: Boolean,
-      default: false,
+      default: null,
     },
     only: {
       type: Array,
@@ -49,7 +49,7 @@ export default {
             method: props.method,
             replace: props.replace,
             preserveScroll: props.preserveScroll,
-            preserveState: props.preserveState,
+            preserveState: props.preserveState ?? (props.method !== 'get'),
             only: props.only,
             headers: props.headers,
             onCancelToken: attrs.onCancelToken || (() => ({})),

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -49,7 +49,7 @@ export default {
             method: props.method,
             replace: props.replace,
             preserveScroll: props.preserveScroll,
-            preserveState: props.preserveState ?? (props.method !== 'get'),
+            preserveState: props.preserveState ?? (props.method.toLowerCase() !== 'get'),
             only: props.only,
             headers: props.headers,
             onCancelToken: attrs.onCancelToken || (() => ({})),

--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -24,7 +24,7 @@ type VisitOptions = {
   method?: string
   replace?: boolean
   preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
-  preserveState?: boolean | ((props: Inertia.PageProps) => boolean)
+  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
   only?: string[]
   headers?: object
   onCancelToken?: (cancelToken: CancelTokenSource) => void
@@ -34,7 +34,7 @@ type VisitOptions = {
   onCancel?: () => void
   onSuccess?: (page: Page) => void | Promise<any>
 }
-  
+
 type InertiaEvent = 'start' | 'progress' | 'success' | 'invalid' | 'error' | 'finish' | 'navigate'
 
 interface Inertia {
@@ -75,7 +75,7 @@ interface Inertia {
   remember: (data: object, key?: string) => void
 
   restore: (key?: string) => object
-  
+
   on: (type: InertiaEvent, callback: (event: Event) => boolean | void) => () => void
 }
 


### PR DESCRIPTION
Fixes #164

This PR changes the default `preserveState` value in the link components from `false` to `false` for `get` visits, and `false` for `post|put|patch|delete` visits.

- [x] Update the Vue 2 adapter
- [x] Update the Vue 3 adapter
- [x] Update the React adapter
- [x] Update the Svelte adapter