### PR TITLE
Simplify code contributions for beginners via automating the dev setup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,6 +29,12 @@ If you're making changes to one of the packages that requires a build step (`ine
 yarn watch
 ```
 
+### Online one-click development setup
+
+You can use Gitpod(a VS-Code like IDE) for online development. With a single click it will launch a workspace and automatically: clone this repo, install the dependencies, run `yarn build` and `yarn watch`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 It's often helpful to develop Inertia.js within a real application, such as [Ping CRM](https://github.com/inertiajs/pingcrm). To do this, you'll need to use the `yarn link` feature to tell your application to use the local versions of the Inertia.js dependencies. To do this, first run `yarn link` within each Inertia.js package that you want to develop.
 
 ```sh

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+tasks:
+  - init: yarn install && yarn build
+    command: yarn watch
+
+vscode:
+  extensions:
+    - svelte.svelte-vscode@102.2.0:iaSoYOG2z21hy3Al1KkLjw==
+    - octref.vetur@0.28.0:bW1RGNnmWYQO43JdJgK34w==


### PR DESCRIPTION
Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `inertia` repo.
- install the dependencies.
- run `yarn build` and `yarn watch`.
- install `Vetur` and `Svelte for VS-Code` extensions.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/inertia

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/96409136-3c8a6400-11fe-11eb-9043-56c97fd69502.png)


