### PR TITLE
Add link "as" option

### DIFF
--- a/packages/inertia-react/src/Link.js
+++ b/packages/inertia-react/src/Link.js
@@ -34,7 +34,7 @@ export default forwardRef(function InertiaLink({
           data,
           method,
           preserveScroll,
-          preserveState: preserveState ?? (method.toLowerCase() !== 'get'),
+          preserveState: preserveState ?? (method !== 'get'),
           replace,
           only,
           headers,
@@ -66,6 +66,8 @@ export default forwardRef(function InertiaLink({
     ],
   )
 
+  as = as.toLowerCase()
+  method = method.toLowerCase()
   const [url, _data] = mergeDataIntoQueryString(method, hrefToUrl(href), data)
   href = url.href
   data = _data

--- a/packages/inertia-react/src/Link.js
+++ b/packages/inertia-react/src/Link.js
@@ -5,6 +5,7 @@ const noop = () => undefined
 
 export default forwardRef(function InertiaLink({
   children,
+  as = 'a',
   data = {},
   href,
   method = 'get',
@@ -69,5 +70,10 @@ export default forwardRef(function InertiaLink({
   href = url.href
   data = _data
 
-  return createElement('a', { ...props, href, ref, onClick: visit }, children)
+  return createElement(as, {
+    ...props,
+    ...as === 'a' ? { href } : {},
+    ref,
+    onClick: visit,
+  }, children)
 })

--- a/packages/inertia-react/src/Link.js
+++ b/packages/inertia-react/src/Link.js
@@ -72,6 +72,10 @@ export default forwardRef(function InertiaLink({
   href = url.href
   data = _data
 
+  if (as === 'a' && method !== 'get') {
+    console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<InertiaLink href="${href}" method="${method}" as="button">...</InertiaLink>`)
+  }
+
   return createElement(as, {
     ...props,
     ...as === 'a' ? { href } : {},

--- a/packages/inertia-svelte/src/Link.svelte
+++ b/packages/inertia-svelte/src/Link.svelte
@@ -19,6 +19,10 @@
     const [url, _data] = mergeDataIntoQueryString(method, hrefToUrl(href), data)
     href = url.href
     data = _data
+
+    if (method !== 'get') {
+      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "inertia" directive. For example:\n\n<button use:inertia={{ method: 'post' }} href="${url.href}" >...</button>`)
+    }
   })
 
   function visit(event) {

--- a/packages/inertia-svelte/src/Link.svelte
+++ b/packages/inertia-svelte/src/Link.svelte
@@ -21,7 +21,7 @@
     data = _data
 
     if (method !== 'get') {
-      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "inertia" directive. For example:\n\n<button use:inertia={{ method: 'post' }} href="${url.href}" >...</button>`)
+      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "inertia" directive. For example:\n\n<button use:inertia={{ method: 'post', href: '${url.href}' }}>...</button>`)
     }
   })
 

--- a/packages/inertia-svelte/src/Link.svelte
+++ b/packages/inertia-svelte/src/Link.svelte
@@ -15,6 +15,7 @@
     headers = {}
 
   beforeUpdate(() => {
+    method = method.toLowerCase()
     const [url, _data] = mergeDataIntoQueryString(method, hrefToUrl(href), data)
     href = url.href
     data = _data
@@ -30,7 +31,7 @@
         data,
         method,
         preserveScroll,
-        preserveState: preserveState !== null ? preserveState : (method.toLowerCase() !== 'get'),
+        preserveState: preserveState !== null ? preserveState : (method !== 'get'),
         replace,
         only,
         headers,

--- a/packages/inertia-svelte/src/link.js
+++ b/packages/inertia-svelte/src/link.js
@@ -2,11 +2,7 @@ import { hrefToUrl, Inertia, mergeDataIntoQueryString, shouldIntercept } from '@
 import { createEventDispatcher } from 'svelte'
 
 export default (node, options = {}) => {
-  const [url, data] = mergeDataIntoQueryString(
-    options.method || 'get',
-    hrefToUrl(node.href || options.href),
-    options.data || {},
-  )
+  const [url, data] = mergeDataIntoQueryString(options.method || 'get', hrefToUrl(node.href || options.href), options.data || {})
   node.href = url.href
   options.data = data
 
@@ -31,11 +27,7 @@ export default (node, options = {}) => {
 
   return {
     update(newOptions) {
-      const [url, data] = mergeDataIntoQueryString(
-        newOptions.method || 'get',
-        hrefToUrl(node.href || newOptions.href),
-        newOptions.data || {},
-      )
+      const [url, data] = mergeDataIntoQueryString(newOptions.method || 'get', hrefToUrl(node.href || newOptions.href), newOptions.data || {})
       node.href = url.href
       newOptions.data = data
       options = newOptions

--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -56,6 +56,10 @@ export default {
     const method = props.method.toLowerCase()
     const [url, propsData] = mergeDataIntoQueryString(method, hrefToUrl(props.href), props.data)
 
+    if (as === 'a' && method !== 'get') {
+      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<inertia-link href="${url.href}" method="${method}" as="button">...</inertia-link>`)
+    }
+
     return h(props.as, {
       ...data,
       attrs: {

--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -3,6 +3,10 @@ import { hrefToUrl, Inertia, mergeDataIntoQueryString, shouldIntercept } from '@
 export default {
   functional: true,
   props: {
+    as: {
+      type: String,
+      default: 'a',
+    },
     data: {
       type: Object,
       default: () => ({}),
@@ -54,11 +58,11 @@ export default {
       props.data,
     )
 
-    return h('a', {
+    return h(props.as, {
       ...data,
       attrs: {
         ...data.attrs,
-        href: url.href,
+        ...props.as === 'a' ? { href: url.href } : {},
       },
       on: {
         ...data.on,

--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -52,17 +52,15 @@ export default {
       ...(data.on || {}),
     }
 
-    let [url, propsData] = mergeDataIntoQueryString(
-      props.method,
-      hrefToUrl(props.href),
-      props.data,
-    )
+    const as = props.as.toLowerCase()
+    const method = props.method.toLowerCase()
+    const [url, propsData] = mergeDataIntoQueryString(method, hrefToUrl(props.href), props.data)
 
     return h(props.as, {
       ...data,
       attrs: {
         ...data.attrs,
-        ...props.as === 'a' ? { href: url.href } : {},
+        ...as === 'a' ? { href: url.href } : {},
       },
       on: {
         ...data.on,
@@ -74,10 +72,10 @@ export default {
 
             Inertia.visit(url.href, {
               data: propsData,
-              method: props.method,
+              method: method,
               replace: props.replace,
               preserveScroll: props.preserveScroll,
-              preserveState: props.preserveState ?? (props.method.toLowerCase() !== 'get'),
+              preserveState: props.preserveState ?? (method !== 'get'),
               only: props.only,
               headers: props.headers,
               onCancelToken: data.on.cancelToken,

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -46,6 +46,10 @@ export default {
       const method = props.method.toLowerCase()
       const [url, data] = mergeDataIntoQueryString(method, hrefToUrl(props.href), props.data)
 
+      if (as === 'a' && method !== 'get') {
+        console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<inertia-link href="${url.href}" method="${method}" as="button">...</inertia-link>`)
+      }
+
       return h(props.as, {
         ...attrs,
         ...as === 'a' ? { href: url.href } : {},

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -42,25 +42,23 @@ export default {
   },
   setup(props, { slots, attrs }) {
     return props => {
-      let [url, data] = mergeDataIntoQueryString(
-        props.method,
-        hrefToUrl(props.href),
-        props.data,
-      )
+      const as = props.as.toLowerCase()
+      const method = props.method.toLowerCase()
+      const [url, data] = mergeDataIntoQueryString(method, hrefToUrl(props.href), props.data)
 
       return h(props.as, {
         ...attrs,
-        ...props.as === 'a' ? { href: url.href } : {},
+        ...as === 'a' ? { href: url.href } : {},
         onClick: (event) => {
           if (shouldIntercept(event)) {
             event.preventDefault()
 
             Inertia.visit(url.href, {
               data: data,
-              method: props.method,
+              method: method,
               replace: props.replace,
               preserveScroll: props.preserveScroll,
-              preserveState: props.preserveState ?? (props.method.toLowerCase() !== 'get'),
+              preserveState: props.preserveState ?? (method !== 'get'),
               only: props.only,
               headers: props.headers,
               onCancelToken: attrs.onCancelToken || (() => ({})),

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -3,6 +3,10 @@ import { hrefToUrl, Inertia, mergeDataIntoQueryString, shouldIntercept } from '@
 
 export default {
   props: {
+    as: {
+      type: String,
+      default: 'a',
+    },
     data: {
       type: Object,
       default: () => ({}),
@@ -44,9 +48,9 @@ export default {
         props.data,
       )
 
-      return h('a', {
+      return h(props.as, {
         ...attrs,
-        href: url.href,
+        ...props.as === 'a' ? { href: url.href } : {},
         onClick: (event) => {
           if (shouldIntercept(event)) {
             event.preventDefault()

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -163,6 +163,7 @@ export default {
     onCancel = () => ({}),
     onSuccess = () => ({}),
   } = {}) {
+    method = method.toLowerCase();
     [url, data] = mergeDataIntoQueryString(method, hrefToUrl(url), data)
 
     let visit = { url, ...arguments[1] }
@@ -178,8 +179,8 @@ export default {
       Axios({
         method,
         url: urlWithoutHash(url).href,
-        data: method.toLowerCase() === 'get' ? {} : data,
-        params: method.toLowerCase() === 'get' ? data : {},
+        data: method === 'get' ? {} : data,
+        params: method === 'get' ? data : {},
         cancelToken: this.cancelToken.token,
         headers: {
           ...headers,

--- a/packages/inertia/src/shouldIntercept.js
+++ b/packages/inertia/src/shouldIntercept.js
@@ -1,11 +1,12 @@
 export default function shouldIntercept(event) {
+  const isLink = event.currentTarget.tagName.toLowerCase() === 'a'
   return !(
     (event.target && event.target.isContentEditable)
     || event.defaultPrevented
-    || event.which > 1
-    || event.altKey
-    || event.ctrlKey
-    || event.metaKey
-    || event.shiftKey
+    || (isLink && event.which > 1)
+    || (isLink && event.altKey)
+    || (isLink && event.ctrlKey)
+    || (isLink && event.metaKey)
+    || (isLink && event.shiftKey)
   )
 }


### PR DESCRIPTION
Closes #268

This PR adds a new "as" attribute to the Inertia link component that allows you to render a link as a different element. For example:

```vue
<inertia-link href="/example" as="div">Example</inertia-link>

<!-- Renders as div (with a click event listener) -->
<div>Example</div>
```

- [x] Make `shouldIntercept` method compatible with non-anchor elements.
- [x] Deprecate non-GET `<a>` links (show console warning, suggesting button or another element)
- [x] Update the Vue 2 adapter
- [x] Update the Vue 3 adapter
- [x] Update the React adapter
- ~~Update the Svelte adapter~~

## Svelte adapter

The only adapter I'm not sure about is the Svelte adapter, since Svelte does not support dynamic elements yet (see [here](https://github.com/sveltejs/svelte/issues/2324)). It would literally mean a huge if statement for all the possible elements:

```js
{#if as === 'a'}
  <a {...$$restProps} {href} on:click={visit}><slot /></a>
{:else if as ==='button'}
  <button {...$$restProps} on:click={visit}><slot /></button>
{:else if as ==='div'}
  <div {...$$restProps} on:click={visit}><slot /></div>
<!-- etc... -->
{/if}
```

Considering there is already support for this in Svelte using the `inertia` directive, I think it probably doesn't make sense to add it here at this time.

```svelte
<div use:inertia href="/example">Example</div>
```