### PR TITLE
ensure data is object

### DIFF
--- a/packages/inertia/src/url.js
+++ b/packages/inertia/src/url.js
@@ -14,7 +14,7 @@ export function hrefToUrl(href) {
 }
 
 export function mergeDataIntoQueryString(method, url, data) {
-  if (method === 'get' && Object.keys(data).length) {
+  if (method === 'get' && typeof data === 'object' && Object.keys(data).length) {
     url.search = qs.stringify(deepmerge(qs.parse(url.search, { ignoreQueryPrefix: true }), data), { encode: false })
     data = {}
   }


### PR DESCRIPTION
Ensure that `data` is an object. There might be a case, where people try to provide an array instead of an object as `data`. The array just removes all queries in the url. This PR prevents queries from being wiped out.

```
// <inertia-link href="https://google.com?a=aaa&b=bbb" :data="[1, 2]">Go to google</inertia-link>

let data = [1, 2]
let url = new URL('https://google.com?a=aaa&b=bbb')

let search = qs.parse(url.search, { ignoreQueryPrefix: true })

console.log(search) => {a: "aaa", b: "bbb"}
console.log(data) => [1, 2]

let deepMerge = deepmerge(search, data)

console.log(deepMerge) => [1, 2]

let stringify = qs.stringify(deepMerge, { encode: false })

console.log(stringify); => 0=1&1=2
```

