### PR TITLE
Update type definitions

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -41,7 +41,7 @@ interface InertiaLinkProps {
 }
 
 type InertiaLink = React.FunctionComponent<
-  InertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'>
+  InertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'> & React.AllHTMLAttributes<HTMLElement>
 >
 
 export function usePage<

--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -18,9 +18,11 @@ type App<
 }>
 
 interface InertiaLinkProps {
+  as?: string
   data?: object
   href: string
   method?: string
+  headers?: object
   onClick?: (
     event:
       | React.MouseEvent<HTMLAnchorElement>
@@ -39,7 +41,7 @@ interface InertiaLinkProps {
 }
 
 type InertiaLink = React.FunctionComponent<
-  InertiaLinkProps & Omit<React.HTMLAttributes<HTMLAnchorElement>, 'onProgress'>
+  InertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'>
 >
 
 export function usePage<

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -27,13 +27,22 @@ type App<
 >
 
 interface InertiaLinkProps {
+  as?: string
   data?: object
   href: string
   method?: string
+  headers?: object
   onClick?: (event: MouseEvent | KeyboardEvent) => void
-  preserveScroll?: boolean
-  preserveState?: boolean | null
+  preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
+  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
   replace?: boolean
+  only?: string[]
+  onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
+  onStart?: () => void
+  onProgress?: (progress: number) => void
+  onFinish?: () => void
+  onCancel?: () => void
+  onSuccess?: () => void
 }
 
 type InertiaLink = FunctionalComponentOptions<InertiaLinkProps>


### PR DESCRIPTION
This PR adds InertiaLink's missing type definitions for React and Vue.

For React I also allowed all HTML attributes, since you can now do the following to create a button: `<InertiaLink as="button" type="button" href="/test">Some test!</InertiaLink>`. I'm not sure if this is the correct way to do this in React/TS, but I've tested this and it works and the builds finish without errors.

The Vue TS definitions probably also require a change to allow HTML attributes, but I couldn't figure out how to do this with Vue.

To test this I simply created a React TS app (`npx create-react-app my-app --template typescript`), installed inertia/inertia-react, made the changes within the node_modules folder and simply added an InertiaLink with new Inertia attributes and some default HTML attributes.