### PR TITLE
Add Typescript definitions for 'App' and 'plugin' named imports

### DIFF
--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -50,3 +50,7 @@ type InertiaLink = FunctionalComponentOptions<InertiaLinkProps>
 export const InertiaLink: InertiaLink
 
 export const InertiaApp: App
+
+export const App: App
+
+export const plugin: PluginObject


### PR DESCRIPTION
Following the recent changes on client-side framework setup:

```js
import { App, plugin } from '@inertiajs/inertia-vue'
```