### PR TITLE
Fix: hrefToUrl can call startsWith on Objects

### DIFF
--- a/packages/inertia/src/url.js
+++ b/packages/inertia/src/url.js
@@ -2,6 +2,8 @@ import qs from 'qs'
 import deepmerge from 'deepmerge'
 
 export function hrefToUrl(href) {
+  href = href.toString()
+
   try {
     if (href.startsWith('#')) {
       return new URL(`${urlWithoutHash(window.location)}${href}`)


### PR DESCRIPTION
When using `window.location` or similar objects inside a `this.$method.post` (or similar request method), the request itself fails instantly due to calling `startsWith` on an object that does not have that method defined. 

As a result, the logic that does this check throws an error, which is caught instantly inside the same method, and instead returns a differently-formatted fallback URL that (in this case) causes the request URL to become malformed.

By calling `toString` on the object first, we essentially solve this problem, as the string object does have the `startsWith` method defined. Calling `toString` on a string is fine as well, and simply returns the existing string.

**Example**:
URL: `http://example.test/templates/1/variants/1`
Request: `this.$inertia.post(window.location)`
Result: `POST http://example.testhttp//example.test/templates/1/variants/1 net::ERR_NAME_NOT_RESOLVED`