### PR TITLE
Update reload() method to preserve scroll position

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -310,7 +310,7 @@ export default {
   },
 
   reload(options = {}) {
-    return this.visit(window.location.href, { preserveScroll: true, preserveState: true, ...options })
+    return this.visit(window.location.href, { ...options, preserveScroll: true, preserveState: true })
   },
 
   replace(url, options = {}) {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -310,7 +310,7 @@ export default {
   },
 
   reload(options = {}) {
-    return this.replace(window.location.href, options)
+    return this.visit(window.location.href, { preserveScroll: true, preserveState: true, ...options })
   },
 
   replace(url, options = {}) {


### PR DESCRIPTION
The goal with `Inertia.reload()` is to refresh the page data (props) using a nice terse API. This method is similar to `location.reload()`, except `location.reload()` also preserves the scroll position, where `Inertia.reload()` doesn't currently. This PR updates it to do that.

This also forces the `preserveState` to `true`, instead of allowing you to override this via the `options`. If you don't want `preserveScroll` and `preserveState`, use a different method. 👍 

I also took the opportunity to break the dependency on `Inertia.replace()`, which is being deprecated.

We also don't need to explicitly set `replace: true`, since that happens automatically by making a visit to the same URL.