### PR TITLE
Add deprecation notice for replace() method

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -314,6 +314,7 @@ export default {
   },
 
   replace(url, options = {}) {
+    console.warn(`Inertia.replace() has been deprecated and will be removed in a future release. Please use Inertia.${options.method ?? 'get'}() instead.`)
     return this.visit(url, { preserveState: true, ...options, replace: true })
   },
 


### PR DESCRIPTION
Closes #292

This PR adds a deprecation notice for the `Inertia.replace()` method, which has a number of issues (see #292).