### PR TITLE
Clone page before transforming props

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -269,14 +269,15 @@ export default {
   setPage(page, { visitId = this.createVisitId(), replace = false, preserveScroll = false, preserveState = false } = {}) {
     return Promise.resolve(this.resolveComponent(page.component)).then(component => {
       if (visitId === this.visitId) {
-        page.props = this.transformProps(page.props)
         page.scrollRegions = page.scrollRegions || []
         page.rememberedState = page.rememberedState || {}
         preserveState = typeof preserveState === 'function' ? preserveState(page) : preserveState
         preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page) : preserveScroll
         replace = replace || hrefToUrl(page.url).href === window.location.href
         replace ? this.replaceState(page) : this.pushState(page)
-        this.swapComponent({ component, page, preserveState }).then(() => {
+        const clone = JSON.parse(JSON.stringify(page))
+        clone.props = this.transformProps(clone.props)
+        this.swapComponent({ component, page: clone, preserveState }).then(() => {
           if (!preserveScroll) {
             this.resetScrollPositions()
           }


### PR DESCRIPTION
Fixes #278
Fixes #295 

This fixes an issue where, when transforming props, if you put non-primitives (functions/classes) into your page props, it generates the following error:

```
Uncaught (in promise) DOMException: Failed to execute 'replaceState' on 'History': function () { ... } could not be cloned.
```

This is because the object that's put in history state must be something that can be serialized, and non-primitives cannot be.

To fix this, we need to deep clone the `page` object, and then do the props transforming on that, and then pass that to the `swapComponent()` method to be used in our apps.