### PR TITLE
Update peer dependency

### DIFF
--- a/packages/inertia-vue/package.json
+++ b/packages/inertia-vue/package.json
@@ -25,7 +25,7 @@
     "vue": "^2.0.0"
   },
   "peerDependencies": {
-    "@inertiajs/inertia": "^0.5.0",
+    "@inertiajs/inertia": "^0.6.0",
     "vue": "^2.0.0"
   }
 }


### PR DESCRIPTION
according to the upgrade instructions one must use `@inertiajs/inertia` to `^0.6.0` yet the peer dependency refers still on `^0.5.0`