### PR TITLE
Fix inertia-link crashing when self-closing

### DIFF
--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -75,7 +75,7 @@ export default {
             })
           }
         },
-      }, slots.default())
+      }, slots && slots.default() || '')
     }
   },
 }

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -75,7 +75,7 @@ export default {
             })
           }
         },
-      }, slots && slots.default() || '')
+      }, slots)
     }
   },
 }


### PR DESCRIPTION
This PR fixes an error triggered when you create self-closing `inertia-link` component, which sets `slots` to null:

```vue
<inertia-link class="absolute inset-0 z-10" :href="route('dashboard.edit', dashboard).url()" />
```