### PR TITLE
Prevent finish event from firing twice

### DIFF
--- a/packages/inertia/src/events.js
+++ b/packages/inertia/src/events.js
@@ -12,8 +12,8 @@ export function fireErrorEvent(error) {
   return fireEvent('error', { cancelable: true, detail: { error } })
 }
 
-export function fireFinishEvent(visit, { completed = false, cancelled = false, interrupted = false }) {
-  return fireEvent('finish', { detail: { visit: { ...visit, completed, cancelled, interrupted } } } )
+export function fireFinishEvent(visit) {
+  return fireEvent('finish', { detail: { visit } } )
 }
 
 export function fireInvalidEvent(response) {


### PR DESCRIPTION
Fixes #305

This PR fixes a regression that happened with the recent "finish" event changes. While the "start" and "finish" events are firing in the right sequence, the "finish" event (and callback) is now firing twice. This is because we're not checking to see if the last visit has completed before cancelling it.