### PR TITLE
Add links to be read out by npm

### DIFF
--- a/packages/inertia-react/package.json
+++ b/packages/inertia-react/package.json
@@ -7,6 +7,15 @@
     "Jonathan Reinink <jonathan@reinink.ca>",
     "Sebastian De Deyne <sebastiandedeyne@gmail.com>"
   ],
+  "homepage": "https://inertiajs.com/",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/inertiajs/inertia.git",
+      "directory": "packages/inertia-react"
+  },
+  "bugs": {
+      "url": "https://github.com/inertiajs/inertia/issues"
+  },
   "source": "src/index.js",
   "main": "dist/index.js",
   "unpkg": "dist/index.umd.js",

--- a/packages/inertia-svelte/package.json
+++ b/packages/inertia-svelte/package.json
@@ -7,6 +7,15 @@
     "Jonathan Reinink <jonathan@reinink.ca>",
     "Pedro Borges <oi@pedroborg.es>"
   ],
+  "homepage": "https://inertiajs.com/",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/inertiajs/inertia.git",
+      "directory": "packages/svelte"
+  },
+  "bugs": {
+      "url": "https://github.com/inertiajs/inertia/issues"
+  },
   "keywords": [
     "svelte"
   ],

--- a/packages/inertia-vue/package.json
+++ b/packages/inertia-vue/package.json
@@ -7,6 +7,15 @@
     "Jonathan Reinink <jonathan@reinink.ca>",
     "Sebastian De Deyne <sebastiandedeyne@gmail.com>"
   ],
+  "homepage": "https://inertiajs.com/",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/inertiajs/inertia.git",
+      "directory": "packages/inertia-vue"
+  },
+  "bugs": {
+      "url": "https://github.com/inertiajs/inertia/issues"
+  },
   "source": "src/index.js",
   "main": "dist/index.js",
   "unpkg": "dist/index.umd.js",

--- a/packages/inertia-vue3/package.json
+++ b/packages/inertia-vue3/package.json
@@ -6,6 +6,15 @@
   "contributors": [
     "Jonathan Reinink <jonathan@reinink.ca>"
   ],
+  "homepage": "https://inertiajs.com/",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/inertiajs/inertia.git",
+      "directory": "packages/inertia-vue3"
+  },
+  "bugs": {
+      "url": "https://github.com/inertiajs/inertia/issues"
+  },
   "source": "src/index.js",
   "main": "dist/index.js",
   "unpkg": "dist/index.umd.js",

--- a/packages/inertia/package.json
+++ b/packages/inertia/package.json
@@ -7,6 +7,15 @@
     "Jonathan Reinink <jonathan@reinink.ca>",
     "Sebastian De Deyne <sebastiandedeyne@gmail.com>"
   ],
+  "homepage": "https://inertiajs.com/",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/inertiajs/inertia.git",
+      "directory": "packages/inertia"
+  },
+  "bugs": {
+      "url": "https://github.com/inertiajs/inertia/issues"
+  },
   "source": "src/index.js",
   "main": "dist/index.js",
   "unpkg": "dist/index.umd.js",


### PR DESCRIPTION
This allows npm to display links like this:

![image](https://user-images.githubusercontent.com/12762044/98006043-11a13200-1df2-11eb-8e10-7c7da1fa02e8.png)


This is useful because on Google, results for some queries including `inertia` still show the npm page higher than the GitHub repo and homepage.