### PR TITLE
Add new "inline visits" feature

### DIFF
--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -4,8 +4,8 @@ import { computed, h, markRaw, ref } from 'vue'
 import { Inertia } from '@inertiajs/inertia'
 
 const component = ref(null)
+const inlineComponent = ref(null)
 const page = ref({})
-const inline = ref({})
 const key = ref(null)
 
 export default {
@@ -31,9 +31,9 @@ export default {
       transformProps,
       swapComponent: async (args) => {
         component.value = markRaw(args.component)
+        inlineComponent.value = args.inlineComponent ? markRaw(args.inlineComponent) : null
         page.value = args.page
-        key.value = (args.preserveState || args.inline) ? key.value : Date.now()
-        inline.value = args.inline ? { component: markRaw(args.inline.component), props: args.inline.props, url: args.inline.url } : null
+        key.value = args.preserveState ? key.value : Date.now()
       },
     })
 
@@ -56,13 +56,13 @@ export default {
 
           return [
             h(component.value.layout, () => child),
-            inline.value ? h(inline.value.component, inline.value.props) : null,
+            inlineComponent.value ? h(inlineComponent.value, page.value.inline.props) : null,
           ]
         }
 
         return [
           child,
-          inline.value ? h(inline.value.component, inline.value.props) : null,
+          inlineComponent.value ? h(inlineComponent.value, page.value.inline.props) : null,
         ]
       }
     }
@@ -73,7 +73,6 @@ export const plugin = {
   install(app) {
     Object.defineProperty(app.config.globalProperties, '$inertia', { get: () => Inertia })
     Object.defineProperty(app.config.globalProperties, '$page', { get: () => page.value })
-    Object.defineProperty(app.config.globalProperties, '$inline', { get: () => inline.value })
     app.mixin(remember)
     app.component('InertiaLink', link)
   },
@@ -85,6 +84,5 @@ export function usePage() {
     url: computed(() => page.value.url),
     component: computed(() => page.value.component),
     version: computed(() => page.value.version),
-    inline: computed(() => inline.value),
   }
 }

--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -5,7 +5,7 @@ import { Inertia } from '@inertiajs/inertia'
 
 const component = ref(null)
 const page = ref({})
-const partials = ref([])
+const partial = ref(null)
 const key = ref(null)
 
 export default {
@@ -33,7 +33,7 @@ export default {
         component.value = markRaw(args.component)
         page.value = args.page
         key.value = args.preserveState ? key.value : Date.now()
-        partials.value = args.partials.map(partial => h(markRaw(partial)))
+        partial.value = args.partial ? h(markRaw(args.partial.component), args.partial.props) : null
       },
     })
 
@@ -54,10 +54,10 @@ export default {
               .reduce((child, layout) => h(layout, [child]))
           }
 
-          return [h(component.value.layout, () => child), ...partials.value]
+          return [h(component.value.layout, () => child), partial.value]
         }
 
-        return [child, ...partials.value ]
+        return [child, partial.value]
       }
     }
   },

--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -7,6 +7,7 @@ const component = ref(null)
 const inlineComponent = ref(null)
 const page = ref({})
 const key = ref(null)
+const inlineKey = ref(null)
 
 export default {
   name: 'Inertia',
@@ -33,7 +34,8 @@ export default {
         component.value = markRaw(args.component)
         inlineComponent.value = args.inlineComponent ? markRaw(args.inlineComponent) : null
         page.value = args.page
-        key.value = args.preserveState ? key.value : Date.now()
+        key.value = (args.preserveState || args.inlineComponent) ? key.value : Date.now()
+        inlineKey.value = (args.preserveState && args.inlineComponent) ? inlineKey.value : Date.now()
       },
     })
 
@@ -56,13 +58,14 @@ export default {
 
           return [
             h(component.value.layout, () => child),
-            inlineComponent.value ? h(inlineComponent.value, page.value.inline.props) : null,
+            inlineComponent.value ? h(inlineComponent.value, { ...page.value.inline.props, key: inlineKey.value }) : null,
           ]
         }
 
+
         return [
           child,
-          inlineComponent.value ? h(inlineComponent.value, page.value.inline.props) : null,
+          inlineComponent.value ? h(inlineComponent.value, { ...page.value.inline.props, key: inlineKey.value }) : null,
         ]
       }
     }

--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -5,6 +5,7 @@ import { Inertia } from '@inertiajs/inertia'
 
 const component = ref(null)
 const page = ref({})
+const partials = ref([])
 const key = ref(null)
 
 export default {
@@ -32,6 +33,7 @@ export default {
         component.value = markRaw(args.component)
         page.value = args.page
         key.value = args.preserveState ? key.value : Date.now()
+        partials.value = args.partials.map(partial => h(markRaw(partial)))
       },
     })
 
@@ -52,13 +54,13 @@ export default {
               .reduce((child, layout) => h(layout, [child]))
           }
 
-          return h(component.value.layout, () => child)
+          return [h(component.value.layout, () => child), ...partials.value]
         }
 
-        return child
+        return [child, ...partials.value ]
       }
     }
-  }
+  },
 }
 
 export const plugin = {

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -23,6 +23,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    inline: {
+      type: Boolean,
+      default: false,
+    },
     preserveScroll: {
       type: Boolean,
       default: false,
@@ -61,6 +65,7 @@ export default {
               data: data,
               method: method,
               replace: props.replace,
+              inline: props.inline,
               preserveScroll: props.preserveScroll,
               preserveState: props.preserveState ?? (method !== 'get'),
               only: props.only,

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -231,36 +231,28 @@ export default {
           return Promise.reject({ response })
         }
 
-        return Promise.resolve(inline ? this.resolveComponent(response.data.component) : null).then(inlineComponent => {
-          let page = response.data
+        let page = response.data
 
-          if ((inlineComponent && inlineComponent.section === this.page.section) && (
-            inline === true ||
-            (inline === 'maintain' && this.page.inline) ||
-            (inline === 'same' && this.page.inline && this.page.inline.component === response.data.component)
-          )) {
-            page = this.page
-            page.inline = {
-              component: response.data.component,
-              props: response.data.props,
-              url: response.data.url,
-            }
+        if ((this.page.inline && this.page.inline.component === response.data.component) || inline === response.data.inlineable) {
+          page = this.page
+          page.inline = {
+            component: response.data.component,
+            props: response.data.props,
+            url: response.data.url,
           }
+        }
 
-          if (only.length && page.component === this.page.component) {
-            page.props = { ...this.page.props, ...page.props }
-          }
+        if (only.length && page.component === this.page.component) {
+          page.props = { ...this.page.props, ...page.props }
+        }
 
-          const responseUrl = hrefToUrl(page.url)
-          if (url.hash && !responseUrl.hash && urlWithoutHash(url).href === responseUrl.href) {
-            responseUrl.hash = url.hash
-            page.url = responseUrl.href
-          }
+        const responseUrl = hrefToUrl(page.url)
+        if (url.hash && !responseUrl.hash && urlWithoutHash(url).href === responseUrl.href) {
+          responseUrl.hash = url.hash
+          page.url = responseUrl.href
+        }
 
-          return this.setPage(page, { visitId, replace, preserveScroll, preserveState })
-        })
-
-
+        return this.setPage(page, { visitId, replace, preserveScroll, preserveState })
       }).then(() => {
         fireSuccessEvent(this.page)
         return onSuccess(this.page)
@@ -309,8 +301,8 @@ export default {
         page.section = component.section
         page.scrollRegions = page.scrollRegions || []
         page.rememberedState = page.rememberedState || {}
-        preserveState = (typeof preserveState === 'function' ? preserveState(page) : preserveState) || page.inline
-        preserveScroll = (typeof preserveScroll === 'function' ? preserveScroll(page) : preserveScroll) || page.inline
+        preserveState = (typeof preserveState === 'function' ? preserveState(page) : preserveState)
+        preserveScroll = (typeof preserveScroll === 'function' ? preserveScroll(page) : preserveScroll)
         replace = replace || hrefToUrl(page.inline ? page.inline.url : page.url).href === window.location.href
         replace ? this.replaceState(page) : this.pushState(page)
         const clone = JSON.parse(JSON.stringify(page))

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -76,8 +76,10 @@ export default {
   restoreScrollPositions() {
     if (this.page.scrollRegions) {
       this.scrollRegions().forEach((region, index) => {
-        region.scrollTop = this.page.scrollRegions[index].top
-        region.scrollLeft = this.page.scrollRegions[index].left
+        if (this.page.scrollRegions[index]) {
+          region.scrollTop = this.page.scrollRegions[index].top
+          region.scrollLeft = this.page.scrollRegions[index].left
+        }
       })
     }
   },

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -231,7 +231,7 @@ export default {
           return Promise.reject({ response })
         }
 
-        let page = null
+        let page = response.data
 
         if (inline === true ||
           (inline === 'maintain' && this.page.inline) ||
@@ -243,20 +243,19 @@ export default {
             props: response.data.props,
             url: response.data.url,
           }
-        } else {
-          page = response.data
         }
 
         if (only.length && page.component === this.page.component) {
           page.props = { ...this.page.props, ...page.props }
         }
+
         const responseUrl = hrefToUrl(page.url)
         if (url.hash && !responseUrl.hash && urlWithoutHash(url).href === responseUrl.href) {
           responseUrl.hash = url.hash
           page.url = responseUrl.href
         }
-        return this.setPage(page, { visitId, replace, preserveScroll, preserveState })
 
+        return this.setPage(page, { visitId, replace, preserveScroll, preserveState })
       }).then(() => {
         fireSuccessEvent(this.page)
         return onSuccess(this.page)

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -212,6 +212,7 @@ export default {
           Accept: 'text/html, application/xhtml+xml',
           'X-Requested-With': 'XMLHttpRequest',
           'X-Inertia': true,
+          ...(inline ? { 'X-Inertia-Inline': inline } : {}),
           ...(only.length ? {
             'X-Inertia-Partial-Component': this.page.component,
             'X-Inertia-Partial-Data': only.join(','),

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -301,8 +301,8 @@ export default {
       if (visitId === this.visitId) {
         page.scrollRegions = page.scrollRegions || []
         page.rememberedState = page.rememberedState || {}
-        preserveState = typeof preserveState === 'function' ? preserveState(page) : preserveState
-        preserveScroll = typeof preserveScroll === 'function' ? preserveScroll(page) : preserveScroll
+        preserveState = (typeof preserveState === 'function' ? preserveState(page) : preserveState) || page.inline
+        preserveScroll = (typeof preserveScroll === 'function' ? preserveScroll(page) : preserveScroll) || page.inline
         replace = replace || hrefToUrl(page.inline ? page.inline.url : page.url).href === window.location.href
         replace ? this.replaceState(page) : this.pushState(page)
         const clone = JSON.parse(JSON.stringify(page))

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -311,8 +311,7 @@ export default {
         const clone = JSON.parse(JSON.stringify(page))
         clone.props = this.transformProps(clone.props)
         Promise.resolve(page.inline ? this.resolveComponent(page.inline.component) : null).then(inlineComponent => {
-          const inline = inlineComponent ? { component: inlineComponent, props: page.inline.props, url: page.inline.url } : null
-          this.swapComponent({ component, page: clone, preserveState, inline }).then(() => {
+          this.swapComponent({ component, page: clone, preserveState, inlineComponent }).then(() => {
             if (!preserveScroll) {
               this.resetScrollPositions()
             }
@@ -343,8 +342,7 @@ export default {
         if (visitId === this.visitId) {
           this.page = page
           Promise.resolve(page.inline ? this.resolveComponent(page.inline.component) : null).then(inlineComponent => {
-            const inline = inlineComponent ? { component: inlineComponent, props: page.inline.props, url: page.inline.url } : null
-            this.swapComponent({ component, page, preserveState: false, inline: inline }).then(() => {
+            this.swapComponent({ component, page, preserveState: false, inlineComponent }).then(() => {
               this.restoreScrollPositions()
               fireNavigateEvent(page)
             })

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -232,8 +232,8 @@ export default {
         let page = null
 
         if (inline === true ||
-          (inline === 'if-inline' && this.page.inline) ||
-          (inline === 'if-inline-and-same-component' && this.page.inline && this.page.inline.component === response.data.component)
+          (inline === 'maintain' && this.page.inline) ||
+          (inline === 'same' && this.page.inline && this.page.inline.component === response.data.component)
         ) {
           page = this.page
           page.inline = {


### PR DESCRIPTION
This PR adds the ability to make "inline visits", which lets you add a second page component to the current page with its own props and URL. This second page component is rendered as a child of the existing page component, and can be positioned elsewhere on the page using portals.

- [x] Core
- [ ] React adapter
- [ ] Svelte adapter
- [ ] Vue 2 adapter
- [x] Vue 3 adapter


## How to use it

To make an inline visit, set the `inline` attribute on an Inertia link:

```vue
<inertia-link href="/users/create" inline>
```

You can also do this programmatically:

```js
Inertia.get('/users/create', {}, { inline: true })
```

You can access the inline page details via `$page.property (Vue) or `usePage().inline`.

The `inline` property accepts three possible values:

- `true`: Inline the response
- `maintain`: Inline if the current page is inlined
- `same`: Inline if the current page is inlined, and the component is the same


## Name

This feature is not properly named yet. Working name ideas (bold ones I like):

- **inline**
- partial
- insert
- append
- **stack**
- **nest**
- fragment
- sibling

## Brainstorming notes

1. If Inertia *partial visit*
    - Add the partial to the current page
2. Otherwise:
    - Prepare partial object (`component`, `props`, `url`), and flash it in the session
    - Redirect to `fallack` url
    - When sending response back to browser
        - use fallback page as the main page (`page`)
        - and use the partial as the partial (`page.partial`)
        - with the partial URL as the url (`page.partial.url)

```php
class UserController
{
    public function index()
    {
        return Inertia::render('Users/Index', [
            'users' => User::with('company')->get()->map(fn ($user) => [
                'id' => $user->id,
                'name' => $user->name,
                'company' => $user->company->name,
            ])
        ]);
    }

    public function create()
    {
        return Inertia::partial('Users/Create', [
            'companies' => Company::get(['id', 'name']),
        ])->fallback('/users');
    }
}
```