### PR TITLE
Fix type definition for usePage and add missing properties to Page

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -46,8 +46,8 @@ type InertiaLink = React.FunctionComponent<
 >
 
 export function usePage<
-  PageProps extends Inertia.PageProps = Inertia.PageProps
->(): PageProps
+  Page extends Inertia.Page = Inertia.Page
+>(): Page
 
 export function useRememberedState<RememberedState>(
   initialState: RememberedState,

--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -18,6 +18,10 @@ export interface Page<CustomPageProps extends PageProps = PageProps> {
   props: CustomPageProps
   url: string
   version: string | null
+  scrollRegions: { top: number, left: number }[]
+  rememberedState: {
+    [key: string]: any
+  }
 }
 
 type VisitOptions = {


### PR DESCRIPTION
- Set the return type for `usePage` to `Inertia.Page` instead of `Inertia.PageProps`
- Add `scrollRegions` and `rememberedState` to `Page`

Resolves #321 

/cc @sebastiandedeyne 