### PR TITLE
Added missing 'before' event to InertiaEvent

### DIFF
--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -39,7 +39,7 @@ type VisitOptions = {
   onSuccess?: (page: Page) => void | Promise<any>
 }
 
-type InertiaEvent = 'start' | 'progress' | 'success' | 'invalid' | 'error' | 'finish' | 'navigate'
+type InertiaEvent = 'before' | 'start' | 'progress' | 'success' | 'invalid' | 'error' | 'finish' | 'navigate'
 
 interface Inertia {
   init: <


### PR DESCRIPTION
Fix for [issue: before event not included in InertiaEvent definition](https://github.com/inertiajs/inertia/issues/324)