### PR TITLE
Fix typings for preserveScroll and preserveState

### DIFF
--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -27,8 +27,8 @@ export interface Page<CustomPageProps extends PageProps = PageProps> {
 type VisitOptions = {
   method?: string
   replace?: boolean
-  preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
-  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
+  preserveScroll?: boolean | ((props: Page<Inertia.PageProps>) => boolean)
+  preserveState?: boolean | ((props: Page<Inertia.PageProps>) => boolean) | null
   only?: string[]
   headers?: object
   onCancelToken?: (cancelToken: CancelTokenSource) => void


### PR DESCRIPTION
According to these lines
https://github.com/inertiajs/inertia/blob/173b35933d883c5e1ef4beda482e200ad49b88c4/packages/inertia/src/inertia.js#L285-L286

and a quick check on my end using `preserveState: (pageProps) => console.log(pageProps);` which gives me the Page object and not the PageProps object:
![image](https://user-images.githubusercontent.com/12762044/99377459-84b4a900-28c6-11eb-843b-7f93b8a502f8.png)


The typings of `preserveScroll` and `preserveState` should be `Page<Inertia.PageProps>` instead of `Inertia.PageProps`.

This seems to be related to/have been "caused by" https://github.com/inertiajs/inertia/issues/321 and https://github.com/inertiajs/inertia/pull/323 (that PR is also correct and doesn't need to be reverted, as far as I can tell).