### PR TITLE
Fix remember with externally updated querystring

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -362,7 +362,7 @@ export default {
 
   remember(data, key = 'default') {
     this.replaceState({
-      ...this.page,
+      ...window.history.state,
       rememberedState: {
         ...this.page.rememberedState,
         [key]: data,


### PR DESCRIPTION
In our inertia-react application, we're using Axios to fetch new data when a filter in an index page changes. We also then update the querystring, so the URL to the filtered index page is shareable. We're storing all data using `useRememberedState()`, so when navigating to a detail page and pressing the back button, the index page hasn't changed from how it looked before (this works terrifically btw, including saving the scroll position in an infinite scroll container and everything).

After upgrading inertia from 0.4.1 to 0.6.x, the querystring is now updated by our application, only to revert to what it was before a second later. After some sleuthing, it looks like this update to the remember() function in inertia@0.4.2 is the culprit:

https://github.com/inertiajs/inertia/compare/v0.4.1...v0.4.2#diff-467a987931305e1cb6da2436149dad1d780e881e4df994731a88c53bbdf53b08R347-R354

The `remember` function is called by the `useEffect` hook in `useRememberedState` in `inertia-react` when I update my data:
https://github.com/inertiajs/inertia/blob/master/packages/inertia-react/src/useRememberedState.js#L11-L13

At this point, `this.page` does not yet include my change to the querystring, so my change gets overwritten.

I've changed it back to work like it did before, getting the state from `window.history.state` instead of the (untouchable by external changes) `this.page`. This seems to put everything back in working order, and remembered state still works properly on navigating through the state.

Please let me know if I overlooked anything with this change that could break another part of inertia.