### PR TITLE
Allow external link clicks with inertia-link

### DIFF
--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -39,6 +39,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    external: {
+      type: Boolean,
+      default: false,
+    }
   },
   render(h, { props, data, children }) {
     data.on = {
@@ -70,6 +74,10 @@ export default {
         ...data.on,
         click: event => {
           data.on.click(event)
+
+          if (external) {
+              window.location.href = url.href
+          }
 
           if (shouldIntercept(event)) {
             event.preventDefault()


### PR DESCRIPTION
This PR enables `inertia-link` to redirect to a non inertia page.

```html
<inertia-link href="/" external>External page</inertia-link>
```