### PR TITLE
Improve query string formatting

### DIFF
--- a/packages/inertia/src/url.js
+++ b/packages/inertia/src/url.js
@@ -7,7 +7,7 @@ export function hrefToUrl(href) {
 
 export function mergeDataIntoQueryString(method, url, data) {
   if (method === 'get' && Object.keys(data).length) {
-    url.search = qs.stringify(deepmerge(qs.parse(url.search, { ignoreQueryPrefix: true }), data), { encode: false })
+    url.search = qs.stringify(deepmerge(qs.parse(url.search, { ignoreQueryPrefix: true }), data), { encodeValuesOnly: true })
     data = {}
   }
   return [url, data]

--- a/packages/inertia/src/url.js
+++ b/packages/inertia/src/url.js
@@ -7,7 +7,12 @@ export function hrefToUrl(href) {
 
 export function mergeDataIntoQueryString(method, url, data) {
   if (method === 'get' && Object.keys(data).length) {
-    url.search = qs.stringify(deepmerge(qs.parse(url.search, { ignoreQueryPrefix: true }), data), { encodeValuesOnly: true })
+    url.search = qs.stringify(
+      deepmerge(qs.parse(url.search, { ignoreQueryPrefix: true }), data), {
+        encodeValuesOnly: true,
+        arrayFormat: 'brackets',
+      },
+    )
     data = {}
   }
   return [url, data]


### PR DESCRIPTION
This PR updates Inertia core to automatically encode query string values. This is important for situations where a query string value might include an unsafe character, such as an `&`. By using `encodeValuesOnly: true` instead of `encode: true`, the array format remains nicer looking.

I've also updated the array format to omit indices. So instead of `key[0]=value`, it's now `key[]=value`.

Consider a search for "jonathan & amy" with an array of statuses, the final query string will be:

```
/families?search=jonathan%20%26%20amy&statuses[]=member&statuses[]=guest
```

Instead of:

```
/families?search=jonathan%20&%20amy&statuses[0]=member&statuses[1]=guest
```

Eventually I'd like to actually expose some options for Inertia to give developers the choice on what array format to use (see #282).