### PR TITLE
Add App export to typescript declaration file to fix ts warning

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -58,4 +58,6 @@ export const InertiaLink: InertiaLink
 
 export const Link: InertiaLink
 
+export const App: App
+
 export const InertiaApp: App


### PR DESCRIPTION
Using App instead of InertiaApp causes typescript warning

```
import React from "react";
import { App } from "@inertiajs/inertia-react";
import { render } from "react-dom";
import { InertiaProgress } from "@inertiajs/progress";

InertiaProgress.init();

const el = document.getElementById("app");

render(
  <App
    initialPage={JSON.parse(el.dataset.page)}
    resolveComponent={(name) =>
      import(`./Pages/${name}`).then((module) => module.default)
    }
  />,
  el
);
```
![image](https://user-images.githubusercontent.com/11737104/101195418-96999880-3689-11eb-9fe3-2717c1c27c1e.png)
