### PR TITLE
Transfrom props when handling popstate events

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -337,6 +337,7 @@ export default {
   handlePopstateEvent(event) {
     if (event.state !== null) {
       const page = event.state
+      page.props = this.transformProps(page.props)
       let visitId = this.createVisitId()
       return Promise.resolve(this.resolveComponent(page.component)).then(component => {
         if (visitId === this.visitId) {


### PR DESCRIPTION
The page is stored in the history state before transforming props. History state is serialized, so transforming it beforehand is not possible without losing information. Instead it needs to be transformed again after retrieval.

Fixes #343