### PR TITLE
Add support for delete body data

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -364,8 +364,8 @@ export default {
     return this.visit(url, { preserveState: true, ...options, method: 'patch', data })
   },
 
-  delete(url, options = {}) {
-    return this.visit(url, { preserveState: true, ...options, method: 'delete' })
+  delete(url, data = {}, options = {}) {
+    return this.visit(url, { preserveState: true, ...options, method: 'delete', data })
   },
 
   remember(data, key = 'default') {


### PR DESCRIPTION
While not technically part of the HTTP spec, browsers do support body data for `DELETE` requests. This PR adds the option to include data when making an `Inertia.delete()` request. Example use case:

```js
Inertia.delete('/other-sessions', {
  password: this.form.pasword, // password required to delete other sessions
})
```

This fixes hacky workaround, such as [this one](https://github.com/laravel/jetstream/blob/c856ef6c3012a34e41b66e1cf3a7a48ac0b80c26/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue#L116) in Jetstream.

This is a breaking change, as it changes the `Inertia.delete` method signature:

```js
// Before
Inertia.delete(url, options)

// After
Inertia.delete(url, data, options)
```