### PR TITLE
Add error bag support

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -174,6 +174,7 @@ export default {
     preserveState = false,
     only = [],
     headers = {},
+    errorBag = null,
     onCancelToken = () => ({}),
     onBefore = () => ({}),
     onStart = () => ({}),
@@ -185,7 +186,7 @@ export default {
   } = {}) {
     method = method.toLowerCase();
     [url, data] = mergeDataIntoQueryString(method, hrefToUrl(url), data)
-    const visit = { url, method, data, replace, preserveScroll, preserveState, only, headers, onCancelToken, onBefore, onStart, onProgress, onFinish, onCancel, onSuccess, onError }
+    const visit = { url, method, data, replace, preserveScroll, preserveState, only, headers, errorBag, onCancelToken, onBefore, onStart, onProgress, onFinish, onCancel, onSuccess, onError }
 
     if (onBefore(visit) === false || !fireBeforeEvent(visit)) {
       return
@@ -218,6 +219,7 @@ export default {
             'X-Inertia-Partial-Component': this.page.component,
             'X-Inertia-Partial-Data': only.join(','),
           } : {}),
+          ...(errorBag ? { 'X-Inertia-Error-Bag': errorBag } : {}),
           ...(this.page.version ? { 'X-Inertia-Version': this.page.version } : {}),
         },
         onUploadProgress: progress => {
@@ -241,8 +243,8 @@ export default {
       }).then(() => {
         const errors = this.resolveErrors(this.page)
         if (Object.keys(errors).length > 0) {
-          fireErrorEvent(errors)
-          return onError(errors)
+          fireErrorEvent(errors[errorBag] || errors)
+          return onError(errors[errorBag] || errors)
         }
         fireSuccessEvent(this.page)
         return onSuccess(this.page)


### PR DESCRIPTION
This PR adds first-class support for error bags via a new `X-Inertia-Error-Bag` header. This header instructs the server-side adapters to scope the errors within the error bag key provided. Meaning, the server-side adapters will have to be updated to support this feature.

## Example

```js
this.$inertia.post(`/users/${user.id}`, this.form, {
  errorBag: 'editUser',
})
```

Now, any validation errors returned from the server for this request will be scoped to `$page.props.errors.editUser`.

## Callback and error event

Note, however, that the `onError` callback and `error` event will NOT be scoped. They will simply contain the errors from the error bag.