### PR TITLE
Add Inertia Form to Vue 2 adapter

### DIFF
--- a/packages/inertia-vue/src/app.js
+++ b/packages/inertia-vue/src/app.js
@@ -1,5 +1,5 @@
-import link from './link'
 import form from './form'
+import link from './link'
 import remember from './remember'
 import { Inertia } from '@inertiajs/inertia'
 

--- a/packages/inertia-vue/src/app.js
+++ b/packages/inertia-vue/src/app.js
@@ -1,4 +1,5 @@
 import link from './link'
+import form from './form'
 import remember from './remember'
 import { Inertia } from '@inertiajs/inertia'
 
@@ -78,6 +79,7 @@ export default {
 export const plugin = {
   install(Vue) {
     Object.defineProperty(Vue.prototype, '$inertia', { get: () => Inertia })
+    Object.defineProperty(Vue.prototype.$inertia, 'form', { get: () => form })
     Object.defineProperty(Vue.prototype, '$page', { get: () => app.page })
     Vue.mixin(remember)
     Vue.component('InertiaLink', link)

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -77,9 +77,6 @@ export default data => {
 
       return this
     },
-    hasErrors() {
-      return Object.keys(form.errors).length > 0
-    },
   }
 
   return new Proxy(form, {

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -66,7 +66,13 @@ export default function(data) {
             return options.onStart(visit)
           }
         },
-        onProgress: progress => (this.progress = progress),
+        onProgress: event => {
+          this.progress = event
+
+          if (options.onProgress) {
+            return options.onProgress(event)
+          }
+        },
         onSuccess: page => {
           this.clearErrors()
 

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -1,10 +1,10 @@
 import Vue from 'vue'
 import { Inertia } from '@inertiajs/inertia'
 
-export default initialData => {
+export default data => {
   const form = {
-    data: { ... initialData },
-    defaults: { ... initialData },
+    data: { ... data },
+    defaults: { ... data },
     errors: {},
     processing: false,
     submit(method, url, options) {

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -11,7 +11,7 @@ export default initialData => {
       url = url || Inertia.page.url
       options = options || {}
 
-      const requestOptions = {
+      Inertia[method](url, form.data, {
         ... options,
         onStart: visit => {
           form.processing = true
@@ -41,9 +41,7 @@ export default initialData => {
             return options.onSuccess(page)
           }
         },
-      }
-
-      Inertia[method](url, form.data, requestOptions)
+      })
     },
     post(url, options) {
       form.submit('post', url, options)

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -19,18 +19,16 @@ export default function(data) {
         }, {})
     },
     reset(fields) {
-      const args = Array.isArray(fields)
-        ? fields
-        : Object.values(arguments)
+      fields = Array.isArray(fields) ? fields : Object.values(arguments)
 
-      if (args.length === 0) {
+      if (fields.length === 0) {
         Object.assign(this, defaults)
       } else {
         Object.assign(
           this,
           Object
             .keys(defaults)
-            .filter(key => args.includes(key))
+            .filter(key => fields.includes(key))
             .reduce((carry, key) => {
               carry[key] = defaults[key]
               return carry

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -40,7 +40,8 @@ export default function(data) {
       return this.clearErrors()
     },
     clearErrors() {
-      this.errors = {}
+      Vue.set(this, 'errors', {})
+      this.hasErrors = false
 
       return this
     },
@@ -80,8 +81,7 @@ export default function(data) {
           }
         },
         onSuccess: page => {
-          Vue.set(this, 'errors', {})
-          this.hasErrors = false
+          this.clearErrors()
 
           if (options.onSuccess) {
             return options.onSuccess(page)

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -63,12 +63,15 @@ export default data => {
       if (args.length === 0) {
         form.data = { ... form.defaults }
       } else {
-        Object.assign(form.data, Object.keys(form.defaults)
-          .filter(key => args.includes(key))
-          .reduce((carry, key) => {
-            carry[key] = form.defaults[key]
-            return carry
-          }, {})
+        Object.assign(
+          form.data,
+          Object
+            .keys(form.defaults)
+            .filter(key => args.includes(key))
+            .reduce((carry, key) => {
+              carry[key] = form.defaults[key]
+              return carry
+            }, {}),
         )
       }
 

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -66,12 +66,12 @@ export default function(data) {
             return options.onStart(visit)
           }
         },
-        onFinish: () => {
-          this.processing = false
-          this.progress = null
+        onProgress: progress => (this.progress = progress),
+        onSuccess: page => {
+          this.clearErrors()
 
-          if (options.onFinish) {
-            return options.onFinish()
+          if (options.onSuccess) {
+            return options.onSuccess(page)
           }
         },
         onError: errors => {
@@ -82,12 +82,12 @@ export default function(data) {
             return options.onError(errors)
           }
         },
-        onProgress: progress => (this.progress = progress),
-        onSuccess: page => {
-          this.clearErrors()
+        onFinish: () => {
+          this.processing = false
+          this.progress = null
 
-          if (options.onSuccess) {
-            return options.onSuccess(page)
+          if (options.onFinish) {
+            return options.onFinish()
           }
         },
       })

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -9,6 +9,7 @@ export default function(data) {
     errors: {},
     hasErrors: false,
     processing: false,
+    progress: null,
     data() {
       return Object
         .keys(data)
@@ -67,6 +68,7 @@ export default function(data) {
         },
         onFinish: () => {
           this.processing = false
+          this.progress = null
 
           if (options.onFinish) {
             return options.onFinish()
@@ -80,6 +82,7 @@ export default function(data) {
             return options.onError(errors)
           }
         },
+        onProgress: progress => (this.progress = progress),
         onSuccess: page => {
           this.clearErrors()
 

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -1,0 +1,100 @@
+import Vue from 'vue'
+import { Inertia } from '@inertiajs/inertia'
+
+export default initialData => {
+  const form = {
+    data: { ... initialData },
+    defaults: { ... initialData },
+    errors: {},
+    processing: false,
+    submit(method, url, options) {
+      url = url || Inertia.page.url
+      options = options || {}
+
+      const requestOptions = {
+        ... options,
+        onStart: visit => {
+          form.processing = true
+
+          if (options.onStart) {
+            return options.onStart(visit)
+          }
+        },
+        onFinish: () => {
+          form.processing = false
+
+          if (options.onFinish) {
+            return options.onFinish()
+          }
+        },
+        onError: errors => {
+          Vue.set(form, 'errors', errors)
+
+          if (options.onError) {
+            return options.onError(errors)
+          }
+        },
+        onSuccess: page => {
+          Vue.set(form, 'errors', {})
+
+          if (options.onSuccess) {
+            return options.onSuccess(page)
+          }
+        },
+      }
+
+      Inertia[method](url, form.data, requestOptions)
+    },
+    post(url, options) {
+      form.submit('post', url, options)
+    },
+    put(url, options) {
+      form.submit('put', url, options)
+    },
+    patch(url, options) {
+      form.submit('patch', url, options)
+    },
+    delete(url, options) {
+      form.submit('delete', url, options)
+    },
+    reset(fields) {
+      const args = Array.isArray(fields)
+        ? fields
+        : Object.values(arguments)
+
+      if (args.length === 0) {
+        form.data = { ... form.defaults }
+      } else {
+        Object.assign(form.data, Object.keys(form.defaults)
+          .filter(key => args.includes(key))
+          .reduce((carry, key) => {
+            carry[key] = form.defaults[key]
+            return carry
+          }, {}))
+      }
+
+      return this
+    },
+    hasErrors() {
+      return Object.keys(form.errors).length > 0
+    },
+  }
+
+  return new Proxy(form, {
+    has(obj, prop) {
+      return Object.keys(form.data).includes(prop) || Object.keys(form).includes(prop)
+    },
+    get(obj, prop) {
+      return form.data[prop] || form[prop]
+    },
+    set(obj, prop, value){
+      if (Object.keys(form).includes(prop)) {
+        throw new Error(`Field name [${prop}] cannot be used within an Inertia Form, as it is reserved keyword.`)
+      }
+
+      form.data[prop] = value
+
+      return true
+    },
+  })
+}

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -68,7 +68,8 @@ export default data => {
           .reduce((carry, key) => {
             carry[key] = form.defaults[key]
             return carry
-          }, {}))
+          }, {})
+        )
       }
 
       return this

--- a/packages/inertia-vue/src/remember.js
+++ b/packages/inertia-vue/src/remember.js
@@ -25,14 +25,21 @@ export default {
     const restored = Inertia.restore(stateKey)
 
     this.$options.remember.data.forEach(key => {
-      if (restored !== undefined && restored[key] !== undefined) {
-        this[key] = restored[key]
+      if (this[key] !== undefined && restored !== undefined && restored[key] !== undefined) {
+        typeof this[key].serialize === 'function' && typeof this[key].unserialize === 'function'
+          ? this[key].unserialize(restored[key])
+          : (this[key] = restored[key])
       }
 
       this.$watch(key, () => {
         Inertia.remember(
-          this.$options.remember.data.reduce((data, key) => ({ ...data, [key]: this[key] }), {}),
-          stateKey
+          this.$options.remember.data.reduce((carry, key) => ({
+            ...carry,
+            [key]: typeof this[key].serialize === 'function' && typeof this[key].unserialize === 'function'
+              ? this[key].serialize()
+              : this[key],
+          }), {}),
+          stateKey,
         )
       }, { immediate: true, deep: true })
     })


### PR DESCRIPTION
This PR brings a first-class form helper to InertiaJS, as part of the Inertia Plugin (`this.$inertia.form`). The goal here is to integrate Jetstream's form helper and to keep the signature as similar as possible to make migration easy, while also improving the developer experience at the same time.

As an example, let's imagine we're building an Inertia page where you can edit the user's details using an Inertia form. 
If you've used Inertia with Laravel Jetstream before, this will probably look very familiar:
```html
<template>
  ...
  <input v-model="form.email" type="text" placeholder="foo@example.com" />
  <input v-model="form.password" type="password" placeholder="Password" />
  ...
</template>

<script>
props: {
  email: String, // The user's existing email, passed as an Inertia prop
},
data: () => {
  return {
    form: this.$inertia.form({
      email: this.email, // Assigning the form's default values
      password: ''
    })
  }
),
methods: {
  submit() {
    this.form.post(this.$inertia.page.url)
  }
}
</script>
```

This by itself will create a POST request to the current page, submitting the form itself. 

## Resetting fields (to their initial values)

Now, let's imagine a requirement to enter the user's current `password` as an extra layer of validation before changing the user details. In normal situations, a successful update would send you back to the same page, clearing out the `password` field, but this wouldn't happen when an invalid password is given and validation errors are displayed, meaning we have to manually reset the password field somehow. 

With the power of events and the Inertia form, this task becomes very simple:

```js
submit() {
  this.form.post(this.$inertia.page.url, {
    onError() {
      this.form.reset('password')
    }
  })
}
```

The above ensures that only the `password` field gets reset back to it's initial value, as define in when the form was initialized (in the `data` section of the page component). Perhaps the `password` field isn't the best of examples here, because it's default value is an empty string instead of an actual starting value, but you get the idea.

#### Usage
- `form.reset()`: Resets the entire form back to it's initial values
- `form.reset('foo')` Only resets the 'foo' field back to it's initial value
- `form.reset(['foo', 'bar'])`: Resets only the 'foo' and 'bar' fields back to their initial values
- `form.reset('foo', 'bar')`: Same as array-based entry, but using a fluent list of arguments.

## Errors

Form errors work very similar to the page-wide `errors` prop, but are scoped to the form itself, meaning they'll only show up or get updated when you've submitted that specific form. Usage is as you'd expect:

```html
<template>
  ...
  <input v-model="form.email" type="text" placeholder="foo@example.com" id="email" />
  <label v-if=form.errors.email for="email">{{ form.errors.email }}</label>
  ...
</template>
```

## Processing state
If you want to display a custom loading indicator while the form is being submitted, this is also very easy to do, because each Inertia form instance also contains a `processing` prop that will be automatically updated as the request gets processed:

```html
<span v-if="form.processing">Please wait.. the form is being submitted.</span>
```

## Methods

So far, we've only used the `post` method in our example, but other methods are also available:

- `form.post()`
- `form.put()`
- `form.patch()`
- `form.delete()`

Lastly, something that is nice to know, is that if you don't provide any arguments (like in the signatures listed here), the form will submit the form using the requested method toward the current page (`$inertia.page.url`) with the default Inertia options for that request method.. 