### PR TITLE
Add Vue 3 form helper

### DIFF
--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -1,3 +1,4 @@
+import form from './form'
 import link from './link'
 import remember from './remember'
 import { computed, h, markRaw, ref } from 'vue'
@@ -68,6 +69,7 @@ export default {
 
 export const plugin = {
   install(app) {
+    Inertia.form = form
     Object.defineProperty(app.config.globalProperties, '$inertia', { get: () => Inertia })
     Object.defineProperty(app.config.globalProperties, '$page', { get: () => page.value })
     app.mixin(remember)

--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -85,3 +85,7 @@ export function usePage() {
     version: computed(() => page.value.version),
   }
 }
+
+export function useForm(data) {
+  return ref(form(data))
+}

--- a/packages/inertia-vue3/src/form.js
+++ b/packages/inertia-vue3/src/form.js
@@ -1,0 +1,109 @@
+import { Inertia } from '@inertiajs/inertia'
+
+export default function(data) {
+  const defaults = JSON.parse(JSON.stringify(data))
+
+  return {
+    ...defaults,
+    errors: {},
+    hasErrors: false,
+    processing: false,
+    progress: null,
+    data() {
+      return Object
+        .keys(data)
+        .reduce((carry, key) => {
+          carry[key] = this[key]
+          return carry
+        }, {})
+    },
+    reset(...fields) {
+      if (fields.length === 0) {
+        Object.assign(this, defaults)
+      } else {
+        Object.assign(
+          this,
+          Object
+            .keys(defaults)
+            .filter(key => fields.includes(key))
+            .reduce((carry, key) => {
+              carry[key] = defaults[key]
+              return carry
+            }, {}),
+        )
+      }
+
+      return this.clearErrors()
+    },
+    clearErrors() {
+      this.errors = {}
+      this.hasErrors = false
+
+      return this
+    },
+    serialize() {
+      return {
+        errors: this.errors,
+        ...this.data(),
+      }
+    },
+    unserialize(data) {
+      Object.assign(this, data)
+      this.hasErrors = Object.keys(this.errors).length > 0
+    },
+    submit(method, url, options = {}) {
+      Inertia[method](url, this.data(), {
+        ...options,
+        onStart: visit => {
+          this.processing = true
+
+          if (options.onStart) {
+            return options.onStart(visit)
+          }
+        },
+        onProgress: event => {
+          this.progress = event
+
+          if (options.onProgress) {
+            return options.onProgress(event)
+          }
+        },
+        onSuccess: page => {
+          this.clearErrors()
+
+          if (options.onSuccess) {
+            return options.onSuccess(page)
+          }
+        },
+        onError: errors => {
+          this.errors = errors
+          this.hasErrors = true
+
+          if (options.onError) {
+            return options.onError(errors)
+          }
+        },
+        onFinish: () => {
+          this.processing = false
+          this.progress = null
+
+          if (options.onFinish) {
+            return options.onFinish()
+          }
+        },
+      })
+    },
+    post(url, options) {
+      this.submit('post', url, options)
+    },
+    put(url, options) {
+      this.submit('put', url, options)
+    },
+    patch(url, options) {
+      this.submit('patch', url, options)
+    },
+    delete(url, options) {
+      this.submit('delete', url, options)
+    },
+  }
+}

--- a/packages/inertia-vue3/src/index.js
+++ b/packages/inertia-vue3/src/index.js
@@ -1,2 +1,2 @@
-export { default as App, default as app, plugin, usePage } from './app'
+export { default as App, default as app, plugin, useForm, usePage } from './app'
 export { default as Link, default as link } from './link'


### PR DESCRIPTION
This PR adds the same form helper that's available in the Vue 2 adapter to the Vue 3 adapter. It is literally identical. However, since we don't want this logic in core, we'll leave it duplicated for now.

Here's how to use it:

```vue
<template>
  <form @submit.prevent="form.post('/login')">
    <input type="text" v-model="form.email" :error="form.errors.email" />
    <input type="password" v-model="form.password" :error="form.errors.password"/>
    <button type="submit" :disabled="form.processing">Login</button>
  </form>
</template>

<script>
export default {
  data() {
    return {
      form: this.$inertia.form({
        email: null,
        password: null,
      }),
    }
  },
}
</script>
```

It also comes with a `form.reset()` helper for resetting the form back to its original state. Or, if you want to only reset specific fields, you can call `form.reset('fieldname', 'anotherfieldname')`.

Also, in the event that you're uploading files, the current progress event is available at `form.progress`, which makes it really easy to show upload progress in your views:

```vue
<progress :value="form.progress.percentage" max="100">{{ form.progress.percentage }}%</progress>
```

And, of course, you can also use the form helper with the new composition API:

```js
import { useForm } from '@inertiajs/inertia-vue3'

export default {
  setup () {
    const form = useForm({
      email: 'johndoe@example.com',
      password: 'secret',
      remember: null,
    })

    return { form }
  },
}
````