### PR TITLE
Form helper improvements

### DIFF
--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -1,6 +1,7 @@
 import { Inertia } from '@inertiajs/inertia'
 
 export default function(data) {
+  let transform = data => data
   const defaults = JSON.parse(JSON.stringify(data))
 
   return {
@@ -16,6 +17,10 @@ export default function(data) {
           carry[key] = this[key]
           return carry
         }, {})
+    },
+    transform(callback) {
+      transform = callback
+      return this
     },
     reset(...fields) {
       if (fields.length === 0) {
@@ -58,7 +63,7 @@ export default function(data) {
       this.hasErrors = Object.keys(this.errors).length > 0
     },
     submit(method, url, options = {}) {
-      Inertia[method](url, this.data(), {
+      Inertia[method](url, transform(this.data()), {
         ...options,
         onStart: visit => {
           this.processing = true

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -20,6 +20,7 @@ export default function(data) {
     },
     transform(callback) {
       transform = callback
+
       return this
     },
     reset(...fields) {

--- a/packages/inertia-vue3/src/form.js
+++ b/packages/inertia-vue3/src/form.js
@@ -1,6 +1,7 @@
 import { Inertia } from '@inertiajs/inertia'
 
 export default function(data) {
+  let transform = data => data
   const defaults = JSON.parse(JSON.stringify(data))
 
   return {
@@ -16,6 +17,10 @@ export default function(data) {
           carry[key] = this[key]
           return carry
         }, {})
+    },
+    transform(callback) {
+      transform = callback
+      return this
     },
     reset(...fields) {
       if (fields.length === 0) {
@@ -58,7 +63,7 @@ export default function(data) {
       this.hasErrors = Object.keys(this.errors).length > 0
     },
     submit(method, url, options = {}) {
-      Inertia[method](url, this.data(), {
+      Inertia[method](url, transform(this.data()), {
         ...options,
         onStart: visit => {
           this.processing = true

--- a/packages/inertia-vue3/src/form.js
+++ b/packages/inertia-vue3/src/form.js
@@ -20,6 +20,7 @@ export default function(data) {
     },
     transform(callback) {
       transform = callback
+
       return this
     },
     reset(...fields) {


### PR DESCRIPTION
This PR adds a new `transform()` function to form helper, which allows you to modify the data prior to it being sent to the server.

```js
export default {
  data() {
    return {
      form: this.$inertia.form({
        email: null,
        password: null,
        remember: false,
      }),
    }
  },
  methods: {
    submit() {
      this.form
        .transform(data => ({
          ...data,
          remember: data.remember ? 'on' : '',
        }))
        .post('/login')
    },
  },
}
```