### PR TITLE
Fix: Prevent errors from being cleared on form reset

### DIFF
--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -41,7 +41,7 @@ export default function(data = {}) {
         )
       }
 
-      return this.clearErrors(...fields)
+      return this
     },
     clearErrors(...fields) {
       this.errors = Object

--- a/packages/inertia-vue3/src/form.js
+++ b/packages/inertia-vue3/src/form.js
@@ -41,7 +41,7 @@ export default function(data = {}) {
         )
       }
 
-      return this.clearErrors(...fields)
+      return this
     },
     clearErrors(...fields) {
       this.errors = Object


### PR DESCRIPTION
This PR solves an issue with the form helper where errors are being cleared when you call `reset`, which causes issues. 

For example, imagine a situation where you have to confirm your password to continue (e.g. github's confirmation screen), and you enter your password incorrectly. What you'd want to happen here, is that the field gets cleared, and the error message is shown, however in the current implementation it looks as-if no error occurred and the field just got reset.