### PR TITLE
Rename React "useRememberedState" hook to "useRemember"

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -49,10 +49,10 @@ export function usePage<
   Page extends Inertia.Page = Inertia.Page
 >(): Page
 
-export function useRememberedState<RememberedState>(
-  initialState: RememberedState,
+export function useRemember<State>(
+  initialState: State,
   key?: string
-): [RememberedState, React.Dispatch<React.SetStateAction<RememberedState>>]
+): [State, React.Dispatch<React.SetStateAction<State>>]
 
 export const InertiaLink: InertiaLink
 

--- a/packages/inertia-react/src/index.js
+++ b/packages/inertia-react/src/index.js
@@ -1,4 +1,4 @@
 export { default as App, default as app, default as InertiaApp } from './App'
 export { default as Link, default as link, default as InertiaLink } from './Link'
 export { default as usePage } from './usePage'
-export { default as useRememberedState } from './useRememberedState'
+export { default as useRemember, useRememberedState } from './useRemember'

--- a/packages/inertia-react/src/useRemember.js
+++ b/packages/inertia-react/src/useRemember.js
@@ -1,7 +1,7 @@
 import { Inertia } from '@inertiajs/inertia'
 import { useEffect, useState } from 'react'
 
-export default function useRememberedState(initialState, key) {
+export default function useRemember(initialState, key) {
   const [state, setState] = useState(() => {
     const restored = Inertia.restore(key)
 
@@ -13,4 +13,9 @@ export default function useRememberedState(initialState, key) {
   }, [state, key])
 
   return [state, setState]
+}
+
+export function useRememberedState(initialState, key) {
+  console.warn('The "useRememberedState" hook has been deprecated and will be removed in a future release. Use "useRemember" instead.')
+  return useRemember(initialState, key)
 }


### PR DESCRIPTION
Closes #387

This PR renames the React `useRememberedState` hook to `useRemember`. The primary motivation here is to keep the adapters in sync as much as possible, as both the Vue adapters, as well as the Svelte adapter just use the word "remember" here. I also plan to add a `useRemember` hook to the Vue 3 adapter.

Note, this is not a breaking change, as `useRememberedState` still exists. However, if you use it, you'll get this deprecation warning:

> The "useRememberedState" hook has been deprecated and will be removed in a future release. Use "useRemember" instead.