### PR TITLE
Fix remember serialization in Vue 3 adapter

### DIFF
--- a/packages/inertia-vue3/src/form.js
+++ b/packages/inertia-vue3/src/form.js
@@ -58,7 +58,9 @@ export default function(data = {}) {
     },
     serialize() {
       return {
-        errors: this.errors,
+        errors: {
+          ...this.errors,
+        },
         ...this.data(),
       }
     },

--- a/packages/inertia-vue3/src/remember.js
+++ b/packages/inertia-vue3/src/remember.js
@@ -1,3 +1,4 @@
+import { toRaw } from 'vue'
 import { Inertia } from '@inertiajs/inertia'
 
 export default {
@@ -25,13 +26,20 @@ export default {
     const restored = Inertia.restore(stateKey)
 
     this.$options.remember.data.forEach(key => {
-      if (restored !== undefined && restored[key] !== undefined) {
-        this[key] = restored[key]
+      if (this[key] !== undefined && restored !== undefined && restored[key] !== undefined) {
+        typeof this[key].serialize === 'function' && typeof this[key].unserialize === 'function'
+          ? this[key].unserialize(restored[key])
+          : (this[key] = restored[key])
       }
 
       this.$watch(key, () => {
         Inertia.remember(
-          this.$options.remember.data.reduce((data, key) => ({ ...data, [key]: JSON.parse(JSON.stringify(this[key])) }), {}),
+          this.$options.remember.data.reduce((data, key) => ({
+            ...data,
+            [key]: typeof this[key].serialize === 'function' && typeof this[key].unserialize === 'function'
+              ? this[key].serialize()
+              : toRaw(this[key]),
+          }), {}),
           stateKey,
         )
       }, { immediate: true, deep: true })


### PR DESCRIPTION
This PR updates the Vue 3 adapter to implement the remember `serialize` and `unserialize` functionality, necessary for the remember behaviour to work with the form helper.

It also fixes an issue with the form helper `serialize` method, where the errors were not being serialized properly.

Also, previously we used `JSON.parse(JSON.stringify(value))` to convert a reactive property to a plain value. It now uses the `toRaw` helper in Vue 3 to do this.