### PR TITLE
Use remember history state when visiting the same component and preserving state

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -244,6 +244,9 @@ export default {
         if (only.length && response.data.component === this.page.component) {
           response.data.props = { ...this.page.props, ...response.data.props }
         }
+        if (preserveState && window.history.state?.rememberedState && response.data.component === this.page.component) {
+          response.data.rememberedState = window.history.state.rememberedState
+        }
         const responseUrl = hrefToUrl(response.data.url)
         if (url.hash && !responseUrl.hash && urlWithoutHash(url).href === responseUrl.href) {
           responseUrl.hash = url.hash


### PR DESCRIPTION
This PR fixes an edge case where the remember history state is lost when making a visit to the same page component and while preserving state.

For example, if you're submitting a form, and you end up back on the same page (ie. to show errors), we want to make sure that all the remember data is preserved. Previously, since a visit happened, it was lost.