### PR TITLE
Move "useForm" hook to form file in Vue 3 adapter

### DIFF
--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -85,7 +85,3 @@ export function usePage() {
     version: computed(() => page.value.version),
   }
 }
-
-export function useForm(data) {
-  return ref(form(data))
-}

--- a/packages/inertia-vue3/src/form.js
+++ b/packages/inertia-vue3/src/form.js
@@ -1,6 +1,7 @@
+import { ref } from 'vue'
 import { Inertia } from '@inertiajs/inertia'
 
-export default function(data = {}) {
+export default function form(data = {}) {
   const defaults = JSON.parse(JSON.stringify(data))
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
@@ -142,4 +143,8 @@ export default function(data = {}) {
       this.submit('delete', url, options)
     },
   }
+}
+
+export function useForm(data) {
+  return ref(form(data))
 }

--- a/packages/inertia-vue3/src/index.js
+++ b/packages/inertia-vue3/src/index.js
@@ -1,2 +1,3 @@
-export { default as App, default as app, plugin, useForm, usePage } from './app'
+export { default as App, default as app, plugin, usePage } from './app'
 export { default as Link, default as link } from './link'
+export { useForm } from './form'


### PR DESCRIPTION
This is simply a maintenance change. I think it makes more sense to put the `useForm` hook in `form.js`, along with the form helper, instead of putting this in `app.js`.