### PR TITLE
Update axios versions due to vulnerability

### DIFF
--- a/packages/inertia/package.json
+++ b/packages/inertia/package.json
@@ -28,7 +28,7 @@
     "watch": "microbundle watch --format cjs"
   },
   "dependencies": {
-    "axios": "^0.19.0 || ^0.20.0 || ^0.21.0",
+    "axios": "^0.19.0 || ^0.20.0 || ^0.21.1",
     "deepmerge": "^4.0.0",
     "qs": "^6.9.0"
   },


### PR DESCRIPTION
Apparently there is a [vulnerability](https://github.com/advisories/GHSA-4w2v-q235-vp99) in axios `0.21.0`. This PR updates the minimum version to the patch version, `0.21.1`.