### PR TITLE
Add "onBeforeRender" callback

### DIFF
--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -93,22 +93,21 @@ export default function(data = {}) {
             return options.onProgress(event)
           }
         },
+        onBeforeRender: page => {
+          this.errors = page.resolvedErrors
+          this.hasErrors = Object.keys(this.errors).length > 0
+          this.wasSuccessful = !this.hasErrors
+          this.recentlySuccessful = !this.hasErrors
+
+          if (options.onBeforeRender) {
+            return options.onBeforeRender(page)
+          }
+        },
         onSuccess: page => {
-          this.clearErrors()
-          this.wasSuccessful = true
-          this.recentlySuccessful = true
           recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
 
           if (options.onSuccess) {
             return options.onSuccess(page)
-          }
-        },
-        onError: errors => {
-          this.errors = errors
-          this.hasErrors = true
-
-          if (options.onError) {
-            return options.onError(errors)
           }
         },
         onFinish: () => {

--- a/packages/inertia-vue3/src/form.js
+++ b/packages/inertia-vue3/src/form.js
@@ -97,22 +97,21 @@ export default function form(data = {}) {
             return options.onProgress(event)
           }
         },
+        onBeforeRender: page => {
+          this.errors = page.resolvedErrors
+          this.hasErrors = Object.keys(this.errors).length > 0
+          this.wasSuccessful = !this.hasErrors
+          this.recentlySuccessful = !this.hasErrors
+
+          if (options.onBeforeRender) {
+            return options.onBeforeRender(page)
+          }
+        },
         onSuccess: page => {
-          this.clearErrors()
-          this.wasSuccessful = true
-          this.recentlySuccessful = true
           recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
 
           if (options.onSuccess) {
             return options.onSuccess(page)
-          }
-        },
-        onError: errors => {
-          this.errors = errors
-          this.hasErrors = true
-
-          if (options.onError) {
-            return options.onError(errors)
           }
         },
         onFinish: () => {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -183,6 +183,7 @@ export default {
     onProgress = () => ({}),
     onFinish = () => ({}),
     onCancel = () => ({}),
+    onBeforeRender = () => ({}),
     onSuccess = () => ({}),
     onError = () => ({}),
   } = {}) {
@@ -252,12 +253,13 @@ export default {
           responseUrl.hash = url.hash
           response.data.url = responseUrl.href
         }
+        response.data.resolvedErrors = ((errors) => errors[errorBag] || errors)(this.resolveErrors(response.data))
+        onBeforeRender(response.data)
         return this.setPage(response.data, { visitId, replace, preserveScroll, preserveState })
       }).then(() => {
-        const errors = this.resolveErrors(this.page)
-        if (Object.keys(errors).length > 0) {
-          fireErrorEvent(errors[errorBag] || errors)
-          return onError(errors[errorBag] || errors)
+        if (Object.keys(this.page.resolvedErrors).length > 0) {
+          fireErrorEvent(this.page.resolvedErrors)
+          return onError(this.page.resolvedErrors)
         }
         fireSuccessEvent(this.page)
         return onSuccess(this.page)


### PR DESCRIPTION
Resolves #389

This PR fixes a tricky, edge case issue with the form helpers, where the `preserveState` and `preserveScroll` callbacks are evaluated *before* the page is rendered, props are swapped, and the `onError` and `onSuccess` callbacks are evaluated. The result is that if you have local state (such as the form helper) that updates based on the `onError` and `onSuccess` callbacks, that state will not be updated on time for the `preserveState` and `preserveScroll` callbacks.

```js
preserveScroll: () => this.form.hasErrors, // will have value prior to submit, not after submit
preserveState: () => this.form.hasErrors, // will have value prior to submit, not after submit
```

One solution is to simply not use the local state in this situation, and just use the `page` object that's provided to these callbacks. For example:

```js
preserveScroll: (page) => Object.keys(page.props.errors).length > 0,
preserveState: (page) => Object.keys(page.props.errors).length > 0,
```

However, this isn't very intuitive. One option is to evaluate the `onError` and `onSuccess` callbacks *before* rendering the page component, but this seems like a really bad idea. These callbacks should fire after the fact.

To fix this properly, this PR adds a new `onBeforeRender()` callback, which is called after a response is finished, but before the new page is rendered. This allows you to update your local component state (ie. the form helper), so it's ready when the `preserveState` and `preserveScroll` callbacks are evaluated.

Also included in this PR is the changes needed to the form helpers to take advantage of this new callback.

My feeling is that the `onBeforeRender()` callback would remain "private API" for a while, at least until we feel comfortable documenting this as a feature.