### PR TITLE
Debounce remember method

### DIFF
--- a/packages/inertia/src/debounce.js
+++ b/packages/inertia/src/debounce.js
@@ -1,7 +1,11 @@
 export default function debounce(fn, delay) {
   let timeoutID = null
-  return function () {
+  let debouncedFn = function () {
     clearTimeout(timeoutID)
     timeoutID = setTimeout(() => fn.apply(this, arguments), delay)
   }
+  debouncedFn.cancel = function () {
+    clearTimeout(timeoutID)
+  }
+  return debouncedFn
 }

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -324,11 +324,15 @@ export default {
   },
 
   pushState(page) {
+    this.remember.cancel()
     this.page = page
     window.history.pushState(page, '', page.url)
   },
 
-  replaceState(page) {
+  replaceState(page, { cancelRemember = true } = {}) {
+    if (cancelRemember) {
+      this.remember.cancel()
+    }
     this.page = page
     window.history.replaceState(page, '', page.url)
   },
@@ -383,15 +387,15 @@ export default {
     return this.visit(url, { preserveState: true, ...options, method: 'delete' })
   },
 
-  remember(data, key = 'default') {
+  remember: debounce(function (data, key = 'default') {
     this.replaceState({
       ...this.page,
       rememberedState: {
         ...this.page.rememberedState,
         [key]: data,
       },
-    })
-  },
+    }, { cancelRemember: false })
+  }, 400),
 
   restore(key = 'default') {
     return window.history.state?.rememberedState?.[key]


### PR DESCRIPTION
Safari has this bonkers limitation of limiting `pushState` and `replaceState` calls to 100 times per 30 seconds. That's 3 calls per second. Clicking around an app won't cause this, but binding `Inertia.remember` to a textfield can. The problem here is that once Safari throws the error, all navigation breaks.

<img width="542" alt="Screenshot 2021-01-05 at 18 35 35" src="https://user-images.githubusercontent.com/1561079/103683376-698f1d00-4f8a-11eb-9e4b-f88a1b3810bb.png">

To work around this issue, we could add a debounce to the `remember` method at about 400ms. 333ms would work, but better to have some leeway.

Unable to test this atm, but this is my idea on how we can debounce the `remember` method without interfering with other `pushState`/`replaceState` calls.

I'm not sure about the code, the `debounce` placement is ugly, and I don't like the `cancelRemember` switch, but we can at least discuss and play around with this PR.