### PR TITLE
Fix 'remember' issue for null values

### DIFF
--- a/packages/inertia-vue/src/remember.js
+++ b/packages/inertia-vue/src/remember.js
@@ -26,7 +26,7 @@ export default {
 
     this.$options.remember.data.forEach(key => {
       if (this[key] !== undefined && restored !== undefined && restored[key] !== undefined) {
-        typeof this[key].serialize === 'function' && typeof this[key].unserialize === 'function'
+        this[key] !== null && typeof this[key].serialize === 'function' && typeof this[key].unserialize === 'function'
           ? this[key].unserialize(restored[key])
           : (this[key] = restored[key])
       }
@@ -35,7 +35,7 @@ export default {
         Inertia.remember(
           this.$options.remember.data.reduce((carry, key) => ({
             ...carry,
-            [key]: typeof this[key].serialize === 'function' && typeof this[key].unserialize === 'function'
+            [key]: this[key] !== null && typeof this[key].serialize === 'function' && typeof this[key].unserialize === 'function'
               ? this[key].serialize()
               : this[key],
           }), {}),


### PR DESCRIPTION
Hi there!

This PR attempts to address #417 by checking whether a value is `null` before the `typeof this[key].serialize === 'function'` check. After making this change, the remember functionality started working as expected again.

I imagine this change also needs to happen in Vue 3 adaptor but since I don't have a project setup with it atm, I don't feel comfortable changing without verifying it works first.

Let me know if there are any questions or if any changes are needed.