### PR TITLE
WIP Add build step for inertia-svelte

### DIFF
--- a/packages/inertia-svelte/package.json
+++ b/packages/inertia-svelte/package.json
@@ -28,6 +28,7 @@
     "@rollup/plugin-node-resolve": "^6.0.0",
     "eslint": "^7.0.0",
     "rollup": "^2.30.0",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-svelte": "^7.0.0",
     "svelte": "^3.31.2"
   },

--- a/packages/inertia-svelte/package.json
+++ b/packages/inertia-svelte/package.json
@@ -19,10 +19,21 @@
   "keywords": [
     "svelte"
   ],
-  "main": "src/index.js",
+  "module": "dist/index.mjs",
+  "main": "dist/index.js",
   "devDependencies": {
     "@inertiajs/inertia": "^0.8.0",
-    "eslint": "^7.0.0"
+    "@rollup/plugin-commonjs": "^17.0.0",
+    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-node-resolve": "^6.0.0",
+    "eslint": "^7.0.0",
+    "rollup": "^2.30.0",
+    "rollup-plugin-svelte": "^7.0.0",
+    "svelte": "^3.31.2"
+  },
+  "scripts": {
+    "build": "rollup -c",
+    "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
     "@inertiajs/inertia": "^0.8.0",

--- a/packages/inertia-svelte/rollup.config.js
+++ b/packages/inertia-svelte/rollup.config.js
@@ -1,8 +1,11 @@
 import json from '@rollup/plugin-json';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import svelte from 'rollup-plugin-svelte';
 import pkg from './package.json';
+
+const production = process.env.NODE_ENV !== 'development'
 
 export default [
   {
@@ -13,9 +16,17 @@ export default [
     ],
     plugins: [
       json(),
+      peerDepsExternal(),
+      svelte({
+        compilerOptions: {
+          dev: !production
+        }
+      }),
+      resolve({
+        browser: true,
+        dedupe: ['svelte/*']
+      }),
       commonjs(),
-      resolve({ browser: true }),
-      svelte()
     ]
   },
 ]

--- a/packages/inertia-svelte/rollup.config.js
+++ b/packages/inertia-svelte/rollup.config.js
@@ -1,0 +1,21 @@
+import json from '@rollup/plugin-json';
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import svelte from 'rollup-plugin-svelte';
+import pkg from './package.json';
+
+export default [
+  {
+    input: 'src/index.js',
+    output: [
+      { file: pkg.module, 'format': 'es' },
+      { file: pkg.main, 'format': 'umd', name: 'inertia-svelte' }
+    ],
+    plugins: [
+      json(),
+      commonjs(),
+      resolve({ browser: true }),
+      svelte()
+    ]
+  },
+]


### PR DESCRIPTION
This change represents a first step at adding a building step for the
inertia-svelte package, specifically hoping to address #394.

---

I've introduced rollup as that seems to be the common practice in the
svelte world and I believe I have a working build, but frankly I'm solidly
out of my depth here. One concerning aspect is that the built dist/index.js
is 128kB which makes me think I have some things misconfigured. Hoping to
poke a bit more and perhaps solicit some help from folks who know more than
I do, but wanted to share what I have now.
