### PR TITLE
Add array support for errors to form helpers

### DIFF
--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -44,12 +44,30 @@ export default function(data = {}) {
 
       return this
     },
+    getErrors(field) {
+      const errors = Object
+        .keys(this.errors)
+        .filter(key => key === field || key.startsWith(`${field}.`))
+        .reduce((carry, key) => {
+          if (Array.isArray(this.errors[key])) {
+            this.errors[key].forEach(message => {
+              carry.push(message)
+            })
+          } else {
+            carry.push(this.errors[key])
+          }
+
+          return carry
+        }, [])
+
+      return errors.length > 0 ? errors : null
+    },
     clearErrors(...fields) {
       this.errors = Object
         .keys(this.errors)
-        .reduce((carry, field) => ({
+        .reduce((carry, key) => ({
           ...carry,
-          ...(fields.length > 0 && !fields.includes(field) ? { [field] : this.errors[field] } : {}),
+          ...(fields.length > 0 && !fields.some(field => key === field || key.startsWith(`${field}.`)) ? { [key]: this.errors[key] } : {}),
         }), {})
 
       this.hasErrors = Object.keys(this.errors).length > 0

--- a/packages/inertia-vue3/src/form.js
+++ b/packages/inertia-vue3/src/form.js
@@ -45,12 +45,30 @@ export default function form(data = {}) {
 
       return this
     },
+    getErrors(field) {
+      const errors = Object
+        .keys(this.errors)
+        .filter(key => key === field || key.startsWith(`${field}.`))
+        .reduce((carry, key) => {
+          if (Array.isArray(this.errors[key])) {
+            this.errors[key].forEach(message => {
+              carry.push(message)
+            })
+          } else {
+            carry.push(this.errors[key])
+          }
+
+          return carry
+        }, [])
+
+      return errors.length > 0 ? errors : null
+    },
     clearErrors(...fields) {
       this.errors = Object
         .keys(this.errors)
-        .reduce((carry, field) => ({
+        .reduce((carry, key) => ({
           ...carry,
-          ...(fields.length > 0 && !fields.includes(field) ? { [field] : this.errors[field] } : {}),
+          ...(fields.length > 0 && !fields.some(field => key === field || key.startsWith(`${field}.`)) ? { [key]: this.errors[key] } : {}),
         }), {})
 
       this.hasErrors = Object.keys(this.errors).length > 0


### PR DESCRIPTION
Resolves #437

This PR adds support for array based (dot.noted) error messages to the form helpers. It also adds support for multiple error messages per field and clearing all nested errors.

When using Laravel, you validate an array like this

```php
$request->validate([
  'field' => 'required|array|min:3',
  'field.*.value' => 'required',
]);

```

The form.errors object is populated as follows

```json
{
  "field": "The field must have at least 3 items.",
  "field.0.value": "The field.0.value field is required.",
  "field.1.value": "The field.1.value field is required."
}
```

### getErrors('field')

The introduced `getErrors('field')` will return an array of error messages or `null` if there are no errors. 

```js
[
  "The field must have at least 3 items.",
  "The field.0.value field is required.",
  "The field.1.value field is required."
]
```

You can use `v-if` (or `v-show`) and `v-for`.

```html
<div v-if="form.getErrors('field')">
    <p v-for="(message, index) in form.getErrors('field')" :key="index" v-text="message" />
</div>
```

It's totally optional. You still can access `form.errors.field` directly. No breaking changes.

If you want to have an universal approach to always receive error messages as an array, you may want it use also for non-array values. 

Even multiple error message per field are supported, e.g. if you override or do not use the `resolveValidationErrors()` in the Laravel adapter to not only return the first error message via `$errors[0]`, you will receive receive a response like this:

```json
{
  "field": [
    "The field must be 6 digits.",
    "The selected field is invalid."
  ]
}
```

`getErrors('field')` will return:

```js
[
  "The field must be 6 digits.",
  "The selected field is invalid."
]
```

### clearErrors('field')

The `clearErrors()` now also clears related error messages, e.g. `clearErrors('field')` clears `field`, `field.0.value`, `field.1.value` etc.

It still works for non-array fields, also no breaking change here.

