### PR TITLE
Add GET support to form helper

### DIFF
--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -127,6 +127,9 @@ export default function(data = {}) {
         Inertia[method](url, data, _options)
       }
     },
+    get(url, options) {
+      this.submit('get', url, options)
+    },
     post(url, options) {
       this.submit('post', url, options)
     },

--- a/packages/inertia-vue3/src/form.js
+++ b/packages/inertia-vue3/src/form.js
@@ -131,6 +131,9 @@ export default function form(data = {}) {
         Inertia[method](url, data, _options)
       }
     },
+    get(url, options) {
+      this.submit('get', url, options)
+    },
     post(url, options) {
       this.submit('post', url, options)
     },


### PR DESCRIPTION
Currently you cannot submit a form via `GET` using the form helper, even though this is a totally valid thing to do. This adds support for that.

```js
this.form.get('/users')
```