### PR TITLE
Deep clone form defaults

### DIFF
--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -1,7 +1,13 @@
 import { Inertia } from '@inertiajs/inertia'
+import { cloneDeep } from './objects'
 
 export default function(data = {}) {
-  const defaults = JSON.parse(JSON.stringify(data))
+  const defaults = Object.keys(data).reduce((carry, key) => {
+    carry[key] = cloneDeep(data[key])
+
+    return carry
+  }, {})
+
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
 

--- a/packages/inertia-vue/src/objects.js
+++ b/packages/inertia-vue/src/objects.js
@@ -1,0 +1,21 @@
+export function cloneDeep(object) {
+  const type = getType(object)
+
+  if (type === 'array') {
+    return object.map(function (item) {
+      return cloneDeep(item)
+    })
+  } else if (type === 'object') {
+    return Object.keys(object).reduce((carry, key) => {
+      carry[key] = cloneDeep(object[key])
+
+      return carry
+    }, {})
+  } else {
+    return object
+  }
+}
+
+export function getType(object) {
+  return Object.prototype.toString.call(object).slice(8, -1).toLowerCase()
+}

--- a/packages/inertia-vue3/src/form.js
+++ b/packages/inertia-vue3/src/form.js
@@ -1,8 +1,14 @@
 import { ref } from 'vue'
+import { cloneDeep } from './objects'
 import { Inertia } from '@inertiajs/inertia'
 
 export default function form(data = {}) {
-  const defaults = JSON.parse(JSON.stringify(data))
+  const defaults = Object.keys(data).reduce((carry, key) => {
+    carry[key] = cloneDeep(data[key])
+
+    return carry
+  }, {})
+
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
 

--- a/packages/inertia-vue3/src/objects.js
+++ b/packages/inertia-vue3/src/objects.js
@@ -1,0 +1,21 @@
+export function cloneDeep(object) {
+  const type = getType(object)
+
+  if (type === 'array') {
+    return object.map(function (item) {
+      return cloneDeep(item)
+    })
+  } else if (type === 'object') {
+    return Object.keys(object).reduce((carry, key) => {
+      carry[key] = cloneDeep(object[key])
+
+      return carry
+    }, {})
+  } else {
+    return object
+  }
+}
+
+export function getType(object) {
+  return Object.prototype.toString.call(object).slice(8, -1).toLowerCase()
+}


### PR DESCRIPTION
Resolves #455 

This PR deep clone the defaults object and adds support for complex types (e.g. `Date()`) within the form (defaults) object. This replaces the current deep clone with `JSON.parse/stringify`.

`cloneDeep` is using a helper function `getType` to determine if we need to go deeper, e.g. on `objects` and `arrays` or if we need to return the complex type. As nearly everything in JS is an object (`typeof new Date() === 'object'` will also be `true`), this helps the `cloneDeep` to have universal approach. So we do not need to check for every single type which typically results in multiple `if` and `else if` clauses. 