### PR TITLE
Update the React definitions

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -17,7 +17,7 @@ type App<
   transformProps?: (props: PagePropsBeforeTransform) => PageProps
 }>
 
-interface InertiaLinkProps {
+interface BaseInertiaLinkProps {
   as?: string
   data?: object
   href: string
@@ -41,9 +41,9 @@ interface InertiaLinkProps {
   onSuccess?: () => void
 }
 
-type InertiaLink = React.FunctionComponent<
-  InertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'> & React.AllHTMLAttributes<HTMLElement>
->
+type InertiaLinkProps = InertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'> & React.AllHTMLAttributes<HTMLElement>
+
+type InertiaLink = React.FunctionComponent<InertiaLinkProps>
 
 export function usePage<
   Page extends Inertia.Page = Inertia.Page

--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -41,7 +41,7 @@ interface BaseInertiaLinkProps {
   onSuccess?: () => void
 }
 
-type InertiaLinkProps = InertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'> & React.AllHTMLAttributes<HTMLElement>
+type InertiaLinkProps = BaseInertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'> & React.AllHTMLAttributes<HTMLElement>
 
 type InertiaLink = React.FunctionComponent<InertiaLinkProps>
 


### PR DESCRIPTION
If you want to change the default behavior of the `InertiaLink` component and you are going to use the `InertiaLinkProps` interface, properties will not be compatible.

```typescript
import {
  InertiaLink as OriginalInertiaLink,
  InertiaLinkProps,
} from '@inertiajs/inertia-react';

export const InertiaLink: React.FC<InertiaLinkProps> = (props) => {
  const newProps = React.useMemo(() => {
    // Update the default behavior...
  }, [props]);

  // This will throw an error:
  //
  // Type '(event: KeyboardEvent<HTMLAnchorElement> | MouseEvent<HTMLAnchorElement, MouseEvent>) => void'
  //   is not assignable to type '(event: MouseEvent<HTMLElement, MouseEvent>) => void'
  return <OriginalInertiaLink {...newProps} />;
}
```

That's why I updated the InertiaLinkProps, that way interfaces will be compatible.