### PR TITLE
Fixing edge case where state is gone

### DIFF
--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -95,7 +95,7 @@ export default {
 
   handleBackForwardVisit(page) {
     window.history.state.version = page.version
-    this.setPage(window.history.state, { preserveScroll: true }).then(() => {
+    this.setPage(window.history.state || page, { preserveScroll: true }).then(() => {
       this.restoreScrollPositions()
     })
   },


### PR DESCRIPTION
```
TypeError Cannot read property 'component' of undefined 
    node_modules/@inertiajs/inertia/dist/index.js:1:10373 Object.setPage
    resources/js/app.js:153:19 Object.$inertia.setPage
    node_modules/@inertiajs/inertia/dist/index.js:1:4854 Object.handleBackForwardVisit
    node_modules/@inertiajs/inertia/dist/index.js:1:3195 Object.handleInitialPageVisit
    node_modules/@inertiajs/inertia/dist/index.js:1:3075 Object.init
    node_modules/@inertiajs/inertia-vue/dist/index.js:1:5109 l.created
    node_modules/vue/dist/vue.runtime.esm.js:1854:56 invokeWithErrorHandling
    node_modules/vue/dist/vue.runtime.esm.js:4219:6 callHook
    node_modules/vue/dist/vue.runtime.esm.js:5008:4 l.e._init
    node_modules/vue/dist/vue.runtime.esm.js:5154:11 new l
```

I keep seeing this error over and over on my bug tracking tool but i'm not able to reproduce, what i think is happening is that the history is getting too big or the user is navigating out of the site and navigating back to the site and the history state is getting lost.

Thoughts?