### PR TITLE
Store page props in session storage

### DIFF
--- a/packages/inertia/package.json
+++ b/packages/inertia/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "axios": "^0.21.1",
     "deepmerge": "^4.0.0",
-    "qs": "^6.9.0"
+    "qs": "^6.9.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "eslint": "^7.0.0",


### PR DESCRIPTION
Currently Inertia "enforces" a character limit to the response size, especially for Firefox. This is because all page props are stored within the browsers History object. This artificial limit can be quite cumbersome to workaround, data is usually user-generated and having a few varchar(255) fields with a text field can potentially cause issues.

With this PR I wanted get some feedback about the idea of using sessionStorage for props and if there's any issues with this that I'm missing.