### PR TITLE
Add blob support

### DIFF
--- a/packages/inertia/src/files.js
+++ b/packages/inertia/src/files.js
@@ -1,5 +1,6 @@
 export function hasFiles(data) {
   return data instanceof File
+    || data instanceof Blob
     || data instanceof FileList
     || (typeof data === 'object' && data !== null && Object.values(data).find(value => hasFiles(value)) !== undefined)
 }

--- a/packages/inertia/src/formData.js
+++ b/packages/inertia/src/formData.js
@@ -21,6 +21,8 @@ function appendToFormData(formData, key, value) {
     return formData.append(key, value.toISOString())
   } else if (value instanceof File) {
     return formData.append(key, value, value.name)
+  } else if (value instanceof Blob) {
+    return formData.append(key, value)
   } else if (typeof value === 'boolean') {
     return formData.append(key, value ? '1' : '0')
   } else if (value === null) {


### PR DESCRIPTION
Fixes #512

This PR adds `Blob` support to Inertia, when determining if a request should be sent using `FormData`.