### PR TITLE
Add form helper to React adapter

### DIFF
--- a/packages/inertia-react/src/index.js
+++ b/packages/inertia-react/src/index.js
@@ -1,4 +1,5 @@
 export { default as App, default as app, default as InertiaApp } from './App'
 export { default as Link, default as link, default as InertiaLink } from './Link'
+export { default as useForm } from './useForm'
 export { default as usePage } from './usePage'
 export { default as useRemember, useRememberedState } from './useRemember'

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -120,6 +120,7 @@ export default function useForm(defaults, key) {
       )
       setHasErrors(Object.keys(errors).length > 0)
     },
+    submit,
     get(url, options) {
       submit('get', url, options)
     },

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -81,16 +81,21 @@ export default function useForm(defaults, key) {
 
   return {
     data,
-    setData,
+    setData(key, value) {
+      if (typeof key === 'string') {
+        setData({ ...data, [key]: value })
+      } else if (typeof key === 'function') {
+        setData(data => key(data))
+      } else {
+        setData(key)
+      }
+    },
     errors,
     hasErrors,
     processing,
     progress,
     wasSuccessful,
     recentlySuccessful,
-    set(key, value) {
-      setData({ ...data, [key]: value })
-    },
     transform(callback) {
       transform = callback
     },

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -3,7 +3,7 @@ import { useRef, useCallback, useState } from 'react'
 import useRemember from './useRemember'
 
 export default function useForm(defaults, key) {
-  let transform = data => data
+  let transform = (data) => data
 
   const recentlySuccessfulTimeoutId = useRef(null)
   const [data, setData] = useRemember(defaults, `${key}-data`)
@@ -14,67 +14,70 @@ export default function useForm(defaults, key) {
   const [wasSuccessful, setWasSuccessful] = useState(false)
   const [recentlySuccessful, setRecentlySuccessful] = useState(false)
 
-  const submit = useCallback((method, url, options = {}) => {
-    const _options = {
-      ...options,
-      onBefore: visit => {
-        setWasSuccessful(false)
-        setRecentlySuccessful(false)
-        clearTimeout(recentlySuccessfulTimeoutId.current)
+  const submit = useCallback(
+    (method, url, options = {}) => {
+      const _options = {
+        ...options,
+        onBefore: (visit) => {
+          setWasSuccessful(false)
+          setRecentlySuccessful(false)
+          clearTimeout(recentlySuccessfulTimeoutId.current)
 
-        if (options.onBefore) {
-          return options.onBefore(visit)
-        }
-      },
-      onStart: visit => {
-        setProcessing(true)
+          if (options.onBefore) {
+            return options.onBefore(visit)
+          }
+        },
+        onStart: (visit) => {
+          setProcessing(true)
 
-        if (options.onStart) {
-          return options.onStart(visit)
-        }
-      },
-      onProgress: event => {
-        setProgress(event)
+          if (options.onStart) {
+            return options.onStart(visit)
+          }
+        },
+        onProgress: (event) => {
+          setProgress(event)
 
-        if (options.onProgress) {
-          return options.onProgress(event)
-        }
-      },
-      onSuccess: page => {
-        setErrors({})
-        setHasErrors(false)
-        setWasSuccessful(true)
-        setRecentlySuccessful(true)
-        recentlySuccessfulTimeoutId.current = setTimeout(() => setRecentlySuccessful(false), 2000)
+          if (options.onProgress) {
+            return options.onProgress(event)
+          }
+        },
+        onSuccess: (page) => {
+          setErrors({})
+          setHasErrors(false)
+          setWasSuccessful(true)
+          setRecentlySuccessful(true)
+          recentlySuccessfulTimeoutId.current = setTimeout(() => setRecentlySuccessful(false), 2000)
 
-        if (options.onSuccess) {
-          return options.onSuccess(page)
-        }
-      },
-      onError: errors => {
-        setErrors(errors)
-        setHasErrors(true)
+          if (options.onSuccess) {
+            return options.onSuccess(page)
+          }
+        },
+        onError: (errors) => {
+          setErrors(errors)
+          setHasErrors(true)
 
-        if (options.onError) {
-          return options.onError(errors)
-        }
-      },
-      onFinish: () => {
-        setProcessing(false)
-        setProgress(null)
+          if (options.onError) {
+            return options.onError(errors)
+          }
+        },
+        onFinish: () => {
+          setProcessing(false)
+          setProgress(null)
 
-        if (options.onFinish) {
-          return options.onFinish()
-        }
-      },
-    }
+          if (options.onFinish) {
+            return options.onFinish()
+          }
+        },
+      }
 
-    if (method === 'delete') {
-      Inertia.delete(url, { ..._options, data: transform(data)  })
-    } else {
-      Inertia[method](url, transform(data), _options)
-    }
-  }, [data, setErrors])
+      if (method === 'delete') {
+        Inertia.delete(url, { ..._options, data: transform(data) })
+      } else {
+        Inertia[method](url, transform(data), _options)
+      }
+    },
+    [data, setErrors],
+  )
 
   return {
     data,
@@ -86,7 +89,7 @@ export default function useForm(defaults, key) {
     wasSuccessful,
     recentlySuccessful,
     set(key, value) {
-      setData({ ...data, [key]: value})
+      setData({ ...data, [key]: value })
     },
     transform(callback) {
       transform = callback
@@ -95,39 +98,41 @@ export default function useForm(defaults, key) {
       if (fields.length === 0) {
         setData(defaults)
       } else {
-        setData(Object
-          .keys(defaults)
-          .filter(key => fields.includes(key))
-          .reduce((carry, key) => {
-            carry[key] = defaults[key]
-            return carry
-          }, {}),
+        setData(
+          Object.keys(defaults)
+            .filter((key) => fields.includes(key))
+            .reduce((carry, key) => {
+              carry[key] = defaults[key]
+              return carry
+            }, {}),
         )
       }
     },
     clearErrors(...fields) {
-      setErrors(Object
-        .keys(errors)
-        .reduce((carry, field) => ({
-          ...carry,
-          ...(fields.length > 0 && !fields.includes(field) ? { [field] : errors[field] } : {}),
-        }), {}),
+      setErrors(
+        Object.keys(errors).reduce(
+          (carry, field) => ({
+            ...carry,
+            ...(fields.length > 0 && !fields.includes(field) ? { [field]: errors[field] } : {}),
+          }),
+          {},
+        ),
       )
       setHasErrors(Object.keys(errors).length > 0)
     },
-    get(url, options){
+    get(url, options) {
       submit('get', url, options)
     },
-    post(url, options){
+    post(url, options) {
       submit('post', url, options)
     },
-    put(url, options){
+    put(url, options) {
       submit('put', url, options)
     },
-    patch(url, options){
+    patch(url, options) {
       submit('patch', url, options)
     },
-    delete(url, options){
+    delete(url, options) {
       submit('delete', url, options)
     },
   }

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -1,0 +1,134 @@
+import { Inertia } from '@inertiajs/inertia'
+import { useRef, useCallback, useState } from 'react'
+import useRemember from './useRemember'
+
+export default function useForm(defaults, key) {
+  let transform = data => data
+
+  const recentlySuccessfulTimeoutId = useRef(null)
+  const [data, setData] = useRemember(defaults, `${key}-data`)
+  const [errors, setErrors] = useRemember({}, `${key}-errors`)
+  const [hasErrors, setHasErrors] = useState(false)
+  const [processing, setProcessing] = useState(false)
+  const [progress, setProgress] = useState(null)
+  const [wasSuccessful, setWasSuccessful] = useState(false)
+  const [recentlySuccessful, setRecentlySuccessful] = useState(false)
+
+  const submit = useCallback((method, url, options = {}) => {
+    const _options = {
+      ...options,
+      onBefore: visit => {
+        setWasSuccessful(false)
+        setRecentlySuccessful(false)
+        clearTimeout(recentlySuccessfulTimeoutId.current)
+
+        if (options.onBefore) {
+          return options.onBefore(visit)
+        }
+      },
+      onStart: visit => {
+        setProcessing(true)
+
+        if (options.onStart) {
+          return options.onStart(visit)
+        }
+      },
+      onProgress: event => {
+        setProgress(event)
+
+        if (options.onProgress) {
+          return options.onProgress(event)
+        }
+      },
+      onSuccess: page => {
+        setErrors({})
+        setHasErrors(false)
+        setWasSuccessful(true)
+        setRecentlySuccessful(true)
+        recentlySuccessfulTimeoutId.current = setTimeout(() => setRecentlySuccessful(false), 2000)
+
+        if (options.onSuccess) {
+          return options.onSuccess(page)
+        }
+      },
+      onError: errors => {
+        setErrors(errors)
+        setHasErrors(true)
+
+        if (options.onError) {
+          return options.onError(errors)
+        }
+      },
+      onFinish: () => {
+        setProcessing(false)
+        setProgress(null)
+
+        if (options.onFinish) {
+          return options.onFinish()
+        }
+      },
+    }
+
+    if (method === 'delete') {
+      Inertia.delete(url, { ..._options, data: transform(data)  })
+    } else {
+      Inertia[method](url, transform(data), _options)
+    }
+  }, [data, setErrors])
+
+  return {
+    data,
+    setData,
+    errors,
+    hasErrors,
+    processing,
+    progress,
+    wasSuccessful,
+    recentlySuccessful,
+    set(key, value) {
+      setData({ ...data, [key]: value})
+    },
+    transform(callback) {
+      transform = callback
+    },
+    reset(...fields) {
+      if (fields.length === 0) {
+        setData(defaults)
+      } else {
+        setData(Object
+          .keys(defaults)
+          .filter(key => fields.includes(key))
+          .reduce((carry, key) => {
+            carry[key] = defaults[key]
+            return carry
+          }, {}),
+        )
+      }
+    },
+    clearErrors(...fields) {
+      setErrors(Object
+        .keys(errors)
+        .reduce((carry, field) => ({
+          ...carry,
+          ...(fields.length > 0 && !fields.includes(field) ? { [field] : errors[field] } : {}),
+        }), {}),
+      )
+      setHasErrors(Object.keys(errors).length > 0)
+    },
+    get(url, options){
+      submit('get', url, options)
+    },
+    post(url, options){
+      submit('post', url, options)
+    },
+    put(url, options){
+      submit('put', url, options)
+    },
+    patch(url, options){
+      submit('patch', url, options)
+    },
+    delete(url, options){
+      submit('delete', url, options)
+    },
+  }
+}


### PR DESCRIPTION
This PR adds the form helper to the React adapter, similar to the existing form helpers in the Vue 2 and Vue 3 adapters. The main difference between this form helper and the Vue form helper is that this one automatically remembers the form data and errors in history state. I actually think it makes sense to update the Vue form helpers to do the same thing.

## Example

```jsx
import React from 'react'
import { useForm } from '@inertiajs/inertia-react'

import TextInput from './TextInput'
import LoadingButton from './LoadingButton'

const { data, setData, post, processing, errors } = useForm({
  name: '',
  email: '',
})

function submit(event) {
  event.preventDefault()
  post('/users')
}

return (
  <form onSubmit={submit}>
    <TextInput label="Name" value={data.name} errors={errors.name} onChange={e => setData('name', e.target.value)} />
    <TextInput label="Email" value={data.email} errors={errors.email} onChange={e => setData('email', e.target.value)} />
    <LoadingButton loading={processing} type="submit">Submit</LoadingButton>
  </form>
)
```

## API

Here are the available properties:

- `data`
- `errors`
- `hasErrors`
- `processing`
- `progress`
- `wasSuccessful`
- `recentlySuccessful`

And the available methods:

- `setData(key, value)`, `setData(values)`, `setData(callback)`
- `transform(callback)`
- `reset()`, `reset(fields)`
- `clearErrors()`, `clearErrors(fields)`
- `submit(method, url, options)`
- `get(url, options)`
- `post(url, options)`
- `put(url, options)`
- `patch(url, options)`
- `delete(url, options)`

## Naming considerations

Keep in mind that `delete` is a reserved keyword, meaning if you'd like to destructure, you'll need to alias it. For example:

```js
const { delete: destroy } = useForm({ ... });
```

I'm also not sure if we need both `set()` and `setData()`. I like `set()` as a shortcut to set a specific field...but maybe we should call it `setField()` instead, or just let folks rely on `setData()`. The other issue with `set()` right now is that it only works for top level fields. For example: `set('name', name)`. It would be great to also support dot notation for the keys, like this: `set('user.name', name)`. Some choices here:

```js
// Option 1: set() and SetData()
form.set('name', value)
form.setData({ name: value })

// Option 2: setField() and setData()
form.setField('name', value)
form.setData({ name: value })

// Option 3: set() with type check
form.set('name', value)
form.set({ name: value })

// Option 4: setData() with type check
form.setData('name', value)
form.setData({ name: value })
```

## Future improvements

- Add the ability to use dot/array notation with `setData(key, value)` to set a nested value.
- Add the ability to manually set errors for client-side validation.
- Update the Vue form helpers to automatically remember the form data and errors in history state (like this form helper).