### PR TITLE
Add typings for the React Adapter Form Helper

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -2,79 +2,79 @@ import * as Inertia from '@inertiajs/inertia'
 import * as React from 'react'
 
 type App<
-  PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
-  PageProps extends Inertia.PageProps = Inertia.PageProps
-  > = React.FunctionComponent<{
-    children?: (props: {
-      Component: React.ComponentType
-      key: React.Key
-      props: PageProps
-    }) => React.ReactNode
-    initialPage: Inertia.Page<PageProps>
-    resolveComponent: (
-      name: string
-    ) => React.ComponentType | Promise<React.ComponentType>
-    transformProps?: (props: PagePropsBeforeTransform) => PageProps
-  }>
+	PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
+	PageProps extends Inertia.PageProps = Inertia.PageProps
+	> = React.FunctionComponent<{
+		children?: (props: {
+			Component: React.ComponentType
+			key: React.Key
+			props: PageProps
+		}) => React.ReactNode
+		initialPage: Inertia.Page<PageProps>
+		resolveComponent: (
+			name: string
+		) => React.ComponentType | Promise<React.ComponentType>
+		transformProps?: (props: PagePropsBeforeTransform) => PageProps
+	}>
 
 interface BaseInertiaLinkProps {
-  as?: string
-  data?: object
-  href: string
-  method?: string
-  headers?: object
-  onClick?: (
-    event:
-      | React.MouseEvent<HTMLAnchorElement>
-      | React.KeyboardEvent<HTMLAnchorElement>
-  ) => void
-  preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
-  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
-  replace?: boolean
-  only?: string[]
-  onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
-  onBefore?: () => void
-  onStart?: () => void
-  onProgress?: (progress: number) => void
-  onFinish?: () => void
-  onCancel?: () => void
-  onSuccess?: () => void
+	as?: string
+	data?: object
+	href: string
+	method?: string
+	headers?: object
+	onClick?: (
+		event:
+			| React.MouseEvent<HTMLAnchorElement>
+			| React.KeyboardEvent<HTMLAnchorElement>
+	) => void
+	preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
+	preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
+	replace?: boolean
+	only?: string[]
+	onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
+	onBefore?: () => void
+	onStart?: () => void
+	onProgress?: (progress: number) => void
+	onFinish?: () => void
+	onCancel?: () => void
+	onSuccess?: () => void
 }
 
-interface useFormProps {
-  data: object
-  errors: object
-  hasErrors: boolean
-  processing: boolean
-  progress: number
-  wasSuccessful: boolean
-  recentlySuccessful: boolean
-  setData: (...prop: [key?: string | object | (() => void), value?: any]) => void
-  transform: (callback: () => void) => void
-  reset: (fields?: object) => void
-  clearErrors: (fields?: object) => void
-  submit: (method: () => void, url: string, options?: Inertia.VisitOptions) => Promise<void>
-  get: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-  patch: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-  post: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-  put: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-  delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
+export interface InertiaFormProps {
+	data: object
+	errors: object
+	hasErrors: boolean
+	processing: boolean
+	progress: number
+	wasSuccessful: boolean
+	recentlySuccessful: boolean
+	setData: (...prop: [key?: string | object | (() => void), value?: any]) => void
+	transform: (callback: () => void) => void
+	reset: (fields?: object) => void
+	clearErrors: (fields?: object) => void
+	submit: (method: () => void, url: string, options?: Inertia.VisitOptions) => Promise<void>
+	get: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	patch: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	post: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	put: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
 
 }
 
-type useForm = (initialValues: { [key: string]: any }) => useFormProps
+type useForm = (initialValues: { [key: string]: any }) => InertiaFormProps
 
 type InertiaLinkProps = BaseInertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'> & React.AllHTMLAttributes<HTMLElement>
 
 type InertiaLink = React.FunctionComponent<InertiaLinkProps>
 
 export function usePage<
-  Page extends Inertia.Page = Inertia.Page
+	Page extends Inertia.Page = Inertia.Page
 >(): Page
 
 export function useRemember<State>(
-  initialState: State,
-  key?: string
+	initialState: State,
+	key?: string
 ): [State, React.Dispatch<React.SetStateAction<State>>]
 
 export const InertiaLink: InertiaLink

--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -2,56 +2,79 @@ import * as Inertia from '@inertiajs/inertia'
 import * as React from 'react'
 
 type App<
-  PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
-  PageProps extends Inertia.PageProps = Inertia.PageProps
-> = React.FunctionComponent<{
-  children?: (props: {
-    Component: React.ComponentType
-    key: React.Key
-    props: PageProps
-  }) => React.ReactNode
-  initialPage: Inertia.Page<PageProps>
-  resolveComponent: (
-    name: string
-  ) => React.ComponentType | Promise<React.ComponentType>
-  transformProps?: (props: PagePropsBeforeTransform) => PageProps
-}>
+    PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
+    PageProps extends Inertia.PageProps = Inertia.PageProps
+    > = React.FunctionComponent<{
+        children?: (props: {
+            Component: React.ComponentType
+            key: React.Key
+            props: PageProps
+        }) => React.ReactNode
+        initialPage: Inertia.Page<PageProps>
+        resolveComponent: (
+            name: string
+        ) => React.ComponentType | Promise<React.ComponentType>
+        transformProps?: (props: PagePropsBeforeTransform) => PageProps
+    }>
 
 interface BaseInertiaLinkProps {
-  as?: string
-  data?: object
-  href: string
-  method?: string
-  headers?: object
-  onClick?: (
-    event:
-      | React.MouseEvent<HTMLAnchorElement>
-      | React.KeyboardEvent<HTMLAnchorElement>
-  ) => void
-  preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
-  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
-  replace?: boolean
-  only?: string[]
-  onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
-  onBefore?: () => void
-  onStart?: () => void
-  onProgress?: (progress: number) => void
-  onFinish?: () => void
-  onCancel?: () => void
-  onSuccess?: () => void
+    as?: string
+    data?: object
+    href: string
+    method?: string
+    headers?: object
+    onClick?: (
+        event:
+            | React.MouseEvent<HTMLAnchorElement>
+            | React.KeyboardEvent<HTMLAnchorElement>
+    ) => void
+    preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
+    preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
+    replace?: boolean
+    only?: string[]
+    onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
+    onBefore?: () => void
+    onStart?: () => void
+    onProgress?: (progress: number) => void
+    onFinish?: () => void
+    onCancel?: () => void
+    onSuccess?: () => void
 }
+
+interface useFormProps {
+    data: object
+    errors: object
+    hasErrors: boolean
+    processing: boolean
+    progress: number
+    wasSuccessful: boolean
+    recentlySuccessful: boolean
+    setData: (...prop: [key?: string | object | (() => void), value?: any]) => void
+    transform: (callback: () => void) => void
+    reset: (fields?: object) => void
+    clearErrors: (fields?: object) => void
+    submit: (method: () => void, url: string, options?: Inertia.VisitOptions) => Promise<void>
+    get: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+    patch: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+    post: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+    put: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+    delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
+
+}
+
+type useForm = (initialValues: { [key: string]: any }) => useFormProps
 
 type InertiaLinkProps = BaseInertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'> & React.AllHTMLAttributes<HTMLElement>
 
 type InertiaLink = React.FunctionComponent<InertiaLinkProps>
 
 export function usePage<
-  Page extends Inertia.Page = Inertia.Page
+    Page extends Inertia.Page = Inertia.Page
 >(): Page
 
 export function useRemember<State>(
-  initialState: State,
-  key?: string
+    initialState: State,
+    key?: string
 ): [State, React.Dispatch<React.SetStateAction<State>>]
 
 export const InertiaLink: InertiaLink
@@ -59,3 +82,5 @@ export const InertiaLink: InertiaLink
 export const Link: InertiaLink
 
 export const InertiaApp: App
+
+export const useForm: useForm

--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -2,63 +2,63 @@ import * as Inertia from '@inertiajs/inertia'
 import * as React from 'react'
 
 type App<
-    PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
-    PageProps extends Inertia.PageProps = Inertia.PageProps
-    > = React.FunctionComponent<{
-        children?: (props: {
-            Component: React.ComponentType
-            key: React.Key
-            props: PageProps
-        }) => React.ReactNode
-        initialPage: Inertia.Page<PageProps>
-        resolveComponent: (
-            name: string
-        ) => React.ComponentType | Promise<React.ComponentType>
-        transformProps?: (props: PagePropsBeforeTransform) => PageProps
-    }>
+  PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
+  PageProps extends Inertia.PageProps = Inertia.PageProps
+  > = React.FunctionComponent<{
+    children?: (props: {
+      Component: React.ComponentType
+      key: React.Key
+      props: PageProps
+    }) => React.ReactNode
+    initialPage: Inertia.Page<PageProps>
+    resolveComponent: (
+      name: string
+    ) => React.ComponentType | Promise<React.ComponentType>
+    transformProps?: (props: PagePropsBeforeTransform) => PageProps
+  }>
 
 interface BaseInertiaLinkProps {
-    as?: string
-    data?: object
-    href: string
-    method?: string
-    headers?: object
-    onClick?: (
-        event:
-            | React.MouseEvent<HTMLAnchorElement>
-            | React.KeyboardEvent<HTMLAnchorElement>
-    ) => void
-    preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
-    preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
-    replace?: boolean
-    only?: string[]
-    onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
-    onBefore?: () => void
-    onStart?: () => void
-    onProgress?: (progress: number) => void
-    onFinish?: () => void
-    onCancel?: () => void
-    onSuccess?: () => void
+  as?: string
+  data?: object
+  href: string
+  method?: string
+  headers?: object
+  onClick?: (
+    event:
+      | React.MouseEvent<HTMLAnchorElement>
+      | React.KeyboardEvent<HTMLAnchorElement>
+  ) => void
+  preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
+  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
+  replace?: boolean
+  only?: string[]
+  onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
+  onBefore?: () => void
+  onStart?: () => void
+  onProgress?: (progress: number) => void
+  onFinish?: () => void
+  onCancel?: () => void
+  onSuccess?: () => void
 }
 
 interface useFormProps {
-    data: object
-    errors: object
-    hasErrors: boolean
-    processing: boolean
-    progress: number
-    wasSuccessful: boolean
-    recentlySuccessful: boolean
-    setData: (...prop: [key?: string | object | (() => void), value?: any]) => void
-    transform: (callback: () => void) => void
-    reset: (fields?: object) => void
-    clearErrors: (fields?: object) => void
-    submit: (method: () => void, url: string, options?: Inertia.VisitOptions) => Promise<void>
-    get: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-    patch: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-    post: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-    put: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-    delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
+  data: object
+  errors: object
+  hasErrors: boolean
+  processing: boolean
+  progress: number
+  wasSuccessful: boolean
+  recentlySuccessful: boolean
+  setData: (...prop: [key?: string | object | (() => void), value?: any]) => void
+  transform: (callback: () => void) => void
+  reset: (fields?: object) => void
+  clearErrors: (fields?: object) => void
+  submit: (method: () => void, url: string, options?: Inertia.VisitOptions) => Promise<void>
+  get: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+  patch: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+  post: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+  put: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+  delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
 
 }
 
@@ -69,12 +69,12 @@ type InertiaLinkProps = BaseInertiaLinkProps & Omit<React.HTMLAttributes<HTMLEle
 type InertiaLink = React.FunctionComponent<InertiaLinkProps>
 
 export function usePage<
-    Page extends Inertia.Page = Inertia.Page
+  Page extends Inertia.Page = Inertia.Page
 >(): Page
 
 export function useRemember<State>(
-    initialState: State,
-    key?: string
+  initialState: State,
+  key?: string
 ): [State, React.Dispatch<React.SetStateAction<State>>]
 
 export const InertiaLink: InertiaLink

--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -4,9 +4,9 @@ declare global {
   // These open interfaces may be extended in an application-specific manner via
   // declaration merging / interface augmentation.
   namespace Inertia {
-    interface PagePropsBeforeTransform {}
+    interface PagePropsBeforeTransform { }
 
-    interface PageProps {}
+    interface PageProps { }
   }
 }
 
@@ -32,7 +32,7 @@ export type VisitOptions = {
   only?: string[]
   headers?: object
   onCancelToken?: (cancelToken: CancelTokenSource) => void
-  onStart?: (visit: VisitOptions & {url: string}) => void | boolean
+  onStart?: (visit: VisitOptions & { url: string }) => void | boolean
   onProgress?: (progress: ProgressEvent) => void
   onFinish?: () => void
   onCancel?: () => void
@@ -46,17 +46,17 @@ interface Inertia {
   init: <
     Component,
     CustomPageProps extends PagePropsBeforeTransform = PagePropsBeforeTransform
-  >(arguments: {
-    initialPage: Page<CustomPageProps>
-    resolveComponent: (name: string) => Component | Promise<Component>
-    updatePage: (
-      component: Component,
-      props: CustomPageProps,
-      options: {
-        preserveState: boolean
-      }
-    ) => void
-  }) => void
+    >(arguments: {
+      initialPage: Page<CustomPageProps>
+      resolveComponent: (name: string) => Component | Promise<Component>
+      updatePage: (
+        component: Component,
+        props: CustomPageProps,
+        options: {
+          preserveState: boolean
+        }
+      ) => void
+    }) => void
 
   visit: (
     url: string,

--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -24,7 +24,7 @@ export interface Page<CustomPageProps extends PageProps = PageProps> {
   }
 }
 
-type VisitOptions = {
+export type VisitOptions = {
   method?: string
   replace?: boolean
   preserveScroll?: boolean | ((props: Page<Inertia.PageProps>) => boolean)


### PR DESCRIPTION
This PR adds the typings for the `useForm` Hook and Closes #523 