### PR TITLE
Add react form helper typings

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -1,84 +1,106 @@
-import * as Inertia from '@inertiajs/inertia'
-import * as React from 'react'
+import * as Inertia from "@inertiajs/inertia";
+import * as React from "react";
 
 type App<
   PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
   PageProps extends Inertia.PageProps = Inertia.PageProps
 > = React.FunctionComponent<{
   children?: (props: {
-    Component: React.ComponentType
-    key: React.Key
-    props: PageProps
-  }) => React.ReactNode
-  initialPage: Inertia.Page<PageProps>
+    Component: React.ComponentType;
+    key: React.Key;
+    props: PageProps;
+  }) => React.ReactNode;
+  initialPage: Inertia.Page<PageProps>;
   resolveComponent: (
     name: string
-  ) => React.ComponentType | Promise<React.ComponentType>
-  transformProps?: (props: PagePropsBeforeTransform) => PageProps
-}>
+  ) => React.ComponentType | Promise<React.ComponentType>;
+  transformProps?: (props: PagePropsBeforeTransform) => PageProps;
+}>;
 
 interface BaseInertiaLinkProps {
-  as?: string
-  data?: object
-  href: string
-  method?: string
-  headers?: object
+  as?: string;
+  data?: object;
+  href: string;
+  method?: string;
+  headers?: object;
   onClick?: (
     event:
       | React.MouseEvent<HTMLAnchorElement>
       | React.KeyboardEvent<HTMLAnchorElement>
-  ) => void
-  preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
-  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
-  replace?: boolean
-  only?: string[]
-  onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
-  onBefore?: () => void
-  onStart?: () => void
-  onProgress?: (progress: number) => void
-  onFinish?: () => void
-  onCancel?: () => void
-  onSuccess?: () => void
+  ) => void;
+  preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean);
+  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null;
+  replace?: boolean;
+  only?: string[];
+  onCancelToken?: (cancelToken: import("axios").CancelTokenSource) => void;
+  onBefore?: () => void;
+  onStart?: () => void;
+  onProgress?: (progress: number) => void;
+  onFinish?: () => void;
+  onCancel?: () => void;
+  onSuccess?: () => void;
 }
 
-type InertiaLinkProps = BaseInertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'> & React.AllHTMLAttributes<HTMLElement>
+type InertiaLinkProps = BaseInertiaLinkProps &
+  Omit<React.HTMLAttributes<HTMLElement>, "onProgress"> &
+  React.AllHTMLAttributes<HTMLElement>;
 
-type InertiaLink = React.FunctionComponent<InertiaLinkProps>
+type InertiaLink = React.FunctionComponent<InertiaLinkProps>;
 
-export function usePage<
-  Page extends Inertia.Page = Inertia.Page
->(): Page
+export function usePage<Page extends Inertia.Page = Inertia.Page>(): Page;
 
 export function useRemember<State>(
   initialState: State,
   key?: string
-): [State, React.Dispatch<React.SetStateAction<State>>]
+): [State, React.Dispatch<React.SetStateAction<State>>];
 
-export const InertiaLink: InertiaLink
+export const InertiaLink: InertiaLink;
 
-export const Link: InertiaLink
+export const Link: InertiaLink;
 
-export const InertiaApp: App
+export const InertiaApp: App;
 
 export interface InertiaFormProps {
-	data: object
-	errors: any
-	hasErrors: boolean
-	processing: boolean
-	progress: number
-	wasSuccessful: boolean
-	recentlySuccessful: boolean
-	setData: (...prop: [key?: string | object | (() => void), value?: any]) => void
-	transform: (callback: () => void) => void
-	reset: (fields?: object) => void
-	clearErrors: (fields?: object) => void
-	submit: (method: () => void, url: string, options?: Inertia.VisitOptions) => Promise<void>
-	get: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-	patch: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-	post: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-	put: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
-	delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
+  data: object;
+  errors: any;
+  hasErrors: boolean;
+  processing: boolean;
+  progress: number;
+  wasSuccessful: boolean;
+  recentlySuccessful: boolean;
+  setData: (
+    ...prop: [key?: string | object | (() => void), value?: any]
+  ) => void;
+  transform: (callback: () => void) => void;
+  reset: (...fields: String[]) => void;
+  clearErrors: (fields?: object) => void;
+  submit: (
+    method: () => void,
+    url: string,
+    options?: Inertia.VisitOptions
+  ) => Promise<void>;
+  get: (
+    url: string,
+    data?: object,
+    options?: Inertia.VisitOptions
+  ) => Promise<void>;
+  patch: (
+    url: string,
+    data?: object,
+    options?: Inertia.VisitOptions
+  ) => Promise<void>;
+  post: (
+    url: string,
+    data?: object,
+    options?: Inertia.VisitOptions
+  ) => Promise<void>;
+  put: (
+    url: string,
+    data?: object,
+    options?: Inertia.VisitOptions
+  ) => Promise<void>;
+  delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>;
 }
 
-type InertiaForm = (initialValues: { [key: string]: any }) => InertiaFormProps
-export const useForm:InertiaForm;
+type InertiaForm = (initialValues: { [key: string]: any }) => InertiaFormProps;
+export const useForm: InertiaForm;

--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -59,3 +59,26 @@ export const InertiaLink: InertiaLink
 export const Link: InertiaLink
 
 export const InertiaApp: App
+
+export interface InertiaFormProps {
+	data: object
+	errors: any
+	hasErrors: boolean
+	processing: boolean
+	progress: number
+	wasSuccessful: boolean
+	recentlySuccessful: boolean
+	setData: (...prop: [key?: string | object | (() => void), value?: any]) => void
+	transform: (callback: () => void) => void
+	reset: (fields?: object) => void
+	clearErrors: (fields?: object) => void
+	submit: (method: () => void, url: string, options?: Inertia.VisitOptions) => Promise<void>
+	get: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	patch: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	post: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	put: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
+}
+
+type InertiaForm = (initialValues: { [key: string]: any }) => InertiaFormProps
+export const useForm:InertiaForm;

--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -1,106 +1,84 @@
-import * as Inertia from "@inertiajs/inertia";
-import * as React from "react";
+import * as Inertia from '@inertiajs/inertia'
+import * as React from 'react'
 
 type App<
   PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
   PageProps extends Inertia.PageProps = Inertia.PageProps
 > = React.FunctionComponent<{
   children?: (props: {
-    Component: React.ComponentType;
-    key: React.Key;
-    props: PageProps;
-  }) => React.ReactNode;
-  initialPage: Inertia.Page<PageProps>;
+    Component: React.ComponentType
+    key: React.Key
+    props: PageProps
+  }) => React.ReactNode
+  initialPage: Inertia.Page<PageProps>
   resolveComponent: (
     name: string
-  ) => React.ComponentType | Promise<React.ComponentType>;
-  transformProps?: (props: PagePropsBeforeTransform) => PageProps;
-}>;
+  ) => React.ComponentType | Promise<React.ComponentType>
+  transformProps?: (props: PagePropsBeforeTransform) => PageProps
+}>
 
 interface BaseInertiaLinkProps {
-  as?: string;
-  data?: object;
-  href: string;
-  method?: string;
-  headers?: object;
+  as?: string
+  data?: object
+  href: string
+  method?: string
+  headers?: object
   onClick?: (
     event:
       | React.MouseEvent<HTMLAnchorElement>
       | React.KeyboardEvent<HTMLAnchorElement>
-  ) => void;
-  preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean);
-  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null;
-  replace?: boolean;
-  only?: string[];
-  onCancelToken?: (cancelToken: import("axios").CancelTokenSource) => void;
-  onBefore?: () => void;
-  onStart?: () => void;
-  onProgress?: (progress: number) => void;
-  onFinish?: () => void;
-  onCancel?: () => void;
-  onSuccess?: () => void;
+  ) => void
+  preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
+  preserveState?: boolean | ((props: Inertia.PageProps) => boolean) | null
+  replace?: boolean
+  only?: string[]
+  onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
+  onBefore?: () => void
+  onStart?: () => void
+  onProgress?: (progress: number) => void
+  onFinish?: () => void
+  onCancel?: () => void
+  onSuccess?: () => void
 }
 
-type InertiaLinkProps = BaseInertiaLinkProps &
-  Omit<React.HTMLAttributes<HTMLElement>, "onProgress"> &
-  React.AllHTMLAttributes<HTMLElement>;
+type InertiaLinkProps = BaseInertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'> & React.AllHTMLAttributes<HTMLElement>
 
-type InertiaLink = React.FunctionComponent<InertiaLinkProps>;
+type InertiaLink = React.FunctionComponent<InertiaLinkProps>
 
-export function usePage<Page extends Inertia.Page = Inertia.Page>(): Page;
+export function usePage<
+  Page extends Inertia.Page = Inertia.Page
+>(): Page
 
 export function useRemember<State>(
   initialState: State,
   key?: string
-): [State, React.Dispatch<React.SetStateAction<State>>];
+): [State, React.Dispatch<React.SetStateAction<State>>]
 
-export const InertiaLink: InertiaLink;
+export const InertiaLink: InertiaLink
 
-export const Link: InertiaLink;
+export const Link: InertiaLink
 
-export const InertiaApp: App;
+export const InertiaApp: App
 
 export interface InertiaFormProps {
-  data: object;
-  errors: any;
-  hasErrors: boolean;
-  processing: boolean;
-  progress: number;
-  wasSuccessful: boolean;
-  recentlySuccessful: boolean;
-  setData: (
-    ...prop: [key?: string | object | (() => void), value?: any]
-  ) => void;
-  transform: (callback: () => void) => void;
-  reset: (...fields: String[]) => void;
-  clearErrors: (fields?: object) => void;
-  submit: (
-    method: () => void,
-    url: string,
-    options?: Inertia.VisitOptions
-  ) => Promise<void>;
-  get: (
-    url: string,
-    data?: object,
-    options?: Inertia.VisitOptions
-  ) => Promise<void>;
-  patch: (
-    url: string,
-    data?: object,
-    options?: Inertia.VisitOptions
-  ) => Promise<void>;
-  post: (
-    url: string,
-    data?: object,
-    options?: Inertia.VisitOptions
-  ) => Promise<void>;
-  put: (
-    url: string,
-    data?: object,
-    options?: Inertia.VisitOptions
-  ) => Promise<void>;
-  delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>;
+	data: object
+	errors: any
+	hasErrors: boolean
+	processing: boolean
+	progress: number
+	wasSuccessful: boolean
+	recentlySuccessful: boolean
+	setData: (...prop: [key?: string | object | (() => void), value?: any]) => void
+	transform: (callback: () => void) => void
+	reset: (fields?: object) => void
+	clearErrors: (fields?: object) => void
+	submit: (method: () => void, url: string, options?: Inertia.VisitOptions) => Promise<void>
+	get: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	patch: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	post: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	put: (url: string, data?: object, options?: Inertia.VisitOptions) => Promise<void>
+	delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
 }
 
-type InertiaForm = (initialValues: { [key: string]: any }) => InertiaFormProps;
-export const useForm: InertiaForm;
+type InertiaForm = (initialValues: { [key: string]: any }) => InertiaFormProps
+export const useForm:InertiaForm;


### PR DESCRIPTION
Closes #523 

This [PR](#526) adds Typescript declarations for the `useForm` hook, used by the React adapter.

![image](https://user-images.githubusercontent.com/30869823/109402534-fdf87900-7956-11eb-8d44-b8c13922ca61.png)
