### PR TITLE
Simplify mergeDataIntoQueryString method

### DIFF
--- a/packages/inertia-react/src/Link.js
+++ b/packages/inertia-react/src/Link.js
@@ -1,4 +1,4 @@
-import { hrefToUrl, Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
+import { Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
 import { createElement, useCallback, forwardRef } from 'react'
 
 const noop = () => undefined
@@ -74,9 +74,9 @@ export default forwardRef(function InertiaLink({
 
   as = as.toLowerCase()
   method = method.toLowerCase()
-  const [url, _data] = mergeDataIntoQueryString(method, hrefToUrl(href), data)
+  const url = mergeDataIntoQueryString(method, href, data)
   href = url.href
-  data = _data
+  data = url.data
 
   if (as === 'a' && method !== 'get') {
     console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<InertiaLink href="${href}" method="${method}" as="button">...</InertiaLink>`)

--- a/packages/inertia-svelte/src/Link.svelte
+++ b/packages/inertia-svelte/src/Link.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { hrefToUrl, Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
+  import { Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
   import { beforeUpdate, createEventDispatcher } from 'svelte'
 
   const dispatch = createEventDispatcher()
@@ -16,12 +16,12 @@
 
   beforeUpdate(() => {
     method = method.toLowerCase()
-    const [url, _data] = mergeDataIntoQueryString(method, hrefToUrl(href), data)
+    const url = mergeDataIntoQueryString(method, href, data)
     href = url.href
-    data = _data
+    data = url.data
 
     if (method !== 'get') {
-      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "inertia" directive. For example:\n\n<button use:inertia={{ method: 'post', href: '${url.href}' }}>...</button>`)
+      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "inertia" directive. For example:\n\n<button use:inertia={{ method: 'post', href: '${href}' }}>...</button>`)
     }
   })
 

--- a/packages/inertia-svelte/src/link.js
+++ b/packages/inertia-svelte/src/link.js
@@ -1,10 +1,10 @@
-import { hrefToUrl, Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
+import { Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
 import { createEventDispatcher } from 'svelte'
 
 export default (node, options = {}) => {
-  const [url, data] = mergeDataIntoQueryString(options.method || 'get', hrefToUrl(node.href || options.href), options.data || {})
+  const url = mergeDataIntoQueryString(options.method || 'get', node.href || options.href, options.data || {})
   node.href = url.href
-  options.data = data
+  options.data = url.data
 
   const dispatch = createEventDispatcher()
 
@@ -27,9 +27,9 @@ export default (node, options = {}) => {
 
   return {
     update(newOptions) {
-      const [url, data] = mergeDataIntoQueryString(newOptions.method || 'get', hrefToUrl(node.href || newOptions.href), newOptions.data || {})
+      const url = mergeDataIntoQueryString(newOptions.method || 'get', node.href || newOptions.href, newOptions.data || {})
       node.href = url.href
-      newOptions.data = data
+      newOptions.data = url.data
       options = newOptions
     },
     destroy() {

--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -1,4 +1,4 @@
-import { hrefToUrl, Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
+import { Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
 
 export default {
   functional: true,
@@ -55,17 +55,17 @@ export default {
 
     const as = props.as.toLowerCase()
     const method = props.method.toLowerCase()
-    const [url, propsData] = mergeDataIntoQueryString(method, hrefToUrl(props.href), props.data)
+    const { href, data: propsData } = mergeDataIntoQueryString(method, props.href, props.data)
 
     if (as === 'a' && method !== 'get') {
-      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<inertia-link href="${url.href}" method="${method}" as="button">...</inertia-link>`)
+      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<inertia-link href="${href}" method="${method}" as="button">...</inertia-link>`)
     }
 
     return h(props.as, {
       ...data,
       attrs: {
         ...data.attrs,
-        ...as === 'a' ? { href: url.href } : {},
+        ...as === 'a' ? { href } : {},
       },
       on: {
         ...data.on,
@@ -75,7 +75,7 @@ export default {
           if (shouldIntercept(event)) {
             event.preventDefault()
 
-            Inertia.visit(url.href, {
+            Inertia.visit(href, {
               data: propsData,
               method: method,
               replace: props.replace,

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -1,5 +1,5 @@
 import { h } from 'vue'
-import { hrefToUrl, Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
+import { Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
 
 export default {
   props: {
@@ -44,20 +44,20 @@ export default {
     return props => {
       const as = props.as.toLowerCase()
       const method = props.method.toLowerCase()
-      const [url, data] = mergeDataIntoQueryString(method, hrefToUrl(props.href), props.data)
+      const { href, data } = mergeDataIntoQueryString(method, props.href, props.data)
 
       if (as === 'a' && method !== 'get') {
-        console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<inertia-link href="${url.href}" method="${method}" as="button">...</inertia-link>`)
+        console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<inertia-link href="${href}" method="${method}" as="button">...</inertia-link>`)
       }
 
       return h(props.as, {
         ...attrs,
-        ...as === 'a' ? { href: url.href } : {},
+        ...as === 'a' ? { href } : {},
         onClick: (event) => {
           if (shouldIntercept(event)) {
             event.preventDefault()
 
-            Inertia.visit(url.href, {
+            Inertia.visit(href, {
               data: data,
               method: method,
               replace: props.replace,

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -187,15 +187,15 @@ export default {
     onSuccess = () => ({}),
     onError = () => ({}),
   } = {}) {
-    method = method.toLowerCase();
-    [url, data] = mergeDataIntoQueryString(method, hrefToUrl(url), data)
+    method = method.toLowerCase()
+    url = mergeDataIntoQueryString(method, url, data)
 
     const visitHasFiles = hasFiles(data)
     if (method !== 'get' && (visitHasFiles || forceFormData)) {
       data = objectToFormData(data)
     }
 
-    const visit = { url, method, data, replace, preserveScroll, preserveState, only, headers, errorBag, forceFormData, onCancelToken, onBefore, onStart, onProgress, onFinish, onCancel, onSuccess, onError }
+    const visit = { url: url.href, method, data, replace, preserveScroll, preserveState, only, headers, errorBag, forceFormData, onCancelToken, onBefore, onStart, onProgress, onFinish, onCancel, onSuccess, onError }
 
     if (onBefore(visit) === false || !fireBeforeEvent(visit)) {
       return
@@ -215,7 +215,7 @@ export default {
     return new Proxy(
       Axios({
         method,
-        url: urlWithoutHash(url).href,
+        url: url.hrefWithoutHash,
         data: method === 'get' ? {} : data,
         params: method === 'get' ? data : {},
         cancelToken: this.activeVisit.cancelToken.token,

--- a/packages/inertia/src/url.js
+++ b/packages/inertia/src/url.js
@@ -5,7 +5,17 @@ export function hrefToUrl(href) {
   return new URL(href, window.location)
 }
 
-export function mergeDataIntoQueryString(method, url, data) {
+export function mergeDataIntoQueryString(method, href, data) {
+  let url
+  let preserveHost = true
+
+  try {
+    url = new URL(href)
+  } catch(e) {
+    url = new URL(href, 'http://localhost')
+    preserveHost = false
+  }
+
   if (method === 'get' && Object.keys(data).length) {
     url.search = qs.stringify(
       deepmerge(qs.parse(url.search, { ignoreQueryPrefix: true }), data), {
@@ -15,7 +25,12 @@ export function mergeDataIntoQueryString(method, url, data) {
     )
     data = {}
   }
-  return [url, data]
+
+  return {
+    href: preserveHost ? url.toString() : [url.pathname, url.search, url.hash].join(''),
+    hrefWithoutHash: preserveHost ? url.toString().replace(url.hash, '') : [url.pathname, url.search].join(''),
+    data,
+  }
 }
 
 export function urlWithoutHash(url) {


### PR DESCRIPTION
This PR simplifies the `mergeDataIntoQueryString()` method implementation in Inertia core and all the adapters.

Previously this method normalized links to always make them use absolute URLs. Meaning if you had an `href` of `/about`, the `mergeDataIntoQueryString()` method would turn it into `http://yourdomain.com/about`. While this practically isn't a super big issue, it's an odd thing for a method that's simply responsible for merging data into the query strings. With this update, Inertia will no longer change link URLs. It will simply use whatever you provide. 👍 

That said, the primary motivation for this change is to remove the dependency on the `hrefToUrl()` method, which requires `window` access, and doesn't work in SSR mode (Node).