### PR TITLE
Fix bug `<InertiaLink>` without default slot

### DIFF
--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -76,7 +76,7 @@ export default {
             })
           }
         },
-      }, slots.default())
+      }, slots.default?.())
     }
   },
 }


### PR DESCRIPTION
This seems to break the render function when you use the `<InertiaLink :href="" />` without the default slot provided.