### PR TITLE
[Vue 3] Match Typescript definition with v0.3.6 update

### DIFF
--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -63,8 +63,6 @@ interface Form<Data> {
   delete(url: string, options?: Inertia.VisitOptions): void
 }
 
-type FormWithData<Data> = Data & Form<Data>
-
 export const App: InertiaApp
 
 export const Link: InertiaLink
@@ -80,9 +78,9 @@ export declare function usePage<CustomPageProps extends Inertia.PageProps = Iner
   version: ComputedRef<string | null>
 }
 
-export declare function useRemember(data: object, key?: string): Ref<object>
+export declare function useRemember(data: object, key?: string): object | Ref<object>
 
-export declare function useForm<Data>(data: Data): Ref<FormWithData<Data>>
+export declare function useForm<Data>(data: Data, options: { key?: string, remember?: boolean }): Data & Form<Data>
 
 declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {


### PR DESCRIPTION
The recent v0.3.6﻿ release of the Vue 3 adapter comes with an improved `useForm` and
`useRemember` functions, which were type-hinted before, but weren't updated for the corresponding release.

This PR tries to fix that, so that Typescript users stop getting warnings from their IDEs.
