### PR TITLE
Use function for layout child in Vue 3 adapter

### DIFF
--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -55,7 +55,7 @@ export default {
             return component.value.layout
               .concat(child)
               .reverse()
-              .reduce((child, layout) => h(layout, [child]))
+              .reduce((child, layout) => h(layout, () => child))
           }
 
           return h(component.value.layout, () => child)


### PR DESCRIPTION
Fixes #579

This update prevents Vue 3 from throwing a warning when setting an array of layouts.