### PR TITLE
Fix remember

### DIFF
--- a/packages/inertia-vue3/src/remember.js
+++ b/packages/inertia-vue3/src/remember.js
@@ -1,5 +1,5 @@
-import { toRaw, unref } from 'vue'
 import { Inertia } from '@inertiajs/inertia'
+import cloneDeep from 'lodash.clonedeep'
 
 export default {
   created() {
@@ -38,7 +38,7 @@ export default {
         Inertia.remember(
           rememberable.reduce((data, key) => ({
             ...data,
-            [key]: toRaw(unref(this[key])),
+            [key]: cloneDeep(this[key]),
           }), {}),
           stateKey,
         )


### PR DESCRIPTION
This is a follow-up for the PR https://github.com/inertiajs/inertia/pull/587.

Personally, I use a custom Form component, instead of using the built-in form helper.

My custom component has the `remember` property, which leads to the same issue that is solved for the built-in form helper.

With this change, it works well now. I guess this does not affect any other part of the code.