### PR TITLE
Update Vue 3 useRemember hook to use cloneDeep

### DIFF
--- a/packages/inertia-vue3/src/useRemember.js
+++ b/packages/inertia-vue3/src/useRemember.js
@@ -1,5 +1,6 @@
-import { isReactive, reactive, ref, toRaw, unref, watch } from 'vue'
+import { isReactive, reactive, ref, watch } from 'vue'
 import { Inertia } from '@inertiajs/inertia'
+import cloneDeep from 'lodash.clonedeep'
 
 export default function useRemember(data, key) {
   if (typeof data === 'object' && data !== null && data.__rememberable === false) {
@@ -8,7 +9,7 @@ export default function useRemember(data, key) {
 
   const restored = Inertia.restore(key)
   const remembered = restored === undefined ? data : (isReactive(data) ? reactive(data) : ref(restored))
-  watch(remembered, (value) => Inertia.remember(toRaw(unref(value)), key), { immediate: true, deep: true })
+  watch(remembered, (value) => Inertia.remember(cloneDeep(value), key), { immediate: true, deep: true })
 
   return remembered
 }


### PR DESCRIPTION
Continuing the "clone deep" changes from #587 and #591, this updates the `useRemember` hook to use `cloneDeep` as well.