### PR TITLE
React HMR fix

### DIFF
--- a/packages/inertia-react/src/App.js
+++ b/packages/inertia-react/src/App.js
@@ -29,7 +29,7 @@ export default function App({
         }))
       },
     })
-  }, [initialPage, resolveComponent, resolveErrors, transformProps])
+  }, [])
 
   if (!current.component) {
     return createElement(PageContext.Provider, { value: current.page }, null)


### PR DESCRIPTION
While the `useEffect` dependencies are correct in theory, they're a pain for hot module replacement with React.

When HMR kicks in, the effect gets cleaned up and `Inertia.init` gets called again. This causes the initial page to be rendered instead of the current one.

There might be a cleaner way to solve this along the road, but I can't think of any better, and don't see any practical downsides of this change.