### PR TITLE
Fix bug when creating a form helper without passing a data object

### DIFF
--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -4,7 +4,7 @@ import useRemember from './useRemember'
 
 export default function useForm(...args) {
   const rememberKey = typeof args[0] === 'string' ? typeof args[0] : null
-  const defaults = typeof args[0] === 'string' ? args[1] : args[0]
+  const defaults = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const recentlySuccessfulTimeoutId = useRef(null)
   const [data, setData] = rememberKey ? useRemember(defaults, `${rememberKey}:data`) : useState(defaults)
   const [errors, setErrors] = rememberKey ? useRemember({}, `${rememberKey}:errors`) : useState({})

--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -3,7 +3,7 @@ import { writable } from 'svelte/store'
 
 function useForm(...args) {
   const rememberKey = typeof args[0] === 'string' ? typeof args[0] : null
-  const data = typeof args[0] === 'string' ? args[1] : args[0]
+  const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const defaults = data
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
   let recentlySuccessfulTimeoutId = null

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -4,7 +4,7 @@ import { Inertia } from '@inertiajs/inertia'
 
 export default function(...args) {
   const rememberKey = typeof args[0] === 'string' ? typeof args[0] : null
-  const data = typeof args[0] === 'string' ? args[1] : args[0]
+  const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const defaults = cloneDeep(data)
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
   let recentlySuccessfulTimeoutId = null

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -4,7 +4,7 @@ import { Inertia } from '@inertiajs/inertia'
 
 export default function useForm(...args) {
   const rememberKey = typeof args[0] === 'string' ? typeof args[0] : null
-  const data = typeof args[0] === 'string' ? args[1] : args[0]
+  const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const defaults = cloneDeep(data)
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
   let recentlySuccessfulTimeoutId = null


### PR DESCRIPTION
This fixes a bug with the form helper where you get an error if you don't pass any data. Previously this was possible, and is useful for things like delete forms.

```js
// Breaks (but now fixed)
let form = useForm()

// Works
let form = useForm({})
```