### PR TITLE
fix InertiaLinkProps typing

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -41,7 +41,7 @@ interface BaseInertiaLinkProps {
   onSuccess?: () => void
 }
 
-type InertiaLinkProps = BaseInertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, 'onProgress'> & React.AllHTMLAttributes<HTMLElement>
+type InertiaLinkProps = BaseInertiaLinkProps & Omit<React.HTMLAttributes<HTMLElement>, keyof BaseInertiaLinkProps> & Omit<React.AllHTMLAttributes<HTMLElement>, keyof BaseInertiaLinkProps>
 
 type InertiaLink = React.FunctionComponent<InertiaLinkProps>
 


### PR DESCRIPTION
The way `InertiaLinkProps` is currently typed, causes `data` and `headers` to not accept any value, as it's typed as `string` in `React.AllHTMLAttributes`, and as `object` in `InertiaLinkProps`.

As is already done for `onProgress`, we should omit all the props Inertia is using, to avoid any other conflicts in the typing.

Credits to @sebastiandedeyne for the idea :)