### PR TITLE
Add cancel support to form helper

### DIFF
--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -6,6 +6,7 @@ function useForm(...args) {
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const defaults = data
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
+  let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
 
@@ -68,6 +69,13 @@ function useForm(...args) {
       const data = transform(this.data())
       const _options = {
         ...options,
+        onCancelToken: (token) => {
+          cancelToken = token
+
+          if (options.cancelToken) {
+            return options.cancelToken(token)
+          }
+        },
         onBefore: visit => {
           this.setStore('wasSuccessful', false)
           this.setStore('recentlySuccessful', false)
@@ -110,6 +118,7 @@ function useForm(...args) {
           }
         },
         onFinish: () => {
+          cancelToken = null
           this.setStore('processing', false)
           this.setStore('progress', null)
 
@@ -139,6 +148,11 @@ function useForm(...args) {
     },
     delete(url, options) {
       this.submit('delete', url, options)
+    },
+    cancel() {
+      if (cancelToken) {
+        cancelToken.cancel()
+      }
     },
   })
 

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -7,6 +7,7 @@ export default function(...args) {
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const defaults = cloneDeep(data)
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
+  let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
 
@@ -66,6 +67,13 @@ export default function(...args) {
       const data = transform(this.data())
       const _options = {
         ...options,
+        onCancelToken: (token) => {
+          cancelToken = token
+
+          if (options.cancelToken) {
+            return options.cancelToken(token)
+          }
+        },
         onBefore: visit => {
           this.wasSuccessful = false
           this.recentlySuccessful = false
@@ -90,28 +98,27 @@ export default function(...args) {
           }
         },
         onBeforeRender: page => {
+          cancelToken = null
+          this.processing = false
+          this.progress = null
           this.errors = page.resolvedErrors
           this.hasErrors = Object.keys(this.errors).length > 0
           this.wasSuccessful = !this.hasErrors
           this.recentlySuccessful = !this.hasErrors
 
+          recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
+
           if (options.onBeforeRender) {
             return options.onBeforeRender(page)
           }
         },
-        onSuccess: page => {
-          recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
-
-          if (options.onSuccess) {
-            return options.onSuccess(page)
-          }
-        },
-        onFinish: () => {
+        onCancel: () => {
+          cancelToken = null
           this.processing = false
           this.progress = null
 
-          if (options.onFinish) {
-            return options.onFinish()
+          if (options.onCancel) {
+            return options.onCancel()
           }
         },
       }
@@ -136,6 +143,11 @@ export default function(...args) {
     },
     delete(url, options) {
       this.submit('delete', url, options)
+    },
+    cancel() {
+      if (cancelToken) {
+        cancelToken.cancel()
+      }
     },
     __rememberable: rememberKey === null,
     __remember() {

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -105,7 +105,6 @@ export default function(...args) {
           this.hasErrors = Object.keys(this.errors).length > 0
           this.wasSuccessful = !this.hasErrors
           this.recentlySuccessful = !this.hasErrors
-
           recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
 
           if (options.onBeforeRender) {

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -7,6 +7,7 @@ export default function useForm(...args) {
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const defaults = cloneDeep(data)
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
+  let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
 
@@ -66,6 +67,13 @@ export default function useForm(...args) {
       const data = transform(this.data())
       const _options = {
         ...options,
+        onCancelToken: (token) => {
+          cancelToken = token
+
+          if (options.cancelToken) {
+            return options.cancelToken(token)
+          }
+        },
         onBefore: visit => {
           this.wasSuccessful = false
           this.recentlySuccessful = false
@@ -90,28 +98,27 @@ export default function useForm(...args) {
           }
         },
         onBeforeRender: page => {
+          cancelToken = null
+          this.processing = false
+          this.progress = null
           this.errors = page.resolvedErrors
           this.hasErrors = Object.keys(this.errors).length > 0
           this.wasSuccessful = !this.hasErrors
           this.recentlySuccessful = !this.hasErrors
 
+          recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
+
           if (options.onBeforeRender) {
             return options.onBeforeRender(page)
           }
         },
-        onSuccess: page => {
-          recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
-
-          if (options.onSuccess) {
-            return options.onSuccess(page)
-          }
-        },
-        onFinish: () => {
+        onCancel: () => {
+          cancelToken = null
           this.processing = false
           this.progress = null
 
-          if (options.onFinish) {
-            return options.onFinish()
+          if (options.onCancel) {
+            return options.onCancel()
           }
         },
       }
@@ -136,6 +143,11 @@ export default function useForm(...args) {
     },
     delete(url, options) {
       this.submit('delete', url, options)
+    },
+    cancel() {
+      if (cancelToken) {
+        cancelToken.cancel()
+      }
     },
     __rememberable: rememberKey === null,
     __remember() {

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -105,7 +105,6 @@ export default function useForm(...args) {
           this.hasErrors = Object.keys(this.errors).length > 0
           this.wasSuccessful = !this.hasErrors
           this.recentlySuccessful = !this.hasErrors
-
           recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
 
           if (options.onBeforeRender) {


### PR DESCRIPTION
This PR adds a new `form.cancel()` method to the form helper. This saves you from having to manually track the cancel token.

- [x] Vue 2
- [x] Vue 3
- [x] React
- [x] Svelte

## Before

```js
data() {
  return {
    cancelToken: null,
    form: this.$inertia.form({ ... }),
  }
},

this.form.post('/users', {
  onCancelToken: (cancelToken) => (this.cancelToken = cancelToken),
})

// Cancel the visit
this.cancelToken.cancel()
```

## After

```js
data() {
  return {
    form: this.$inertia.form({ ... }),
  }
},

this.form.post('/users')

// Cancel the visit
this.form.cancel()
```

This PR also removes the `onSuccess` and `onFinish` callbacks, and uses the `onBeforeRender` callback for everything. This was needed, since I noticed that `processing` was showing stale data when used in a visit callback (same problem as #410).