### PR TITLE
Update vue3 adapter type definition file

### DIFF
--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -39,31 +39,29 @@ type InertiaLink = DefineComponent<InertiaLinkProps>
 
 type ProgressEvent = {
   percentage: number
-  [key: string]: any
 }
 
-interface Form<Data> {
-  errors: { [K in keyof Data]: string | undefined }
+interface InertiaFormProps<TForm> {
+  errors: Record<keyof TForm, string>
   hasErrors: boolean
   processing: boolean
   progress: ProgressEvent | null
   wasSuccessful: boolean
   recentlySuccessful: boolean
-  data(): Data
-  transform(callback: (data: Data) => object): this
-  reset(...fields: (keyof Data)[]): this
-  clearErrors(...fields: (keyof Data)[]): this
-  serialize(): { errors: { [K in keyof Data]: string | undefined }, [key: string]: any }
-  unserialize(data: object): this
+  data(): TForm
+  transform(callback: (data: TForm) => object): this
+  reset(...fields: (keyof TForm)[]): this
+  clearErrors(...fields: (keyof TForm)[]): this
   submit(method: string, url: string, options?: Inertia.VisitOptions): void
   get(url: string, options?: Inertia.VisitOptions): void
   post(url: string, options?: Inertia.VisitOptions): void
   put(url: string, options?: Inertia.VisitOptions): void
   patch(url: string, options?: Inertia.VisitOptions): void
   delete(url: string, options?: Inertia.VisitOptions): void
+  cancel(): void
 }
 
-type FormWithData<Data> = Data & Form<Data>
+type InertiaForm<TForm> = TForm & InertiaFormProps<TForm>
 
 export const App: InertiaApp
 
@@ -82,7 +80,9 @@ export declare function usePage<CustomPageProps extends Inertia.PageProps = Iner
 
 export declare function useRemember(data: object, key?: string): Ref<object>
 
-export declare function useForm<Data>(data: Data): Ref<FormWithData<Data>>
+export declare function useForm<TForm>(data: TForm): InertiaForm<TForm>
+
+export declare function useForm<TForm>(rememberKey: string, data: TForm): InertiaForm<TForm>
 
 declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -37,6 +37,14 @@ interface InertiaLinkProps {
 
 type InertiaLink = DefineComponent<InertiaLinkProps>
 
+export const App: InertiaApp
+
+export const Link: InertiaLink
+
+export const plugin: {
+  install(app: App): void
+}
+
 type ProgressEvent = {
   percentage: number
 }
@@ -63,13 +71,11 @@ interface InertiaFormProps<TForm> {
 
 type InertiaForm<TForm> = TForm & InertiaFormProps<TForm>
 
-export const App: InertiaApp
+export declare function useForm<TForm>(data: TForm): InertiaForm<TForm>
 
-export const Link: InertiaLink
+export declare function useForm<TForm>(rememberKey: string, data: TForm): InertiaForm<TForm>
 
-export const plugin: {
-  install(app: App): void
-}
+export declare function useRemember(data: object, key?: string): Ref<object>
 
 export declare function usePage<CustomPageProps extends Inertia.PageProps = Inertia.PageProps>(): {
   props: ComputedRef<CustomPageProps>
@@ -77,12 +83,6 @@ export declare function usePage<CustomPageProps extends Inertia.PageProps = Iner
   component: ComputedRef<string>
   version: ComputedRef<string | null>
 }
-
-export declare function useRemember(data: object, key?: string): Ref<object>
-
-export declare function useForm<TForm>(data: TForm): InertiaForm<TForm>
-
-export declare function useForm<TForm>(rememberKey: string, data: TForm): InertiaForm<TForm>
 
 declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {


### PR DESCRIPTION
Some change is refer to [Inertia React Adapter's type definition file](https://github.com/inertiajs/inertia/blob/master/packages/inertia-react/index.d.ts)

Update list:
* Rename Form type to `InertiaForm` and `InertiaFormProps`
* Rename `Data` type to `TForm`
* Change `errors` property type to `Record`
* Remove `serialize()` and `unserialize()` methods
* Add `useForm()` overload
* Code formatting