### PR TITLE
Fix 'remember' issue for null values

### DIFF
--- a/packages/inertia-vue/src/remember.js
+++ b/packages/inertia-vue/src/remember.js
@@ -29,7 +29,7 @@ export default {
     })
 
     rememberable.forEach(key => {
-      const hasCallacks = typeof this[key].__remember === 'function' && typeof this[key].__restore === 'function'
+      const hasCallacks = this[key] !== null && typeof this[key].__remember === 'function' && typeof this[key].__restore === 'function'
 
       if (this[key] !== undefined && restored !== undefined && restored[key] !== undefined) {
         hasCallacks ? this[key].__restore(restored[key]) : (this[key] = restored[key])

--- a/packages/inertia-vue/src/remember.js
+++ b/packages/inertia-vue/src/remember.js
@@ -25,21 +25,26 @@ export default {
     const restored = Inertia.restore(rememberKey)
 
     const rememberable = this.$options.remember.data.filter(key => {
-      return !(typeof this[key] === 'object' && this[key] !== null && this[key].__rememberable === false)
+      return !(this[key] !== null && typeof this[key] === 'object' && this[key].__rememberable === false)
     })
 
-    rememberable.forEach(key => {
-      const hasCallacks = this[key] !== null && typeof this[key].__remember === 'function' && typeof this[key].__restore === 'function'
+    const hasCallacks = (key) => {
+      return this[key] !== null
+        && typeof this[key] === 'object'
+        && typeof this[key].__remember === 'function'
+        && typeof this[key].__restore === 'function'
+    }
 
+    rememberable.forEach(key => {
       if (this[key] !== undefined && restored !== undefined && restored[key] !== undefined) {
-        hasCallacks ? this[key].__restore(restored[key]) : (this[key] = restored[key])
+        hasCallacks(key) ? this[key].__restore(restored[key]) : (this[key] = restored[key])
       }
 
       this.$watch(key, () => {
         Inertia.remember(
           rememberable.reduce((data, key) => ({
             ...data,
-            [key]: hasCallacks ? this[key].__remember(): this[key],
+            [key]: hasCallacks(key) ? this[key].__remember(): this[key],
           }), {}),
           rememberKey,
         )

--- a/packages/inertia-vue3/src/remember.js
+++ b/packages/inertia-vue3/src/remember.js
@@ -26,21 +26,26 @@ export default {
     const restored = Inertia.restore(rememberKey)
 
     const rememberable = this.$options.remember.data.filter(key => {
-      return !(typeof this[key] === 'object' && this[key] !== null && this[key].__rememberable === false)
+      return !(this[key] !== null && typeof this[key] === 'object' && this[key].__rememberable === false)
     })
 
-    rememberable.forEach(key => {
-      const hasCallacks = typeof this[key].__remember === 'function' && typeof this[key].__restore === 'function'
+    const hasCallacks = (key) => {
+      return this[key] !== null
+        && typeof this[key] === 'object'
+        && typeof this[key].__remember === 'function'
+        && typeof this[key].__restore === 'function'
+    }
 
+    rememberable.forEach(key => {
       if (this[key] !== undefined && restored !== undefined && restored[key] !== undefined) {
-        hasCallacks ? this[key].__restore(restored[key]) : (this[key] = restored[key])
+        hasCallacks(key) ? this[key].__restore(restored[key]) : (this[key] = restored[key])
       }
 
       this.$watch(key, () => {
         Inertia.remember(
           rememberable.reduce((data, key) => ({
             ...data,
-            [key]: cloneDeep(hasCallacks ? this[key].__remember(): this[key]),
+            [key]: cloneDeep(hasCallacks(key) ? this[key].__remember(): this[key]),
           }), {}),
           rememberKey,
         )


### PR DESCRIPTION
This PR fixes #620 by checking whether a value is `null` before the `typeof this[key].__remember === 'function'` check. After making this change, the remember functionality started working as expected again.

Quick note: I had a look around the codebase to see if the optional chaining operator (`?.`) syntax was used anywhere but couldn't see it so didn't use it here. The syntax could however be cleaned up a bit by using:

```js
const hasCallacks = typeof this[key]?.__remember === 'function' && typeof this[key]?.__restore === 'function'
```

Let me know if there are any questions or if any changes are needed.
