### PR TITLE
Remove "onBeforeRender" event and add "errors" option to preserveScroll and preserveState

### DIFF
--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -97,27 +97,31 @@ export default function(...args) {
             return options.onProgress(event)
           }
         },
-        onBeforeRender: page => {
-          cancelToken = null
-          this.processing = false
-          this.progress = null
-          this.errors = page.resolvedErrors
-          this.hasErrors = Object.keys(this.errors).length > 0
-          this.wasSuccessful = !this.hasErrors
-          this.recentlySuccessful = !this.hasErrors
+        onSuccess: page => {
+          this.clearErrors()
+          this.wasSuccessful = true
+          this.recentlySuccessful = true
           recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
 
-          if (options.onBeforeRender) {
-            return options.onBeforeRender(page)
+          if (options.onSuccess) {
+            return options.onSuccess(page)
           }
         },
-        onCancel: () => {
+        onError: errors => {
+          this.errors = errors
+          this.hasErrors = true
+
+          if (options.onError) {
+            return options.onError(errors)
+          }
+        },
+        onFinish: () => {
           cancelToken = null
           this.processing = false
           this.progress = null
 
-          if (options.onCancel) {
-            return options.onCancel()
+          if (options.onFinish) {
+            return options.onFinish()
           }
         },
       }

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -97,27 +97,31 @@ export default function useForm(...args) {
             return options.onProgress(event)
           }
         },
-        onBeforeRender: page => {
-          cancelToken = null
-          this.processing = false
-          this.progress = null
-          this.errors = page.resolvedErrors
-          this.hasErrors = Object.keys(this.errors).length > 0
-          this.wasSuccessful = !this.hasErrors
-          this.recentlySuccessful = !this.hasErrors
+        onSuccess: page => {
+          this.clearErrors()
+          this.wasSuccessful = true
+          this.recentlySuccessful = true
           recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
 
-          if (options.onBeforeRender) {
-            return options.onBeforeRender(page)
+          if (options.onSuccess) {
+            return options.onSuccess(page)
           }
         },
-        onCancel: () => {
+        onError: errors => {
+          this.errors = errors
+          this.hasErrors = true
+
+          if (options.onError) {
+            return options.onError(errors)
+          }
+        },
+        onFinish: () => {
           cancelToken = null
           this.processing = false
           this.progress = null
 
-          if (options.onCancel) {
-            return options.onCancel()
+          if (options.onFinish) {
+            return options.onFinish()
           }
         },
       }


### PR DESCRIPTION
This PR reverts a previous change (#410) that added a new `onBeforeRender()` event, used by the Vue 2 and Vue 3 form helpers to set form state earlier in the visit lifecycle. As it turns out, this creates other issues, such as the page props being out of date when `form.processing` returns back to `false`.

The entire motivation with adding `onBeforeRender()` was to simplify this:

```js
preserveScroll: (page) => Object.keys(page.props.errors).length > 0,
preserveState: (page) => Object.keys(page.props.errors).length > 0,
```
To this:

```js
preserveScroll: () => this.form.hasErrors,
preserveState: () => this.form.hasErrors,
```

Instead of solving the problem that way, I've introduced a new option to `preserveScroll` and `preserveState` specifically for preserving the scroll/state when there are errors:

```js
preserveScroll: 'errors',
preserveState: 'errors',
```

Overall I think this is a much better solution. 👍