### PR TITLE
Fix "processing" and "progress" form helper state

### DIFF
--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -51,6 +51,8 @@ export default function useForm(...args) {
           }
         },
         onSuccess: (page) => {
+          setProcessing(false)
+          setProgress(null)
           setErrors({})
           setHasErrors(false)
           setWasSuccessful(true)
@@ -62,6 +64,8 @@ export default function useForm(...args) {
           }
         },
         onError: (errors) => {
+          setProcessing(false)
+          setProgress(null)
           setErrors(errors)
           setHasErrors(true)
 
@@ -69,10 +73,16 @@ export default function useForm(...args) {
             return options.onError(errors)
           }
         },
-        onFinish: () => {
-          cancelToken.current = null
+        onCancel: () => {
           setProcessing(false)
           setProgress(null)
+
+          if (options.onCancel) {
+            return options.onCancel()
+          }
+        },
+        onFinish: () => {
+          cancelToken.current = null
 
           if (options.onFinish) {
             return options.onFinish()

--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -100,6 +100,8 @@ function useForm(...args) {
           }
         },
         onSuccess: page => {
+          this.setStore('processing', false)
+          this.setStore('progress', null)
           this.clearErrors()
           this.setStore('wasSuccessful', true)
           this.setStore('recentlySuccessful', true)
@@ -110,6 +112,8 @@ function useForm(...args) {
           }
         },
         onError: errors => {
+          this.setStore('processing', false)
+          this.setStore('progress', null)
           this.setStore('errors', errors)
           this.setStore('hasErrors', true)
 
@@ -117,10 +121,16 @@ function useForm(...args) {
             return options.onError(errors)
           }
         },
-        onFinish: () => {
-          cancelToken = null
+        onCancel: () => {
           this.setStore('processing', false)
           this.setStore('progress', null)
+
+          if (options.onCancel) {
+            return options.onCancel()
+          }
+        },
+        onFinish: () => {
+          cancelToken = null
 
           if (options.onFinish) {
             return options.onFinish()

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -98,6 +98,8 @@ export default function(...args) {
           }
         },
         onSuccess: page => {
+          this.processing = false
+          this.progress = null
           this.clearErrors()
           this.wasSuccessful = true
           this.recentlySuccessful = true
@@ -108,6 +110,8 @@ export default function(...args) {
           }
         },
         onError: errors => {
+          this.processing = false
+          this.progress = null
           this.errors = errors
           this.hasErrors = true
 
@@ -115,10 +119,16 @@ export default function(...args) {
             return options.onError(errors)
           }
         },
-        onFinish: () => {
-          cancelToken = null
+        onCancel: () => {
           this.processing = false
           this.progress = null
+
+          if (options.onCancel) {
+            return options.onCancel()
+          }
+        },
+        onFinish: () => {
+          cancelToken = null
 
           if (options.onFinish) {
             return options.onFinish()

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -98,6 +98,8 @@ export default function useForm(...args) {
           }
         },
         onSuccess: page => {
+          this.processing = false
+          this.progress = null
           this.clearErrors()
           this.wasSuccessful = true
           this.recentlySuccessful = true
@@ -108,6 +110,8 @@ export default function useForm(...args) {
           }
         },
         onError: errors => {
+          this.processing = false
+          this.progress = null
           this.errors = errors
           this.hasErrors = true
 
@@ -115,10 +119,16 @@ export default function useForm(...args) {
             return options.onError(errors)
           }
         },
-        onFinish: () => {
-          cancelToken = null
+        onCancel: () => {
           this.processing = false
           this.progress = null
+
+          if (options.onCancel) {
+            return options.onCancel()
+          }
+        },
+        onFinish: () => {
+          cancelToken = null
 
           if (options.onFinish) {
             return options.onFinish()


### PR DESCRIPTION
This PR fixes an issue with the form helper where the `processing` and `progress` states were out of date when using custom event callbacks:

```js
this.form.post('/users', {
  onSuccess: () => {
    console.log(this.form.processing)
    // Before: true
    // After: false
  },
})
```

Previously we set these values in the `onFinish` event callback, which runs after the `onSuccess`, `onError` callbacks. With this update, we now set these values within the `onSuccess`, `onError` and `onCancel` callbacks, so that they are immediately available.