### PR TITLE
Add name to the Inertia link component in the Vue 3 adapter

### DIFF
--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -2,6 +2,7 @@ import { h } from 'vue'
 import { hrefToUrl, Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
 
 export default {
+  name: 'InertiaLink',
   props: {
     as: {
       type: String,


### PR DESCRIPTION
Closes #636

For some reason the Vue 3 adapter shows the `<inertia-link>` component as an anonymous component in the dev tools, even though we're registering it the same way as the Vue 2 adapter. This PR adds an explicit component name to fix that.