### PR TITLE
Add form helper `isDirty` feature

### DIFF
--- a/packages/inertia-react/package.json
+++ b/packages/inertia-react/package.json
@@ -39,5 +39,8 @@
   "peerDependencies": {
     "@inertiajs/inertia": "^0.8.0",
     "react": "^16.9.0 || ^17.0.0"
+  },
+  "dependencies": {
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -1,3 +1,4 @@
+import isEqual from 'lodash.isequal'
 import { Inertia } from '@inertiajs/inertia'
 import { useCallback, useRef, useState } from 'react'
 import useRemember from './useRemember'
@@ -112,6 +113,7 @@ export default function useForm(...args) {
         setData(key)
       }
     },
+    isDirty: !isEqual(data, defaults),
     errors,
     hasErrors,
     processing,

--- a/packages/inertia-svelte/package.json
+++ b/packages/inertia-svelte/package.json
@@ -27,5 +27,8 @@
   "peerDependencies": {
     "@inertiajs/inertia": "^0.8.0",
     "svelte": "^3.20.0"
+  },
+  "dependencies": {
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -1,17 +1,19 @@
-import { Inertia } from '@inertiajs/inertia'
+import isEqual from 'lodash.isequal'
 import { writable } from 'svelte/store'
+import { Inertia } from '@inertiajs/inertia'
 
 function useForm(...args) {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
-  const defaults = data
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
+  let defaults = data
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
 
   const store = writable({
     ...restored ? restored.data : data,
+    isDirty: false,
     errors: restored ? restored.errors : {},
     hasErrors: false,
     progress: null,
@@ -99,7 +101,7 @@ function useForm(...args) {
             return options.onProgress(event)
           }
         },
-        onSuccess: page => {
+        onSuccess: async page => {
           this.setStore('processing', false)
           this.setStore('progress', null)
           this.clearErrors()
@@ -107,9 +109,10 @@ function useForm(...args) {
           this.setStore('recentlySuccessful', true)
           recentlySuccessfulTimeoutId = setTimeout(() => this.setStore('recentlySuccessful', false), 2000)
 
-          if (options.onSuccess) {
-            return options.onSuccess(page)
-          }
+          const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
+          defaults = this.data()
+          this.setStore('isDirty', false)
+          return onSuccess
         },
         onError: errors => {
           this.setStore('processing', false)
@@ -168,9 +171,15 @@ function useForm(...args) {
     },
   })
 
-  if (rememberKey) {
-    store.subscribe(form => Inertia.remember({ data: form.data(), errors: form.errors }, rememberKey))
-  }
+  store.subscribe(form => {
+    if (form.isDirty === isEqual(form.data(), defaults)) {
+      form.setStore('isDirty', !form.isDirty)
+    }
+
+    if (rememberKey) {
+      Inertia.remember({ data: form.data(), errors: form.errors }, rememberKey)
+    }
+  })
 
   return store
 }

--- a/packages/inertia-vue/package.json
+++ b/packages/inertia-vue/package.json
@@ -38,6 +38,7 @@
     "vue": "^2.6.0"
   },
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0"
+    "lodash.clonedeep": "^4.5.0",
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import isEqual from 'lodash.isequal'
 import cloneDeep from 'lodash.clonedeep'
 import { Inertia } from '@inertiajs/inertia'
 
@@ -179,7 +180,7 @@ export default function(...args) {
   new Vue({
     created() {
       this.$watch(() => form, newValue => {
-        form.isDirty = JSON.stringify(form.data()) !== JSON.stringify(form.__defaults)
+        form.isDirty = !isEqual(form.data(), form.__defaults)
         if (rememberKey) {
           Inertia.remember(newValue.__remember(), rememberKey)
         }

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -7,12 +7,12 @@ export default function(...args) {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
+  let defaults = cloneDeep(data)
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
 
   const form = Vue.observable({
-    __defaults: cloneDeep(data),
     ...restored ? restored.data : data,
     isDirty: false,
     errors: restored ? restored.errors : {},
@@ -35,7 +35,7 @@ export default function(...args) {
       return this
     },
     reset(...fields) {
-      let clonedDefaults = cloneDeep(this.__defaults)
+      let clonedDefaults = cloneDeep(defaults)
       if (fields.length === 0) {
         Object.assign(this, clonedDefaults)
       } else {
@@ -108,7 +108,8 @@ export default function(...args) {
           recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
 
           const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
-          this.__defaults = cloneDeep(this.data())
+          defaults = cloneDeep(this.data())
+          this.isDirty = false
           return onSuccess
         },
         onError: errors => {
@@ -180,7 +181,7 @@ export default function(...args) {
   new Vue({
     created() {
       this.$watch(() => form, newValue => {
-        form.isDirty = !isEqual(form.data(), form.__defaults)
+        form.isDirty = !isEqual(form.data(), defaults)
         if (rememberKey) {
           Inertia.remember(newValue.__remember(), rememberKey)
         }

--- a/packages/inertia-vue3/package.json
+++ b/packages/inertia-vue3/package.json
@@ -37,6 +37,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0"
+    "lodash.clonedeep": "^4.5.0",
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -7,12 +7,12 @@ export default function useForm(...args) {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
+  let defaults = cloneDeep(data)
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
 
   let form = reactive({
-    __defaults: cloneDeep(data),
     ...restored ? restored.data : data,
     isDirty: false,
     errors: restored ? restored.errors : {},
@@ -35,7 +35,7 @@ export default function useForm(...args) {
       return this
     },
     reset(...fields) {
-      let clonedDefaults = cloneDeep(this.__defaults)
+      let clonedDefaults = cloneDeep(defaults)
       if (fields.length === 0) {
         Object.assign(this, clonedDefaults)
       } else {
@@ -108,7 +108,8 @@ export default function useForm(...args) {
           recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
 
           const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
-          this.__defaults = cloneDeep(this.data())
+          defaults = cloneDeep(this.data())
+          this.isDirty = false
           return onSuccess
         },
         onError: errors => {
@@ -178,7 +179,7 @@ export default function useForm(...args) {
   })
 
   watch(form, newValue => {
-    form.isDirty = !isEqual(form.data(), form.__defaults)
+    form.isDirty = !isEqual(form.data(), defaults)
     if (rememberKey) {
       Inertia.remember(cloneDeep(newValue.__remember()), rememberKey)
     }

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -1,3 +1,4 @@
+import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
 import cloneDeep from 'lodash.clonedeep'
 import { Inertia } from '@inertiajs/inertia'
@@ -177,7 +178,7 @@ export default function useForm(...args) {
   })
 
   watch(form, newValue => {
-    form.isDirty = JSON.stringify(form.data()) !== JSON.stringify(form.__defaults)
+    form.isDirty = !isEqual(form.data(), form.__defaults)
     if (rememberKey) {
       Inertia.remember(cloneDeep(newValue.__remember()), rememberKey)
     }

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -5,14 +5,15 @@ import { Inertia } from '@inertiajs/inertia'
 export default function useForm(...args) {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
-  const defaults = cloneDeep(data)
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
 
   let form = reactive({
+    __defaults: cloneDeep(data),
     ...restored ? restored.data : data,
+    isDirty: false,
     errors: restored ? restored.errors : {},
     hasErrors: false,
     processing: false,
@@ -33,7 +34,7 @@ export default function useForm(...args) {
       return this
     },
     reset(...fields) {
-      let clonedDefaults = cloneDeep(defaults)
+      let clonedDefaults = cloneDeep(this.__defaults)
       if (fields.length === 0) {
         Object.assign(this, clonedDefaults)
       } else {
@@ -97,7 +98,7 @@ export default function useForm(...args) {
             return options.onProgress(event)
           }
         },
-        onSuccess: page => {
+        onSuccess: async page => {
           this.processing = false
           this.progress = null
           this.clearErrors()
@@ -105,9 +106,9 @@ export default function useForm(...args) {
           this.recentlySuccessful = true
           recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
 
-          if (options.onSuccess) {
-            return options.onSuccess(page)
-          }
+          const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
+          this.__defaults = cloneDeep(this.data())
+          return onSuccess
         },
         onError: errors => {
           this.processing = false
@@ -173,11 +174,12 @@ export default function useForm(...args) {
     },
   })
 
-  if (rememberKey) {
-    watch(form, newValue => {
+  watch(form, newValue => {
+    form.isDirty = JSON.stringify(form.data()) !== JSON.stringify(form.__defaults)
+    if (rememberKey) {
       Inertia.remember(cloneDeep(newValue.__remember()), rememberKey)
-    }, { immediate: true, deep: true })
-  }
+    }
+  }, { immediate: true, deep: true })
 
   return form
 }


### PR DESCRIPTION
This PR adds a new `isDirty` property to the form helper, which indicates whether the current form data is different from the default form data provided. This can be used to show a "there are unsaved form changes" message to the user.

With this update, we now automatically replace the default form data with the current form data on successful submit. This is important, since we compare the default form data with the current form data to determine if the form is dirty. If we didn't update the default form data, the form would remain dirty even after submitting it.

- [x] Vue 2
- [x] Vue 3
- [x] React
- [x] Svelte

https://user-images.githubusercontent.com/882133/117467251-82e8ab80-af21-11eb-86de-0390981cd4b1.mov