### PR TITLE
Add data to reload visit options

### DIFF
--- a/packages/inertia/index.d.ts
+++ b/packages/inertia/index.d.ts
@@ -74,7 +74,7 @@ interface Inertia {
 
   delete: (url: string, options?: VisitOptions) => Promise<void>
 
-  reload: (options?: VisitOptions) => Promise<void>
+  reload: (options?: VisitOptions & { data?: object }) => Promise<void>
 
   replace: (url: string, options?: VisitOptions) => Promise<void>
 


### PR DESCRIPTION
Data property should be available with `reload` because it's calling `visit` behind the scense
```js
reload(options = {}) {
  return this.visit(window.location.href, { ...options, preserveScroll: true, preserveState: true })
},
```
```ts
visit: (
  url: string,
  options?: VisitOptions & { data?: object }
) => Promise<void>
```