### PR TITLE
Extend hasFiles to support FormData

### DIFF
--- a/packages/inertia/src/files.js
+++ b/packages/inertia/src/files.js
@@ -3,4 +3,5 @@ export function hasFiles(data) {
     || data instanceof Blob
     || data instanceof FileList
     || (typeof data === 'object' && data !== null && Object.values(data).find(value => hasFiles(value)) !== undefined)
+    || data instanceof FormData && Array.from(data.values()).some(value => hasFiles(value))
 }

--- a/packages/inertia/src/files.js
+++ b/packages/inertia/src/files.js
@@ -2,6 +2,6 @@ export function hasFiles(data) {
   return data instanceof File
     || data instanceof Blob
     || data instanceof FileList
-    || (typeof data === 'object' && data !== null && Object.values(data).find(value => hasFiles(value)) !== undefined)
     || data instanceof FormData && Array.from(data.values()).some(value => hasFiles(value))
+    || (typeof data === 'object' && data !== null && Object.values(data).find(value => hasFiles(value)) !== undefined)
 }

--- a/packages/inertia/src/formData.js
+++ b/packages/inertia/src/formData.js
@@ -1,4 +1,8 @@
 export function objectToFormData(object, formData = new FormData(), parent = null) {
+  if (object instanceof FormData) {
+    return object;
+  }
+
   if (object === null || object === 'undefined' || object.length === 0) {
     return formData.append(parent, object)
   }

--- a/packages/inertia/src/formData.js
+++ b/packages/inertia/src/formData.js
@@ -1,6 +1,6 @@
 export function objectToFormData(object, formData = new FormData(), parent = null) {
   if (object instanceof FormData) {
-    return object;
+    return object
   }
 
   if (object === null || object === 'undefined' || object.length === 0) {

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -201,7 +201,7 @@ export default {
     [url, data] = mergeDataIntoQueryString(method, hrefToUrl(url), data)
 
     const visitHasFiles = hasFiles(data)
-    if (method !== 'get' && (visitHasFiles || forceFormData)) {
+    if (method !== 'get' && (visitHasFiles || forceFormData) && !(data instanceof FormData)) {
       data = objectToFormData(data)
     }
 

--- a/packages/inertia/src/inertia.js
+++ b/packages/inertia/src/inertia.js
@@ -201,7 +201,7 @@ export default {
     [url, data] = mergeDataIntoQueryString(method, hrefToUrl(url), data)
 
     const visitHasFiles = hasFiles(data)
-    if (method !== 'get' && (visitHasFiles || forceFormData) && !(data instanceof FormData)) {
+    if (method !== 'get' && (visitHasFiles || forceFormData)) {
       data = objectToFormData(data)
     }
 


### PR DESCRIPTION
### Overview
This change makes the `hasFiles` function able to determine if files are included in a `FormData` object.

### Reasoning
I'm currently developing a project that uses [an unofficial port of Inertia](https://github.com/Nothing-Works/inertia-aspnetcore) in an ASP.NET Core environment. To make sure file lists are correctly translated into view models, i need to make sure they are added with the same name without indices attached to the name, as illustrated below:
```js
const formData = new FormData();

formData.append("files", new File([], "file1"));
formData.append("files", new File([], "file2"));
```
In the current version of Inertia, i *can* add an object like the above as a parameter to a visit, but due to Inertia not knowing there are files included in the form, no progress events are being fired, preventing me from displaying a progress bar in my UI.