### PR TITLE
End processing in the onFinish callback

### DIFF
--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -51,7 +51,6 @@ export default function useForm(...args) {
           }
         },
         onSuccess: (page) => {
-          setProcessing(false)
           setProgress(null)
           setErrors({})
           setHasErrors(false)
@@ -64,7 +63,6 @@ export default function useForm(...args) {
           }
         },
         onError: (errors) => {
-          setProcessing(false)
           setProgress(null)
           setErrors(errors)
           setHasErrors(true)
@@ -74,7 +72,6 @@ export default function useForm(...args) {
           }
         },
         onCancel: () => {
-          setProcessing(false)
           setProgress(null)
 
           if (options.onCancel) {
@@ -82,6 +79,7 @@ export default function useForm(...args) {
           }
         },
         onFinish: () => {
+          setProcessing(false)
           cancelToken.current = null
 
           if (options.onFinish) {

--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -100,7 +100,6 @@ function useForm(...args) {
           }
         },
         onSuccess: page => {
-          this.setStore('processing', false)
           this.setStore('progress', null)
           this.clearErrors()
           this.setStore('wasSuccessful', true)
@@ -112,7 +111,6 @@ function useForm(...args) {
           }
         },
         onError: errors => {
-          this.setStore('processing', false)
           this.setStore('progress', null)
           this.setStore('errors', errors)
           this.setStore('hasErrors', true)
@@ -122,7 +120,6 @@ function useForm(...args) {
           }
         },
         onCancel: () => {
-          this.setStore('processing', false)
           this.setStore('progress', null)
 
           if (options.onCancel) {
@@ -130,6 +127,7 @@ function useForm(...args) {
           }
         },
         onFinish: () => {
+          this.setStore('processing', false)
           cancelToken = null
 
           if (options.onFinish) {

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -98,7 +98,6 @@ export default function useForm(...args) {
           }
         },
         onSuccess: page => {
-          this.processing = false
           this.progress = null
           this.clearErrors()
           this.wasSuccessful = true
@@ -110,7 +109,6 @@ export default function useForm(...args) {
           }
         },
         onError: errors => {
-          this.processing = false
           this.progress = null
           this.errors = errors
           this.hasErrors = true
@@ -120,7 +118,6 @@ export default function useForm(...args) {
           }
         },
         onCancel: () => {
-          this.processing = false
           this.progress = null
 
           if (options.onCancel) {
@@ -128,6 +125,7 @@ export default function useForm(...args) {
           }
         },
         onFinish: () => {
+          this.processing = false
           cancelToken = null
 
           if (options.onFinish) {


### PR DESCRIPTION
It makes sense to me that processing would end regardless of a successful, canceled, or errored request. Right now if my server throws a 500, the form is still "processing" even though it's not _really_ processing anything. The state of my form is now stuck processing.

In my case I have a loading state. An exception gets thrown and I can display a nice error, but the form state doesn't reset. If all roads lead to `onFinish` it makes sense to return `processing` to false in that callback.