### PR TITLE
Add `const App` type in inertia-react.

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -60,6 +60,8 @@ export const Link: InertiaLink
 
 export const InertiaApp: App
 
+export const App: App
+
 type setDataByObject<TForm> = (data: TForm) => void
 type setDataByMethod<TForm> = (data: (previousData: TForm) => TForm) => void
 type setDataByKeyValuePair<TForm> = <K extends keyof TForm>(key: K, value: TForm[K]) => void


### PR DESCRIPTION
This PR add `const App` type that has been lacked in `inertia-react`. The same type definition has already been defined in `inertia-vue`. Please see the following code:

https://github.com/inertiajs/inertia/blob/bf5a17e2cff21d0caec85b7c4ee8fbacd63c4500/packages/inertia-vue/index.d.ts#L78

It also solves the issue: https://github.com/inertiajs/inertiajs.com/pull/181 without changing the document.