### PR TITLE
Unify `onHeadUpdate` prop across adapters

### DIFF
--- a/packages/inertia-react/src/App.js
+++ b/packages/inertia-react/src/App.js
@@ -18,12 +18,7 @@ export default function App({
   })
 
   const headManager = useMemo(() => {
-    const isServer = typeof window === 'undefined'
-    const headManager = createHeadManager(isServer)
-    if (isServer && onHeadUpdate) {
-      headManager.onUpdate(onHeadUpdate)
-    }
-    return headManager
+    return createHeadManager(typeof window === 'undefined', onHeadUpdate || (() => {}))
   }, [])
 
   useEffect(() => {

--- a/packages/inertia-vue/src/app.js
+++ b/packages/inertia-vue/src/app.js
@@ -26,6 +26,11 @@ export default {
       type: Function,
       required: false,
     },
+    onHeadUpdate: {
+      type: Function,
+      required: false,
+      default: () => () => {},
+    },
   },
   data() {
     return {
@@ -36,10 +41,9 @@ export default {
   },
   created() {
     app = this
-    headManager = createHeadManager(this.$isServer)
-    if (this.$isServer) {
-      headManager.onUpdate(elements => (this.$ssrContext.head = elements))
-    } else {
+    headManager = createHeadManager(this.$isServer, this.onHeadUpdate)
+
+    if (!this.$isServer) {
       Inertia.init({
         initialPage: this.initialPage,
         resolveComponent: this.resolveComponent,

--- a/packages/inertia/src/head.ts
+++ b/packages/inertia/src/head.ts
@@ -41,14 +41,12 @@ const Renderer = {
   }, 1),
 }
 
-export default function (isServer: boolean): ({
-  onUpdate(callback: (elements: string[]) => void): void,
+export default function (isServer: boolean, onUpdate: ((elements: string[]) => void)): ({
   createProvider: () => ({
     update: (elements: Array<string>) => void,
     disconnect: () => void,
   })
 }) {
-  let onUpdate: null|((elements: string[]) => void) = null
   const states: Record<string, Array<string>> = {}
   let lastProviderId = 0
 
@@ -102,19 +100,10 @@ export default function (isServer: boolean): ({
   }
 
   function commit(): void {
-    if (onUpdate !== null) {
-      onUpdate(collect())
-    }
-
-    if (isServer !== undefined && !isServer) {
-      Renderer.update(collect())
-    }
+    isServer ? onUpdate(collect()) : Renderer.update(collect())
   }
 
   return {
-    onUpdate(callback) {
-      onUpdate = callback
-    },
     createProvider: function () {
       const id = connect()
 


### PR DESCRIPTION
This PR updates the Vue 2, Vue 3 and React adapters to all use an `onHeadUpdate()` prop for handling `<head>` updates in SSR mode. It also tweaks the `createHeadManager()` method to require an `onUpdate()` callback, where previously this was set using `headManager.onUpdate(callback)`.