### PR TITLE
Initial component

### DIFF
--- a/packages/inertia-react/src/App.js
+++ b/packages/inertia-react/src/App.js
@@ -6,12 +6,13 @@ import { createElement, useEffect, useMemo, useState } from 'react'
 export default function App({
   children,
   initialPage,
+  initialComponent,
   resolveComponent,
   onHeadUpdate,
 }) {
   const [current, setCurrent] = useState({
-    component: resolveComponent(initialPage.component),
-    page: initialPage,
+    component: initialComponent || null,
+    page: initialComponent ? initialPage : null,
     key: null,
   })
 

--- a/packages/inertia-vue/src/app.js
+++ b/packages/inertia-vue/src/app.js
@@ -14,9 +14,13 @@ export default {
       type: Object,
       required: true,
     },
+    initialComponent: {
+      type: Object,
+      required: false,
+    },
     resolveComponent: {
       type: Function,
-      required: true,
+      required: false,
     },
     onHeadUpdate: {
       type: Function,
@@ -26,8 +30,8 @@ export default {
   },
   data() {
     return {
-      component: this.resolveComponent(this.initialPage.component),
-      page: this.initialPage,
+      component: this.initialComponent || null,
+      page: this.initialComponent ? this.initialPage : null,
       key: null,
     }
   },

--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -17,9 +17,13 @@ export default {
       type: Object,
       required: true,
     },
+    initialComponent: {
+      type: Object,
+      required: false,
+    },
     resolveComponent: {
       type: Function,
-      required: true,
+      required: false,
     },
     onHeadUpdate: {
       type: Function,
@@ -27,9 +31,9 @@ export default {
       default: () => () => {},
     },
   },
-  setup({ initialPage, resolveComponent, onHeadUpdate }) {
-    component.value = markRaw(resolveComponent(initialPage.component))
-    page.value = initialPage
+  setup({ initialPage, initialComponent, resolveComponent, onHeadUpdate }) {
+    component.value = initialComponent ? markRaw(initialComponent) : null
+    page.value = initialComponent ? initialPage : null
     key.value = null
 
     const isServer = typeof window === 'undefined'


### PR DESCRIPTION
Resolves #696

This PR adds a new `initialComponent` prop to the Vue 2, Vue 3 and React adapters. The primary purpose of this prop is for apps using SSR.

When running the app in Node, you no longer need to provide a `resolveComponent` prop. Instead, you now just provide a `initialComponent` instead.

```diff
- resolveComponent: (name) => require(`./Pages/${name}`).default,
+ initialComponent: require(`./Pages/${request.body.component}`).default,
```

When running an SSR-enable app in the browser, when using code-splitting, you can also pass in an `initialComponent` prop to ensure that client-side hydration works. Otherwise, if you don't do this, the first client-side render will not have the component on time, and will render blank, and hydration will fail.