### PR TITLE
Add createInertiaApp() method

### DIFF
--- a/packages/inertia-react/src/createInertiaApp.js
+++ b/packages/inertia-react/src/createInertiaApp.js
@@ -1,0 +1,35 @@
+import App from './App'
+import { createElement } from 'react'
+
+export default async function createInertiaApp({ id = 'app', resolve, setup, page, render }) {
+  const isServer = typeof window === 'undefined'
+  const el = isServer ? null : document.getElementById(id)
+  const initialPage = page || JSON.parse(el.dataset.page)
+  const resolveComponent = name => Promise.resolve(resolve(name)).then(module => module.default || module)
+
+  let head = []
+
+  const reactApp = await resolveComponent(initialPage.component).then(initialComponent => {
+    return setup({
+      el,
+      App,
+      props: {
+        initialPage,
+        initialComponent,
+        resolveComponent,
+        onHeadUpdate: isServer ? elements => (head = elements) : null,
+      },
+    })
+  })
+
+  if (isServer) {
+    const body = await render(
+      createElement('div', {
+        id,
+        'data-page': JSON.stringify(initialPage),
+      }, reactApp)
+    )
+
+    return { head, body }
+  }
+}

--- a/packages/inertia-react/src/index.js
+++ b/packages/inertia-react/src/index.js
@@ -1,5 +1,6 @@
 export { default as useForm } from './useForm'
 export { default as usePage } from './usePage'
+export { default as createInertiaApp } from './createInertiaApp'
 export { default as Head, default as InertiaHead } from './Head'
 export { default as useRemember, useRememberedState } from './useRemember'
 export { default as App, default as app, default as InertiaApp } from './App'

--- a/packages/inertia-svelte/src/createInertiaApp.js
+++ b/packages/inertia-svelte/src/createInertiaApp.js
@@ -1,0 +1,27 @@
+import App from './App'
+
+export default async function createInertiaApp({ id = 'app', resolve, setup, page, render }) {
+  const isServer = typeof window === 'undefined'
+  const el = isServer ? null : document.getElementById(id)
+  const initialPage = page || JSON.parse(el.dataset.page)
+  const resolveComponent = name => Promise.resolve(resolve(name))
+
+  let head = []
+
+  const svelteApp = await resolveComponent(initialPage.component).then(initialComponent => {
+    return setup({
+      el,
+      App,
+      props: {
+        initialPage,
+        initialComponent,
+        resolveComponent,
+        onHeadUpdate: isServer ? elements => (head = elements) : null,
+      },
+    })
+  })
+
+  if (isServer) {
+    // TODO
+  }
+}

--- a/packages/inertia-svelte/src/index.js
+++ b/packages/inertia-svelte/src/index.js
@@ -1,6 +1,7 @@
 export { default as page } from './page'
 export { default as inertia } from './link'
 export { default as useForm } from './useForm'
+export { default as createInertiaApp } from './createInertiaApp'
 export { default as useRemember, default as remember } from './useRemember'
 export { default as App, default as app, default as InertiaApp } from './App.svelte'
 export { default as Link, default as link, default as InertiaLink } from './InertiaLink.svelte'

--- a/packages/inertia-vue/src/createInertiaApp.js
+++ b/packages/inertia-vue/src/createInertiaApp.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import app, { plugin } from './app'
 
-export default async function createInertiaApp({ id = 'app', resolve, setup, page, renderer }) {
+export default async function createInertiaApp({ id = 'app', resolve, setup, page, render }) {
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
   const initialPage = page || JSON.parse(el.dataset.page)
@@ -30,14 +30,8 @@ export default async function createInertiaApp({ id = 'app', resolve, setup, pag
     })
   })
 
-  if (! isServer) {
-    return vueApp
+  if (isServer) {
+    return render(vueApp)
+      .then(body => ({ head, body }))
   }
-
-  return new Promise((resolve, reject) => {
-    return renderer
-      .renderToString(vueApp)
-      .then(body => resolve({ head, body }))
-      .catch(error => reject(error))
-  })
 }

--- a/packages/inertia-vue/src/createInertiaApp.js
+++ b/packages/inertia-vue/src/createInertiaApp.js
@@ -1,0 +1,30 @@
+import Vue from 'vue'
+import app, { plugin } from './app'
+
+export default function createInertiaApp({ id = 'app', page, resolve, onHeadUpdate, setup }) {
+  const isServer = typeof window === 'undefined'
+  const el = isServer ? null : document.getElementById(id)
+  const initialPage = page || JSON.parse(el.dataset.page)
+  const resolveComponent = name => Promise.resolve(resolve(name)).then(module => module.default || module)
+
+  Vue.use(plugin)
+
+  return resolveComponent(initialPage.component).then(initialComponent => {
+    return setup({
+      el,
+      app,
+      props: {
+        attrs: {
+          id,
+          'data-page': JSON.stringify(initialPage),
+        },
+        props: {
+          initialPage,
+          initialComponent,
+          resolveComponent,
+          onHeadUpdate,
+        },
+      },
+    })
+  })
+}

--- a/packages/inertia-vue/src/index.js
+++ b/packages/inertia-vue/src/index.js
@@ -1,2 +1,3 @@
+export { default as createInertiaApp } from './createInertiaApp'
 export { default as Link, default as link, default as InertiaLink } from './link'
 export { default as App, default as app, plugin, default as InertiaApp } from './app'

--- a/packages/inertia-vue3/src/createInertiaApp.js
+++ b/packages/inertia-vue3/src/createInertiaApp.js
@@ -1,0 +1,37 @@
+import { createSSRApp, h } from 'vue'
+import { default as app, plugin } from './app'
+
+export default async function createInertiaApp({ id = 'app', resolve, setup, page, render }) {
+  const isServer = typeof window === 'undefined'
+  const el = isServer ? null : document.getElementById(id)
+  const initialPage = page || JSON.parse(el.dataset.page)
+  const resolveComponent = name => Promise.resolve(resolve(name)).then(module => module.default || module)
+
+  let head = []
+
+  const vueApp = await resolveComponent(initialPage.component).then(initialComponent => {
+    return setup({
+      el,
+      app,
+      props: {
+        initialPage,
+        initialComponent,
+        resolveComponent,
+        onHeadUpdate: isServer ? elements => (head = elements) : null,
+      },
+      plugin,
+    })
+  })
+
+  if (isServer) {
+    const body = await render(createSSRApp({
+      render: () => h('div', {
+        id,
+        'data-page': JSON.stringify(initialPage),
+        innerHTML: render(vueApp),
+      }),
+    }))
+
+    return { head, body }
+  }
+}

--- a/packages/inertia-vue3/src/index.js
+++ b/packages/inertia-vue3/src/index.js
@@ -1,4 +1,5 @@
 export { default as useForm } from './useForm'
 export { default as useRemember } from './useRemember'
 export { default as Link, default as link } from './link'
+export { default as createInertiaApp } from './createInertiaApp'
 export { default as App, default as app, plugin, usePage } from './app'


### PR DESCRIPTION
This PR adds a new `createInertiaApp()` method to the adapters, making Inertia easier to configure. Here is an example using the Vue 2 adapter:

```js
import Vue from 'vue'
import { createInertiaApp } from '@inertiajs/inertia-vue'

createInertiaApp({
  resolve: name => import(`./Pages/${name}`),
  setup({ el, app, props }) {
    new Vue({
      render: h => h(app, props),
    }).$mount(el)
  },
})
```

TODO:

- [x] Vue 2
- [x] Vue 3
- [x] React
- [x] Svelte