### PR TITLE
Rename `<inertia-head>` "inertia" key to "head-key"

### DIFF
--- a/packages/inertia-react/src/Head.js
+++ b/packages/inertia-react/src/Head.js
@@ -19,7 +19,7 @@ export default function InertiaHead({ children, title }) {
 
   function renderTagStart(node) {
     const attrs = Object.keys(node.props).reduce((carry, name) => {
-      if (['children', 'dangerouslySetInnerHTML'].includes(name)) {
+      if (['head-key', 'children', 'dangerouslySetInnerHTML'].includes(name)) {
         return carry
       }
       const value = node.props[name]
@@ -53,7 +53,9 @@ export default function InertiaHead({ children, title }) {
   }
 
   function ensureNodeHasInertiaProp(node) {
-    return React.cloneElement(node, { inertia: node.props.inertia || '' })
+    return React.cloneElement(node, {
+      inertia: node.props['head-key'] !== undefined ? node.props['head-key'] : '',
+    })
   }
 
   function renderNode(node) {

--- a/packages/inertia-vue/src/head.js
+++ b/packages/inertia-vue/src/head.js
@@ -25,7 +25,9 @@ export default {
       this.ensureNodeHasAttrs(node)
       const attrs = Object.keys(node.data.attrs).reduce((carry, name) => {
         const value = node.data.attrs[name]
-        if (value === '') {
+        if (name === 'head-key') {
+          return carry
+        } else if (value === '') {
           return carry + ` ${name}`
         } else {
           return carry + ` ${name}="${value}"`
@@ -59,7 +61,7 @@ export default {
     },
     ensureNodeHasInertiaAttribute(node) {
       this.ensureNodeHasAttrs(node)
-      node.data.attrs['inertia'] = node.data.attrs.inertia || ''
+      node.data.attrs['inertia'] = node.data.attrs['head-key'] !== undefined ? node.data.attrs['head-key'] : ''
       return node
     },
     renderNode(node) {

--- a/packages/inertia-vue3/src/head.js
+++ b/packages/inertia-vue3/src/head.js
@@ -25,7 +25,9 @@ export default {
       this.ensureNodeHasProps(node)
       const attrs = Object.keys(node.props).reduce((carry, name) => {
         const value = node.props[name]
-        if (value === '') {
+        if (['key', 'head-key'].includes(name)) {
+          return carry
+        } else if (value === '') {
           return carry + ` ${name}`
         } else {
           return carry + ` ${name}="${value}"`
@@ -58,7 +60,7 @@ export default {
     },
     ensureNodeHasInertiaAttribute(node) {
       this.ensureNodeHasProps(node)
-      node.props.inertia = node.props.inertia || ''
+      node.props.inertia = node.props['head-key'] !== undefined ? node.props['head-key'] : ''
       return node
     },
     renderNode(node) {

--- a/packages/inertia/src/head.ts
+++ b/packages/inertia/src/head.ts
@@ -4,7 +4,19 @@ const Renderer = {
   buildDOMElement(tag: string): ChildNode {
     const template = document.createElement('template')
     template.innerHTML = tag
-    return template.content.firstChild as ChildNode
+    const node = (template.content.firstChild as Element)
+
+    if (!tag.startsWith('<script ')) {
+      return node
+    }
+
+    const script = document.createElement('script')
+    script.innerHTML = node.innerHTML
+    node.getAttributeNames().forEach(name => {
+      script.setAttribute(name, node.getAttribute(name) || '')
+    })
+
+    return script
   },
 
   isInertiaManagedElement(element: Element): boolean {


### PR DESCRIPTION
This PR updates the `<inertia-head>` to use `head-key` instead of `inertia` when setting a unique key to prevent duplicate tags. Using "inertia" for this was confusing, as it doesn't really indicate its purpose at all. The term "key", on the other hand, is well known in client-side frameworks for identifying uniqueness. We would have just used `key`, but Vue uses this internally, so that wasn't possible.

```html
<!-- layout -->
<inertia-head>
  <meta head-key="description" name="description" content="This is the default description" />
</inertia-head>

<!-- page -->
<inertia-head>
  <meta head-key="description" name="description" content="This is a page specific description" />
</inertia-head>
```