### PR TITLE
fix: add mapped types to "on" handler

### DIFF
--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -4,7 +4,7 @@ import { hasFiles } from './files'
 import { objectToFormData } from './formData'
 import { AxiosResponse, default as Axios } from 'axios'
 import { hrefToUrl, mergeDataIntoQueryString, urlWithoutHash } from './url'
-import { ActiveVisit, LocationVisit, Method, Page, PageHandler, PageResolver, PreserveStateOption, RequestPayload, Visit, VisitId } from './types'
+import { ActiveVisit, LocationVisit, Method, Page, PageHandler, PageResolver, PreserveStateOption, RequestPayload, Visit, VisitId, GlobalEventCallbacks } from './types'
 import { fireBeforeEvent, fireErrorEvent, fireExceptionEvent, fireFinishEvent, fireInvalidEvent, fireNavigateEvent, fireProgressEvent, fireStartEvent, fireSuccessEvent } from './events'
 
 export class Router {
@@ -467,13 +467,13 @@ export class Router {
     return window.history.state?.rememberedState?.[key]
   }
 
-  public on(type: string, callback: CallableFunction): VoidFunction {
-    const listener: EventListener = event => {
+  public on<TType extends keyof GlobalEventCallbacks>(type: TType, callback: GlobalEventCallbacks[TType]): VoidFunction {
+    const listener = ((event: CustomEvent) => {
       const response = callback(event)
       if (event.cancelable && !event.defaultPrevented && response === false) {
         event.preventDefault()
       }
-    }
+    }) as EventListener
 
     document.addEventListener(`inertia:${type}`, listener)
     return () => document.removeEventListener(`inertia:${type}`, listener)

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -53,6 +53,27 @@ export interface Visit {
   interrupted: boolean,
 }
 
+export interface GlobalEventCallbacks {
+  before: (event: CustomEvent<{
+    visit: Visit
+  }>) => boolean | void
+  start: (event: CustomEvent<{
+    visit: Visit
+  }>) => void
+  progress: (event: CustomEvent) => void
+  success: (event: CustomEvent<{
+    page: Page
+  }>) => void
+  invalid: (event: CustomEvent) => void
+  error: (event: CustomEvent) => void
+  finish: (event: CustomEvent<{
+    visit: Visit
+  }>) => void
+  navigate: (event: CustomEvent<{
+    page: Page
+  }>) => void
+}
+
 export interface LocalEventCallbacks {
   onCancelToken?: { ({ cancel }: { cancel: VoidFunction }): void },
   onBefore: (visit: Visit) => boolean|void,


### PR DESCRIPTION
This PR adds mapped types to the "on" handler so the events are properly typed.