### PR TITLE
fix: fix types

### DIFF
--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -68,11 +68,11 @@ interface InertiaFormProps<TForm> {
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
   submit(method: string, url: string, options?: Inertia.VisitOptions): void
-  get(url: string, options?: Inertia.VisitOptions): void
-  post(url: string, options?: Inertia.VisitOptions): void
-  put(url: string, options?: Inertia.VisitOptions): void
-  patch(url: string, options?: Inertia.VisitOptions): void
-  delete(url: string, options?: Inertia.VisitOptions): void
+  get(url: string, options?: Partial<Inertia.VisitOptions>): void
+  post(url: string, options?: Partial<Inertia.VisitOptions>): void
+  put(url: string, options?: Partial<Inertia.VisitOptions>): void
+  patch(url: string, options?: Partial<Inertia.VisitOptions>): void
+  delete(url: string, options?: Partial<Inertia.VisitOptions>): void
   cancel(): void
 }
 

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -85,7 +85,7 @@ interface InertiaFormTrait {
 
 declare module 'vue/types/vue' {
   export interface Vue {
-    $inertia: Inertia.Inertia & InertiaFormTrait
+    $inertia: typeof Inertia.Inertia & InertiaFormTrait
     $page: Inertia.Page
   }
 }

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -4,4 +4,6 @@ export { default as createHeadManager } from './head'
 export { default as shouldIntercept } from './shouldIntercept'
 export { hrefToUrl, mergeDataIntoQueryString, urlWithoutHash } from './url'
 
+export * from './types'
+
 export const Inertia = new Router()

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -86,3 +86,5 @@ export type PageHandler = ({
   page: Page,
   preserveState: PreserveStateOption,
 }) => Promise<unknown>
+
+export interface PageProps {}

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -17,9 +17,8 @@ export type RequestPayload = Record<string, FormDataConvertible>|FormData
 
 export interface Page {
   component: string,
-  props: {
-    [key: string]: unknown,
-    errors: Errors & ErrorBag,
+  props: PageProps & {
+    errors: Errors & ErrorBag;
   }
   url: string,
   version: string|null


### PR DESCRIPTION
While working with the newest version I noticed several incorrect typings. If you agree, these types would also need to be adapted in `vue3` and `react` package.

Also, currently, types can only be imported from the types file directly but it would be great to have them all exported on package level.