### PR TITLE
Add support for fragments in Head component in Vue 3 adapter

### DIFF
--- a/packages/inertia-vue3/src/head.js
+++ b/packages/inertia-vue3/src/head.js
@@ -41,7 +41,9 @@ export default {
         : node.children.reduce((html, child) => html + this.renderTag(child), '')
     },
     renderTag(node) {
-      if (node.type.toString() === 'Symbol(Text)') {
+      if (node.type.toString() === 'Symbol(Fragment)') {
+        return this.renderTagChildren(node)
+      } else if (node.type.toString() === 'Symbol(Text)') {
         return node.children
       } else if (node.type.toString() === 'Symbol(Comment)') {
         return ''


### PR DESCRIPTION
Fixes #715

Right now if you include a `<slot />` within `<inertia-head>`, it throws an error, since the head component doesn't know how to render a fragment. This fixes that by checking to see if a fragment was provided, and if one was, uses its children instead.