### PR TITLE
Fix double render on initial page load

### DIFF
--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -49,7 +49,7 @@ export class Router {
       this.handleLocationVisit(this.page)
     } else {
       this.page.url += window.location.hash
-      this.setPage(this.page)
+      this.setPage(this.page, { preserveState: true })
     }
     fireNavigateEvent(this.page)
   }
@@ -112,7 +112,7 @@ export class Router {
 
   protected handleBackForwardVisit(page: Page): void {
     window.history.state.version = page.version
-    this.setPage(window.history.state, { preserveScroll: true }).then(() => {
+    this.setPage(window.history.state, { preserveScroll: true, preserveState: true }).then(() => {
       this.restoreScrollPositions()
     })
   }
@@ -144,7 +144,7 @@ export class Router {
     page.url += window.location.hash
     page.rememberedState = window.history.state?.rememberedState ?? {}
     page.scrollRegions = window.history.state?.scrollRegions ?? []
-    this.setPage(page, { preserveScroll: locationVisit.preserveScroll }).then(() => {
+    this.setPage(page, { preserveScroll: locationVisit.preserveScroll, preserveState: true }).then(() => {
       if (locationVisit.preserveScroll) {
         this.restoreScrollPositions()
       }


### PR DESCRIPTION
Fixes #716

This PR updates Inertia core to use `preserveState: true` by default when rendering the initial page. Previously this didn't matter, because the initial page component didn't render until `Inertia.init()` was run. However, recently, to accommodate SSR (server-side rendering), we updated the adapters to render the initial page component on first render. This causes two renders, since it renders again when `Inertia.init()` run. By setting `preserveState` to `true`, we prevent the double render from happening, since the page component key does not change.