### PR TITLE
allow array values to be passed in form

### DIFF
--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -3,7 +3,7 @@ import { CancelTokenSource } from 'axios'
 export type Errors = Record<string, string>
 export type ErrorBag = Record<string, Errors>
 
-export type FormDataConvertible = Date|File|Blob|boolean|string|number|null|undefined
+export type FormDataConvertible = Date|File|Blob|Array<any>|boolean|string|number|null|undefined
 
 export enum Method {
   GET = 'get',


### PR DESCRIPTION
with the new typescript types addition, Its not possible to send the array values to the form data, for example the below code outputs the type error "Type 'CollectionCondition[]' is not assignable to type 'string'."

```ts
export interface CollectionCondition {
  id: number;
  field: CollectionField;
  criteria: string;
  value: string;
}

export interface Collection {
  id: number;
  name: string;
  determiner: CollectionDeterminer;
  conditions: Array<CollectionCondition>;
}

const { data, setData } = useForm<Collection>({
  id: 1,
  name: "Summer collection",
  type: "manual",
  determiner: "all",
  conditions: [],
});

Inertia.post(url, data, {
  onSuccess: () => {
    Inertia.reload();
  },
});
```

with the changes adding Array<any> type in FormDataConvertible type we can pass the array values to the form. 