### PR TITLE
Fix import of App.svelte in createInertiaApp.js

### DIFF
--- a/packages/inertia-svelte/src/createInertiaApp.js
+++ b/packages/inertia-svelte/src/createInertiaApp.js
@@ -1,4 +1,4 @@
-import App from './App'
+import App from './App.svelte'
 
 export default async function createInertiaApp({ id = 'app', resolve, setup, page, render }) {
   const isServer = typeof window === 'undefined'


### PR DESCRIPTION
I am using Rollup and with the current version of the Svelte adapter it aborts with this error:
```
[!] Error: Could not resolve './App' from node_modules\@inertiajs\inertia-svelte\src\createInertiaApp.js
```
This change fixes it.