### PR TITLE
Fix issue with `<inertia-head>` component in production

### DIFF
--- a/packages/inertia-vue3/src/head.js
+++ b/packages/inertia-vue3/src/head.js
@@ -44,6 +44,8 @@ export default {
     renderTag(node) {
       if (node.type.toString() === 'Symbol(Text)') {
         return node.children
+      } else if (node.type.toString() === 'Symbol()') {
+        return ''
       } else if (node.type.toString() === 'Symbol(Comment)') {
         return ''
       }


### PR DESCRIPTION
Resolves #731

This PR adds an addition check to the `<inertia-head>`, needed when running Vue 3 in production. Oddly the vnodes are different in production than development.