### PR TITLE
Add global typescript Inertia SharedData definition

### DIFF
--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -4,7 +4,7 @@ declare global {
   // These open interfaces may be extended in an application-specific manner via
   // declaration merging / interface augmentation.
   namespace Inertia {
-    interface PageProps {}
+    interface SharedData {}
   }
 }
 
@@ -25,7 +25,7 @@ export type RequestPayload = Record<string, FormDataConvertible>|FormData
 
 export type PageProps = {
   [key: string]: unknown
-} & Inertia.PageProps
+} & Inertia.SharedData
 
 export interface Page {
   component: string,

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -1,5 +1,13 @@
 import { CancelTokenSource } from 'axios'
 
+declare global {
+  // These open interfaces may be extended in an application-specific manner via
+  // declaration merging / interface augmentation.
+  namespace Inertia {
+    interface PageProps {}
+  }
+}
+
 export type Errors = Record<string, string>
 export type ErrorBag = Record<string, Errors>
 
@@ -15,9 +23,9 @@ export enum Method {
 
 export type RequestPayload = Record<string, FormDataConvertible>|FormData
 
-export interface PageProps {
+export type PageProps = {
   [key: string]: unknown
-}
+} & Inertia.PageProps
 
 export interface Page {
   component: string,


### PR DESCRIPTION
Add the old global typescript Inertia PageProps definition that was previously removed.

PagePropsBeforeTransform is not added, because `transformProps()` is removed in #693.

Source:
https://github.com/inertiajs/inertia/blob/76a2328c751ce53e0268e211a8e8644094a7a8fc/packages/inertia/index.d.ts#L3-L14