### PR TITLE
Type options param for visit shortcuts.

### DIFF
--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -419,32 +419,32 @@ export class Router {
     }
   }
 
-  public get(url: URL|string, data: RequestPayload = {}, options : Record<string, unknown> = {}): void {
+  public get(url: URL|string, data: RequestPayload = {}, options: Exclude<Partial<VisitOptions>, 'method'|'data'> = {}): void {
     return this.visit(url, { ...options, method: Method.GET, data })
   }
 
-  public reload(options: Record<string, unknown> = {}): void {
+  public reload(options: Exclude<Partial<VisitOptions>, 'preserveScroll'|'preserveState'> = {}): void {
     return this.visit(window.location.href, { ...options, preserveScroll: true, preserveState: true })
   }
 
-  public replace(url: URL|string, options: Record<string, unknown> = {}): void {
+  public replace(url: URL|string, options: Exclude<Partial<VisitOptions>, 'replace'> = {}): void {
     console.warn(`Inertia.replace() has been deprecated and will be removed in a future release. Please use Inertia.${options.method ?? 'get'}() instead.`)
     return this.visit(url, { preserveState: true, ...options, replace: true })
   }
 
-  public post(url: URL|string, data: RequestPayload = {}, options: Record<string, unknown> = {}): void {
+  public post(url: URL|string, data: RequestPayload = {}, options: Exclude<Partial<VisitOptions>, 'method'|'data'> = {}): void {
     return this.visit(url, { preserveState: true, ...options, method: Method.POST, data })
   }
 
-  public put(url: URL|string, data: RequestPayload = {}, options: Record<string, unknown> = {}): void {
+  public put(url: URL|string, data: RequestPayload = {}, options: Exclude<Partial<VisitOptions>, 'method'|'data'> = {}): void {
     return this.visit(url, { preserveState: true, ...options, method: Method.PUT, data })
   }
 
-  public patch(url: URL|string, data: RequestPayload = {}, options: Record<string, unknown> = {}): void {
+  public patch(url: URL|string, data: RequestPayload = {}, options: Exclude<Partial<VisitOptions>, 'method'|'data'> = {}): void {
     return this.visit(url, { preserveState: true, ...options, method: Method.PATCH, data })
   }
 
-  public delete(url: URL|string, options: Record<string, unknown> = {}): void {
+  public delete(url: URL|string, options: Exclude<Partial<VisitOptions>, 'method'> = {}): void {
     return this.visit(url, { preserveState: true, ...options, method: Method.DELETE })
   }
 


### PR DESCRIPTION
This preserves types, while eliminating options rendered unusable due to the method overriding them, all while not adding new types to keep updated in 7 other places.