### PR TITLE
Disable layout attribute inheritance in Vue 3 adapter

### DIFF
--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -65,14 +65,18 @@ export default {
         if (component.value.layout) {
           if (typeof component.value.layout === 'function') {
             return component.value.layout(h, child)
-          } else if (Array.isArray(component.value.layout)) {
-            return component.value.layout
-              .concat(child)
-              .reverse()
-              .reduce((child, layout) => h(layout, { ...page.value.props }, () => child))
           }
 
-          return h(component.value.layout, { ...page.value.props }, () => child)
+          return (Array.isArray(component.value.layout) ? component.value.layout : [component.value.layout])
+            .concat(child)
+            .reverse()
+            .map((layout) => {
+              if (layout.inheritAttrs === undefined) {
+                layout.inheritAttrs = false
+              }
+              return layout
+            })
+            .reduce((child, layout) => h(layout, { ...page.value.props }, () => child))
         }
 
         return child

--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -70,12 +70,7 @@ export default {
           return (Array.isArray(component.value.layout) ? component.value.layout : [component.value.layout])
             .concat(child)
             .reverse()
-            .map((layout) => {
-              if (layout.inheritAttrs === undefined) {
-                layout.inheritAttrs = false
-              }
-              return layout
-            })
+            .map((layout) => ({ ...layout, inheritAttrs: !!layout.inheritAttrs }))
             .reduce((child, layout) => h(layout, { ...page.value.props }, () => child))
         }
 


### PR DESCRIPTION
Resolves #733

This change is similar to #681, where unused page props (that are passed to the layout component as a result of #602) are being actually rendered as attributes in the Vue 3 adapter. For example, the `errors` prop:

```html
<div errors="[object Object]">
  <!-- ... -->
</div>
```

This PR fixes this by automatically disabling attribute inheritance on the layout components by setting `inheritAttrs` to `false`.