### PR TITLE
Update Vue 2/3 adapter type definition file 

### DIFF
--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -1,5 +1,5 @@
 import * as Inertia from '@inertiajs/inertia'
-import { Component, ComponentOptions, FunctionalComponentOptions, PluginObject } from 'vue'
+import Vue, { Component, ComponentOptions, FunctionalComponentOptions, PluginObject } from 'vue'
 
 interface InertiaData {
   component: Component | null
@@ -21,6 +21,26 @@ export const InertiaApp: InertiaApp
 export const App: InertiaApp
 
 export const plugin: PluginObject<any>
+
+interface CreateInertiaAppProps {
+  id?: string
+  resolve: (name: string) => 
+    Component |
+    Promise<Component> |
+    { default: Component }
+  setup: (props: {
+    el: Element
+    app: InertiaApp
+    props: {
+      attrs: { id: string, 'data-page': string }
+      props: InertiaProps
+    }
+  }) => void | Vue
+  page?: Inertia.Page
+  render?: (vm: Vue) => Promise<string>
+}
+
+export declare function createInertiaApp(props: CreateInertiaAppProps): Promise<{ head: string[], body: string } | void>
 
 interface InertiaLinkProps {
   as?: string

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -1,33 +1,24 @@
 import * as Inertia from '@inertiajs/inertia'
-import { Component, FunctionalComponentOptions, PluginObject } from 'vue'
+import { Component, ComponentOptions, FunctionalComponentOptions, PluginObject } from 'vue'
 
-interface AppData<PageProps extends Inertia.PageProps = Inertia.PageProps> {
+interface InertiaData {
   component: Component | null
   key: number | null
-  props: PageProps | {}
+  props: Inertia.PageProps
 }
 
-interface AppProps<
-  PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
-  PageProps extends Inertia.PageProps = Inertia.PageProps
-> {
-  initialPage: Inertia.Page<PageProps>
-  resolveComponent: (name: string) => Component | Promise<Component>
+interface InertiaProps {
+  initialPage: Inertia.Page
+  initialComponent?: object
+  resolveComponent?: (name: string) => Component
+  onHeadUpdate?: (elements: string[]) => void
 }
 
-type App<
-  PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
-  PageProps extends Inertia.PageProps = Inertia.PageProps
-> = Component<
-  AppData<PageProps>,
-  never,
-  never,
-  AppProps<PagePropsBeforeTransform, PageProps>
->
+type InertiaApp = ComponentOptions<never, InertiaData, never, never, InertiaProps>
 
-export const InertiaApp: App
+export const InertiaApp: InertiaApp
 
-export const App: App
+export const App: InertiaApp
 
 export const plugin: PluginObject<any>
 

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -78,7 +78,7 @@ export interface InertiaFormProps<TForm> {
   transform(callback: (data: TForm) => object): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
-  submit(method: string, url: string, options?: Inertia.VisitOptions): void
+  submit(method: string, url: string, options?: Partial<Inertia.VisitOptions>): void
   get(url: string, options?: Partial<Inertia.VisitOptions>): void
   post(url: string, options?: Partial<Inertia.VisitOptions>): void
   put(url: string, options?: Partial<Inertia.VisitOptions>): void

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -71,7 +71,7 @@ export interface InertiaFormProps<TForm> {
   errors: Record<keyof TForm, string>
   hasErrors: boolean
   processing: boolean
-  progress: ProgressEvent | null
+  progress: { percentage: number } | null
   wasSuccessful: boolean
   recentlySuccessful: boolean
   data(): TForm

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -89,6 +89,8 @@ interface InertiaFormProps<TForm> {
 
 type InertiaForm<TForm> = TForm & InertiaFormProps<TForm>
 
+type InertiaHeadManager = ReturnType<typeof Inertia.createHeadManager>
+
 interface InertiaFormTrait {
   form<TForm>(data: TForm): InertiaForm<TForm>
   form<TForm>(rememberKey: string, data: TForm): InertiaForm<TForm>
@@ -98,5 +100,6 @@ declare module 'vue/types/vue' {
   export interface Vue {
     $inertia: typeof Inertia.Inertia & InertiaFormTrait
     $page: Inertia.Page
+    $headManager: InertiaHeadManager
   }
 }

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -1,13 +1,13 @@
 import * as Inertia from '@inertiajs/inertia'
 import Vue, { Component, ComponentOptions, FunctionalComponentOptions, PluginObject } from 'vue'
 
-interface InertiaData {
+export interface InertiaData {
   component: Component | null
   key: number | null
   props: Inertia.PageProps
 }
 
-interface InertiaProps {
+export interface InertiaProps {
   initialPage: Inertia.Page
   initialComponent?: object
   resolveComponent?: (name: string) => Component
@@ -16,13 +16,13 @@ interface InertiaProps {
 
 type InertiaApp = ComponentOptions<never, InertiaData, never, never, InertiaProps>
 
-export const InertiaApp: InertiaApp
+export declare const InertiaApp: InertiaApp
 
-export const App: InertiaApp
+export declare const App: InertiaApp
 
-export const plugin: PluginObject<any>
+export declare const plugin: PluginObject<any>
 
-interface CreateInertiaAppProps {
+export interface CreateInertiaAppProps {
   id?: string
   resolve: (name: string) => 
     Component |
@@ -42,7 +42,7 @@ interface CreateInertiaAppProps {
 
 export declare function createInertiaApp(props: CreateInertiaAppProps): Promise<{ head: string[], body: string } | void>
 
-interface InertiaLinkProps {
+export interface InertiaLinkProps {
   as?: string
   data?: object
   href: string
@@ -64,9 +64,9 @@ interface InertiaLinkProps {
 
 type InertiaLink = FunctionalComponentOptions<InertiaLinkProps>
 
-export const InertiaLink: InertiaLink
+export declare const InertiaLink: InertiaLink
 
-interface InertiaFormProps<TForm> {
+export interface InertiaFormProps<TForm> {
   isDirty: boolean
   errors: Record<keyof TForm, string>
   hasErrors: boolean
@@ -87,11 +87,11 @@ interface InertiaFormProps<TForm> {
   cancel(): void
 }
 
-type InertiaForm<TForm> = TForm & InertiaFormProps<TForm>
+export type InertiaForm<TForm> = TForm & InertiaFormProps<TForm>
 
 type InertiaHeadManager = ReturnType<typeof Inertia.createHeadManager>
 
-interface InertiaFormTrait {
+export interface InertiaFormTrait {
   form<TForm>(data: TForm): InertiaForm<TForm>
   form<TForm>(rememberKey: string, data: TForm): InertiaForm<TForm>
 }

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -1,5 +1,5 @@
 import * as Inertia from '@inertiajs/inertia'
-import { Ref, ComputedRef, App as VueApp, DefineComponent } from 'vue'
+import { Ref, ComputedRef, App as VueApp, DefineComponent, Plugin } from 'vue'
 
 interface InertiaAppProps {
   initialPage: Inertia.Page
@@ -11,6 +11,26 @@ interface InertiaAppProps {
 type InertiaApp = DefineComponent<InertiaAppProps>
 
 export const App: InertiaApp
+
+export const plugin: Plugin
+
+interface CreateInertiaAppProps {
+  id?: string
+  resolve: (name: string) => 
+    DefineComponent |
+    Promise<DefineComponent> |
+    { default: DefineComponent }
+  setup: (props: {
+    el: Element
+    app: InertiaApp
+    props: InertiaAppProps
+    plugin: Plugin
+  }) => void | VueApp
+  page?: Inertia.Page
+  render?: (app: VueApp) => Promise<string>
+}
+
+export declare function createInertiaApp(props: CreateInertiaAppProps): Promise<{ head: string[], body: string } | void>
 
 interface InertiaLinkProps {
   as?: string
@@ -35,10 +55,6 @@ interface InertiaLinkProps {
 type InertiaLink = DefineComponent<InertiaLinkProps>
 
 export const Link: InertiaLink
-
-export const plugin: {
-  install(app: VueApp): void
-}
 
 type ProgressEvent = {
   percentage: number

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -68,12 +68,12 @@ export interface InertiaFormProps<TForm> {
   transform(callback: (data: TForm) => object): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
-  submit(method: string, url: string, options?: Inertia.VisitOptions): void
-  get(url: string, options?: Inertia.VisitOptions): void
-  post(url: string, options?: Inertia.VisitOptions): void
-  put(url: string, options?: Inertia.VisitOptions): void
-  patch(url: string, options?: Inertia.VisitOptions): void
-  delete(url: string, options?: Inertia.VisitOptions): void
+  submit(method: string, url: string, options?: Partial<Inertia.VisitOptions>): void
+  get(url: string, options?: Partial<Inertia.VisitOptions>): void
+  post(url: string, options?: Partial<Inertia.VisitOptions>): void
+  put(url: string, options?: Partial<Inertia.VisitOptions>): void
+  patch(url: string, options?: Partial<Inertia.VisitOptions>): void
+  delete(url: string, options?: Partial<Inertia.VisitOptions>): void
   cancel(): void
 }
 

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -56,16 +56,12 @@ type InertiaLink = DefineComponent<InertiaLinkProps>
 
 export declare const Link: InertiaLink
 
-export declare type ProgressEvent = {
-  percentage: number
-}
-
 export interface InertiaFormProps<TForm> {
   isDirty: boolean
   errors: Record<keyof TForm, string>
   hasErrors: boolean
   processing: boolean
-  progress: ProgressEvent | null
+  progress: { percentage: number } | null
   wasSuccessful: boolean
   recentlySuccessful: boolean
   data(): TForm

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -1,18 +1,14 @@
 import * as Inertia from '@inertiajs/inertia'
-import { Ref, ComputedRef, App, Component, DefineComponent } from 'vue'
+import { Ref, ComputedRef, App as VueApp, DefineComponent } from 'vue'
 
-interface InertiaAppProps<
-  PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
-  PageProps extends Inertia.PageProps = Inertia.PageProps
-> {
-  initialPage: Inertia.Page<PageProps>
-  resolveComponent: (name: string) => Component | Promise<Component>
+interface InertiaAppProps {
+  initialPage: Inertia.Page
+  initialComponent?: object
+  resolveComponent?: (name: string) => DefineComponent
+  onHeadUpdate?: (elements: string[]) => void
 }
 
-type InertiaApp<
-  PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = Inertia.PagePropsBeforeTransform,
-  PageProps extends Inertia.PageProps = Inertia.PageProps
-> = DefineComponent<InertiaAppProps<PagePropsBeforeTransform, PageProps>>
+type InertiaApp = DefineComponent<InertiaAppProps>
 
 export const App: InertiaApp
 
@@ -41,7 +37,7 @@ type InertiaLink = DefineComponent<InertiaLinkProps>
 export const Link: InertiaLink
 
 export const plugin: {
-  install(app: App): void
+  install(app: VueApp): void
 }
 
 type ProgressEvent = {

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -1,7 +1,7 @@
 import * as Inertia from '@inertiajs/inertia'
 import { Ref, ComputedRef, App as VueApp, DefineComponent, Plugin } from 'vue'
 
-interface InertiaAppProps {
+export interface InertiaAppProps {
   initialPage: Inertia.Page
   initialComponent?: object
   resolveComponent?: (name: string) => DefineComponent
@@ -10,11 +10,11 @@ interface InertiaAppProps {
 
 type InertiaApp = DefineComponent<InertiaAppProps>
 
-export const App: InertiaApp
+export declare const App: InertiaApp
 
-export const plugin: Plugin
+export declare const plugin: Plugin
 
-interface CreateInertiaAppProps {
+export interface CreateInertiaAppProps {
   id?: string
   resolve: (name: string) => 
     DefineComponent |
@@ -32,7 +32,7 @@ interface CreateInertiaAppProps {
 
 export declare function createInertiaApp(props: CreateInertiaAppProps): Promise<{ head: string[], body: string } | void>
 
-interface InertiaLinkProps {
+export interface InertiaLinkProps {
   as?: string
   data?: object
   href: string
@@ -54,13 +54,13 @@ interface InertiaLinkProps {
 
 type InertiaLink = DefineComponent<InertiaLinkProps>
 
-export const Link: InertiaLink
+export declare const Link: InertiaLink
 
-type ProgressEvent = {
+export declare type ProgressEvent = {
   percentage: number
 }
 
-interface InertiaFormProps<TForm> {
+export interface InertiaFormProps<TForm> {
   isDirty: boolean
   errors: Record<keyof TForm, string>
   hasErrors: boolean
@@ -81,7 +81,7 @@ interface InertiaFormProps<TForm> {
   cancel(): void
 }
 
-type InertiaForm<TForm> = TForm & InertiaFormProps<TForm>
+export declare type InertiaForm<TForm> = TForm & InertiaFormProps<TForm>
 
 export declare function useForm<TForm>(data: TForm): InertiaForm<TForm>
 
@@ -96,7 +96,7 @@ export declare function usePage<PageProps>(): {
   version: ComputedRef<string | null>
 }
 
-type InertiaHead = DefineComponent<{
+export declare type InertiaHead = DefineComponent<{
   title?: string
 }>
 

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -89,8 +89,8 @@ export declare function useForm<TForm>(rememberKey: string, data: TForm): Inerti
 
 export declare function useRemember(data: object, key?: string): Ref<object>
 
-export declare function usePage<CustomPageProps extends Inertia.PageProps = Inertia.PageProps>(): {
-  props: ComputedRef<CustomPageProps>
+export declare function usePage<PageProps>(): {
+  props: ComputedRef<PageProps & Inertia.PageProps>
   url: ComputedRef<string>
   component: ComputedRef<string>
   version: ComputedRef<string | null>

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -96,10 +96,21 @@ export declare function usePage<PageProps>(): {
   version: ComputedRef<string | null>
 }
 
-declare module '@vue/runtime-core' {
+type InertiaHead = DefineComponent<{
+  title?: string
+}>
+
+declare module 'vue' {
+  /** global components is support in Volar */
+  export interface GlobalComponents {
+    InertiaHead: InertiaHead
+    InertiaLink: InertiaLink
+  }
+
   export interface ComponentCustomProperties {
-    $inertia: Inertia.Inertia
+    $inertia: typeof Inertia.Inertia
     $page: Inertia.Page
+    $headManager: ReturnType<typeof Inertia.createHeadManager>
   }
 
   export interface ComponentCustomOptions {


### PR DESCRIPTION
Update list in vue 2/3 type definition:
* `InertiaApp` type
* `createInertiaApp()` type
* `usePage()` type in vue 3
* head types
* Expose all types (reference by #741)
* Remove `ProgressEvent` type
* Fix `InertiaFormProps` type

Add `GlobalComponents` interface in Vue 3 types to support global components of [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar).