### PR TITLE
Add generic argument to Page type to allow for shared props typing

### DIFF
--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -19,9 +19,9 @@ export interface PageProps {
   [key: string]: unknown
 }
 
-export interface Page {
+export interface Page<SharedPropsType = Record<string, unknown>> {
   component: string,
-  props: PageProps & {
+  props: PageProps & SharedPropsType & {
     errors: Errors & ErrorBag;
   }
   url: string,


### PR DESCRIPTION
This allows adding an optional type to the `Page` interface to create type safety for shared props.

Example:
```typescript
// before
const { foo } = usePage().props; // no type safety :-(

// now
type MyPage = Page<{foo: string}>;
const { foo } = usePage<MyPage>().props; // yeah type safe 'foo'
```