### PR TITLE
Add ability to ignore Inertia default `handlePopstateEvent`

### DIFF
--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -13,6 +13,7 @@ export class Router {
   protected activeVisit?: ActiveVisit
   protected visitId: VisitId = null
   protected page!: Page
+  protected ignoreHistoryState: false
 
   public init({
     initialPage,
@@ -387,6 +388,9 @@ export class Router {
   }
 
   protected handlePopstateEvent(event: PopStateEvent): void {
+    if (this.ignoreHistoryState === true) {
+     return 
+    }
     if (event.state !== null) {
       const page = event.state
       const visitId = this.createVisitId()


### PR DESCRIPTION
This would allow a SPA application to take control of back button action if necessary. Otherwise, we always bound to Inertia default implementation. 

In my use case, I need to intercept the back button request and display a confirmation message. Not too elegant but this would enable us to build actions similar to `beforeRouteLeave()` with vue-router.