### PR TITLE
Fix DOMException when replacing or pushing page history state with a complex object

### DIFF
--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -378,12 +378,12 @@ export class Router {
 
   protected pushState(page: Page): void {
     this.page = page
-    window.history.pushState(page, '', page.url)
+    window.history.pushState(JSON.stringify(page), '', page.url)
   }
 
   protected replaceState(page: Page): void {
     this.page = page
-    window.history.replaceState(page, '', page.url)
+    window.history.replaceState(JSON.stringify(page), '', page.url)
   }
 
   protected handlePopstateEvent(event: PopStateEvent): void {


### PR DESCRIPTION
When trying to replace a page history state with a complex object, DOMException will be thrown. #775 

This PR fixes this issue.