### PR TITLE
feat(vue-3): `components` property for `createInertiaApp`

### DIFF
--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -9,6 +9,10 @@ export interface InertiaAppProps {
 }
 
 type InertiaApp = DefineComponent<InertiaAppProps>
+type ComponentResolvable = DefineComponent 
+  | Promise<DefineComponent> 
+  | { default: DefineComponent }
+  | (() => Promise<{ [key: string]: any; }>)
 
 export declare const App: InertiaApp
 
@@ -16,10 +20,8 @@ export declare const plugin: Plugin
 
 export interface CreateInertiaAppProps {
   id?: string
-  resolve: (name: string) => 
-    DefineComponent |
-    Promise<DefineComponent> |
-    { default: DefineComponent }
+  components: Record<string, ComponentResolvable>
+  resolve?: (name: string) => ComponentResolvable
   setup: (props: {
     el: Element
     app: InertiaApp

--- a/packages/inertia-vue3/src/createInertiaApp.js
+++ b/packages/inertia-vue3/src/createInertiaApp.js
@@ -1,10 +1,25 @@
 import { createSSRApp, h } from 'vue'
 import App, { plugin } from './app'
 
-export default async function createInertiaApp({ id = 'app', resolve, setup, title, page, render }) {
+export default async function createInertiaApp({ id = 'app', resolve, components, setup, title, page, render }) {
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
   const initialPage = page || JSON.parse(el.dataset.page)
+
+  if (components) {
+    resolve = (name) => {
+      for (const path in components) {
+        if (path.endsWith(`${name.replace('.', '/')}.vue`)) {
+          return typeof components[path] === 'function'
+            ? components[path]()
+            : components[path]
+        }
+      }
+
+      throw new Error('Page component not found: ' + name)
+    }
+  }
+
   const resolveComponent = name => Promise.resolve(resolve(name)).then(module => module.default || module)
 
   let head = []


### PR DESCRIPTION
# Summary

This PR adds a new non-breaking feature that allows passing a record of components to the `createInertiaApp` factory via the `components` property: 

```js
createInertiaApp({
	components: import.meta.glob('../views/pages/**/*.vue'), // <--- this is new
	setup({ el, app, props, plugin }) {
		createApp({ render: () => h(app, props) })
			.use(plugin)
			.mount(el)
	},
})
```

# Behavior

The behavior is the following: 
- If `components` is defined, `resolve` is replaced by a function that looks up the given record and returns the corresponding page component
- If the page component is not found, a clean error is printed in the console. 
- If `components` was not given, `resolve` behaves just like before.

# Interface

The record must be of this form: 

```ts
interface ComponentRecord {
  [path: string] ComponentResolvable
}
```

For instance, Vite's [`import.meta.glob`](https://vitejs.dev/guide/features.html#glob-import) returns something like this: 

```js
// import.meta.glob('../views/pages/**/*.vue')
{
  '../views/pages/index.vue': function() {},
  '../views/pages/about.vue': function() {},
  '../views/pages/dashboard/index.vue': function() {}
}
```

# Use cases

This may not be super helpful with Webpack, since ``resolve: name => require(`./Pages/${name}`)`` is available and clear enough, but it's very handy with Vite and reduces the boilerplate a lot. 

The feature is designed to not be only specific to Vite though, since `components` is just a map of paths/components. 

A nice bonus is the console message when the component is not found.

# Alternative

Alternatively, we could export the resolve logic from the package and use it like the following: 

```ts
import { createInertiaApp, withComponents } from '@inertiajs/inertia-vue3'

createInertiaApp({
	resolve: withComponents(import.meta.glob('../views/pages/**/*.vue')),
	setup({ el, app, props, plugin }) {
		createApp({ render: () => h(app, props) })
			.use(plugin)
			.mount(el)
	},
})
```

The only benefit I see of this approach would be the introduced tree-shakability, though.