### PR TITLE
fix resetting partial form data removing all other fields - REACT `useForm`

### DIFF
--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -154,7 +154,7 @@ export default function useForm(...args) {
             .reduce((carry, key) => {
               carry[key] = defaults[key]
               return carry
-            }, {...data}),
+            }, { ...data }),
         )
       }
     },

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -154,7 +154,7 @@ export default function useForm(...args) {
             .reduce((carry, key) => {
               carry[key] = defaults[key]
               return carry
-            }, {}),
+            }, {...data}),
         )
       }
     },


### PR DESCRIPTION

![Screen Recording (13-07-2021 01-00-32 AM) (1)](https://user-images.githubusercontent.com/26733312/125345565-549aa880-e376-11eb-9cb0-392d2444ed15.gif)


**ISSUE:** 
when resetting parts of form fields like: `reset('password')`, all other left fields data gets removed.

this is because the [`initialValue`](https://github.com/inertiajs/inertia/blob/0fb6765af94bb571a907b93df1f5b7b238017df1/packages/inertia-react/src/useForm.js#L157) of the `Array.reduce()` is set to blank `{}` so the `setData` hook keeps only the fields data that were mentioned in `reset()` method called by user.

**SOLVE:**
if the `initialValue` is set to the current field values as a copy `{...data}` then it can be fixed ✌