### PR TITLE
[inertia-vue3] Deprecate `plugin` in favor of `inertia`

### DIFF
--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -24,7 +24,9 @@ export interface CreateInertiaAppProps {
     el: Element
     app: InertiaApp
     props: InertiaAppProps
+		/** @deprecated Use `inertia` instead */
     plugin: Plugin
+    inertia: Plugin
   }) => void | VueApp
   page?: Inertia.Page
   render?: (app: VueApp) => Promise<string>

--- a/packages/inertia-vue3/src/createInertiaApp.js
+++ b/packages/inertia-vue3/src/createInertiaApp.js
@@ -21,7 +21,9 @@ export default async function createInertiaApp({ id = 'app', resolve, setup, tit
         titleCallback: title,
         onHeadUpdate: isServer ? elements => (head = elements) : null,
       },
+      /** @deprecated Use `inertia` instead **/
       plugin,
+      inertia: plugin,
     })
   })
 


### PR DESCRIPTION
## Summary

This PR deprecates the `plugin` export of `createInertiaApp` in favor of `inertia`: 

```ts
import { createApp, h } from 'vue'
import { createInertiaApp } from '@inertiajs/inertia-vue3'

createInertiaApp({
  resolve: (name) => import(`./Pages/${name}`),
  setup({ el, app, props, inertia }) {
    createApp({ render: () => h(app, props) })
      .use(inertia) // <-- instead of `plugin`
      .mount(el)
  },
})
```

## Reasoning

Quite often, we use different Vue plugins, and the plugin variables are named upon the plugin name. For instance, using `vue-i18n` would look like that: 

```ts
createApp().use(i18n)
```

Currently, Inertia's plugin is named `plugin`, which doesn't really make sense in this context. Imagine you have multiple plugins: 

```ts
createInertiaApp({
  resolve: (name) => import(`./Pages/${name}`),
  setup({ el, app, props, inertia }) {
    createApp({ render: () => h(app, props) })
      .use(plugin)
      .use(i18n)
      .use(toast)
      .use(calendar)
      .mount(el)
  },
})
```

For clarity, it should be named `inertia`. 

While the variable can be renamed in the destructuration (`{ plugin: inertia }`), I think it should just be the default, for consistency's sake and so the boilerplate can be reduced. 