### PR TITLE
Update Vue 2/3 adapters types

### DIFF
--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -36,6 +36,7 @@ export interface CreateInertiaAppProps {
       props: InertiaProps
     }
   }) => void | Vue
+  title?: (title: string) => string
   page?: Inertia.Page
   render?: (vm: Vue) => Promise<string>
 }

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -62,9 +62,9 @@ export interface InertiaLinkProps {
   onSuccess?: () => void
 }
 
-type InertiaLink = FunctionalComponentOptions<InertiaLinkProps>
+export type InertiaLink = FunctionalComponentOptions<InertiaLinkProps>
 
-export declare const InertiaLink: InertiaLink
+export declare const Link: InertiaLink
 
 export interface InertiaFormProps<TForm> {
   isDirty: boolean
@@ -89,7 +89,15 @@ export interface InertiaFormProps<TForm> {
 
 export type InertiaForm<TForm> = TForm & InertiaFormProps<TForm>
 
-type InertiaHeadManager = ReturnType<typeof Inertia.createHeadManager>
+export type InertiaHeadManager = ReturnType<typeof Inertia.createHeadManager>
+
+export interface InertiaHeadProps {
+  title?: string
+}
+
+export type InertiaHead = ComponentOptions<never, never, never, never, InertiaHeadProps>
+
+export declare const Head: InertiaHead
 
 export interface InertiaFormTrait {
   form<TForm>(data: TForm): InertiaForm<TForm>

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -26,6 +26,7 @@ export interface CreateInertiaAppProps {
     props: InertiaAppProps
     plugin: Plugin
   }) => void | VueApp
+  title?: (title: string) => string
   page?: Inertia.Page
   render?: (app: VueApp) => Promise<string>
 }

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -52,7 +52,7 @@ export interface InertiaLinkProps {
   onSuccess?: () => void
 }
 
-type InertiaLink = DefineComponent<InertiaLinkProps>
+export type InertiaLink = DefineComponent<InertiaLinkProps>
 
 export declare const Link: InertiaLink
 
@@ -96,13 +96,9 @@ export type InertiaHead = DefineComponent<{
   title?: string
 }>
 
-declare module 'vue' {
-  /** global components is support in Volar */
-  export interface GlobalComponents {
-    InertiaHead: InertiaHead
-    InertiaLink: InertiaLink
-  }
+export declare const Head: InertiaHead
 
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $inertia: typeof Inertia.Inertia
     $page: Inertia.Page


### PR DESCRIPTION
Update list:
* Update Link, Head type
* Add title callback type in createInertiaApp()

---

### Using global components example with Vue 3 & TS & Volar

Register components:

*resources/js/app.d.ts*
```js
...
import { createInertiaApp, Link, Head } from '@inertiajs/inertia-vue3'

createInertiaApp({
  ...
  setup({ el, app, props, plugin }) {
    createApp({ render: () => h(app, props) })
      .use(plugin)
      .component('InertiaLink', Link)  // InertiaLink component
      .component('InertiaHead', Head)  // InertiaHead component
      .mount(el)
  },
})
```

Add global components typing with [Volar](https://github.com/johnsoncodehk/volar):

*resources/js/shims-vue.d.ts*
```ts
declare module 'vue' {
  export interface GlobalComponents {
    InertiaLink: typeof import('@inertiajs/inertia-vue3').Link
    InertiaHead: typeof import('@inertiajs/inertia-vue3').Head
  }
}

export {}
```

Now can use the `<InertiaLink>` and `<InertiaHead>` components.
