### PR TITLE
fire navigate event after resolving initial component

### DIFF
--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -26,21 +26,21 @@ export class Router {
     this.page = initialPage
     this.resolveComponent = resolveComponent
     this.swapComponent = swapComponent
-    this.handleInitialPageVisit()
-    this.setupEventListeners()
-  }
 
-  protected handleInitialPageVisit(): void {
     if (this.isBackForwardVisit()) {
       this.handleBackForwardVisit(this.page)
     } else if (this.isLocationVisit()) {
       this.handleLocationVisit(this.page)
     } else {
-      this.page.url += window.location.hash
-      this.setPage(this.page, { preserveState: true }).then(() => {
-        fireNavigateEvent(this.page)
-      })
+      this.handleInitialPageVisit(this.page)
     }
+
+    this.setupEventListeners()
+  }
+
+  protected handleInitialPageVisit(page: Page): void {
+    this.page.url += window.location.hash
+    this.setPage(page, { preserveState: true }).then(() => fireNavigateEvent(page))
   }
 
   protected setupEventListeners(): void {

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -37,9 +37,10 @@ export class Router {
       this.handleLocationVisit(this.page)
     } else {
       this.page.url += window.location.hash
-      this.setPage(this.page, { preserveState: true })
+      this.setPage(this.page, { preserveState: true }).then(() => {
+        fireNavigateEvent(this.page)
+      })
     }
-    fireNavigateEvent(this.page)
   }
 
   protected setupEventListeners(): void {
@@ -102,6 +103,7 @@ export class Router {
     window.history.state.version = page.version
     this.setPage(window.history.state, { preserveScroll: true, preserveState: true }).then(() => {
       this.restoreScrollPositions()
+      fireNavigateEvent(page)
     })
   }
 
@@ -136,6 +138,7 @@ export class Router {
       if (locationVisit.preserveScroll) {
         this.restoreScrollPositions()
       }
+      fireNavigateEvent(page)
     })
   }
 


### PR DESCRIPTION
This PR changes the behaviour of the initial `navigate` event to be fired *after* the initial component has been resolved. This is similar to the behaviour on subsequent visits in Inertia.

The use case I have for this is that I want to set a value to be remembered after a `navigate` event. However due to the event being fired before the component has been resolved the history state will be overwritten.

```js
Inertia.on('navigate', () => {
	Inertia.remember(Date.now(), 'key');
});
```

Now if you'd check the history after the component has been loaded, you see the `rememberedState` is empty.

```js
window.history.state.rememberedState
> {}
```