### PR TITLE
Check if scroll region's position is available before restoring

### DIFF
--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -86,7 +86,6 @@ export class Router {
     if (this.page.scrollRegions) {
       this.scrollRegions().forEach((region: Element, index: number) => {
         const scrollPosition = this.page.scrollRegions[index]
-
         if (scrollPosition) {
           region.scrollTop = scrollPosition.top
           region.scrollLeft = scrollPosition.left

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -85,8 +85,12 @@ export class Router {
   protected restoreScrollPositions(): void {
     if (this.page.scrollRegions) {
       this.scrollRegions().forEach((region: Element, index: number) => {
-        region.scrollTop = this.page.scrollRegions[index].top
-        region.scrollLeft = this.page.scrollRegions[index].left
+        const scrollPosition = this.page.scrollRegions[index]
+
+        if (scrollPosition) {
+          region.scrollTop = scrollPosition.top
+          region.scrollLeft = scrollPosition.left
+        }
       })
     }
   }


### PR DESCRIPTION
While using Inertia the following error sometimes pops up:
```
Uncaught (in promise) TypeError: Cannot read property 'top' of undefined
    at router.ts:89
    at NodeList.forEach (<anonymous>)
    at e2.n2.restoreScrollPositions (router.ts:88)
    at router.ts:401
```
Relating to this line: https://github.com/inertiajs/inertia/blob/master/packages/inertia/src/router.ts#L88

I am not entirely sure why the scroll regions are not properly saved sometimes so perhaps this does't fix the underlying issue, but it wouldn't hurt to have a little sanity check here that checks if the value is present before applying it.