### PR TITLE
Enable `skipNulls` option for qs.stringify

### DIFF
--- a/packages/inertia/src/url.ts
+++ b/packages/inertia/src/url.ts
@@ -23,6 +23,7 @@ export function mergeDataIntoQueryString(
     url.search = qs.stringify(deepmerge(qs.parse(url.search, { ignoreQueryPrefix: true }), data), {
       encodeValuesOnly: true,
       arrayFormat: 'brackets',
+      skipNulls: true,
     })
     data = {}
   }


### PR DESCRIPTION
This is to ensure that query object data with NULL as values are
stripped from the resulting query string.

Example and reference: https://github.com/ljharb/qs#handling-of-null-values