### PR TITLE
Fix wrong type in InertiaFormProps.submit method

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -79,7 +79,7 @@ export interface InertiaFormProps<TForm = Record<string, any>> {
 	transform: (callback: (data: TForm) => TForm) => void
 	reset: (...fields: (keyof TForm)[]) => void
 	clearErrors: (...fields: (keyof TForm)[]) => void
-	submit: (method: () => void, url: string, options?: Inertia.VisitOptions) => Promise<void>
+	submit: (method: Inertia.Method, url: string, options?: Inertia.VisitOptions) => Promise<void>
 	get: (url: string, options?: Inertia.VisitOptions) => Promise<void>
 	patch: (url: string, options?: Inertia.VisitOptions) => Promise<void>
 	post: (url: string, options?: Inertia.VisitOptions) => Promise<void>


### PR DESCRIPTION
Proposes a fix for a wrong type used for `method` argument in `InertiaFormProps.submit` method, which actually should be one of `Inertia.Method` enum values, or maybe a union type like:

```ts
type submitMethod = 'get' | 'patch' | 'post' | 'put' | 'delete'
```

fixes #837 