### PR TITLE
Fix links with `null` href values

### DIFF
--- a/packages/inertia-react/src/Link.js
+++ b/packages/inertia-react/src/Link.js
@@ -74,7 +74,7 @@ export default forwardRef(function InertiaLink({
 
   as = as.toLowerCase()
   method = method.toLowerCase()
-  const [_href, _data] = mergeDataIntoQueryString(method, href, data)
+  const [_href, _data] = mergeDataIntoQueryString(method, href || '', data)
   href = _href
   data = _data
 

--- a/packages/inertia-svelte/src/link.js
+++ b/packages/inertia-svelte/src/link.js
@@ -2,7 +2,7 @@ import { createEventDispatcher } from 'svelte'
 import { Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
 
 export default (node, options = {}) => {
-  const [href, data] = mergeDataIntoQueryString(options.method || 'get', node.href || options.href, options.data || {})
+  const [href, data] = mergeDataIntoQueryString(options.method || 'get', node.href || options.href || '', options.data || {})
   node.href = href
   options.data = data
 

--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -13,7 +13,6 @@ export default {
     },
     href: {
       type: String,
-      required: true,
     },
     method: {
       type: String,
@@ -55,7 +54,7 @@ export default {
 
     const as = props.as.toLowerCase()
     const method = props.method.toLowerCase()
-    const [href, propsData] = mergeDataIntoQueryString(method, props.href, props.data)
+    const [href, propsData] = mergeDataIntoQueryString(method, props.href || '', props.data)
 
     if (as === 'a' && method !== 'get') {
       console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<inertia-link href="${href}" method="${method}" as="button">...</inertia-link>`)

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -14,7 +14,6 @@ export default {
     },
     href: {
       type: String,
-      required: true,
     },
     method: {
       type: String,
@@ -45,7 +44,7 @@ export default {
     return props => {
       const as = props.as.toLowerCase()
       const method = props.method.toLowerCase()
-      const [href, data] = mergeDataIntoQueryString(method, props.href, props.data)
+      const [href, data] = mergeDataIntoQueryString(method, props.href || '', props.data)
 
       if (as === 'a' && method !== 'get') {
         console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<inertia-link href="${href}" method="${method}" as="button">...</inertia-link>`)


### PR DESCRIPTION
This PR updates the `<Link>` component in all four adapters to gracefully handle the situation where the `href` value is set to `null`. This is actually more common (ie. the Laravel pagination links), which causes a fatal error to occur, since the `mergeDataIntoQueryString()` method doesn't know what to do with `null` or `undefined` values.