### PR TITLE
feat: allow null value for replace parameter

### DIFF
--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -373,6 +373,8 @@ export class Router {
           this.replaceState(page)
         } else if (replace === false) {
           this.pushState(page)
+        } else {
+          this.keepState(page)
         }
         this.swapComponent({ component, page, preserveState }).then(() => {
           if (!preserveScroll) {
@@ -394,6 +396,10 @@ export class Router {
   protected replaceState(page: Page): void {
     this.page = page
     window.history.replaceState(page, '', page.url)
+  }
+
+  protected keepState(page: Page): void {
+    this.page = page
   }
 
   protected handlePopstateEvent(event: PopStateEvent): void {

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -360,7 +360,7 @@ export class Router {
     preserveState = false,
   }: {
     visitId?: VisitId,
-    replace?: boolean,
+    replace?: boolean | null,
     preserveScroll?: PreserveStateOption
     preserveState?: PreserveStateOption
   } = {}): Promise<void> {
@@ -369,7 +369,11 @@ export class Router {
         page.scrollRegions = page.scrollRegions || []
         page.rememberedState = page.rememberedState || {}
         replace = replace || hrefToUrl(page.url).href === window.location.href
-        replace ? this.replaceState(page) : this.pushState(page)
+        if (replace === true) {
+          this.replaceState(page)
+        } else if (replace === false) {
+          this.pushState(page)
+        }
         this.swapComponent({ component, page, preserveState }).then(() => {
           if (!preserveScroll) {
             this.resetScrollPositions()

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -54,7 +54,7 @@ export type LocationVisit = {
 export type Visit = {
   method: Method,
   data: RequestPayload,
-  replace: boolean,
+  replace: boolean | null,
   preserveScroll: PreserveStateOption,
   preserveState: PreserveStateOption,
   only: Array<string>,


### PR DESCRIPTION
This PR will allow users to pass `null` to `replace` parameter. A null value means that neither a new state will be pushed nor a new state will be set. This can be handy for infinite scroll pages where the URL should not change but anyway new items should be loaded.