### PR TITLE
Fix incorrect type for resolve option for React's createInertiaApp

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -103,7 +103,7 @@ export type SetupOptions<ElementType, SharedProps> = {
 
 export type BaseInertiaAppOptions = {
     title?: HeadManagerTitleCallback,
-    resolve(name: string): PageResolver,
+    resolve: PageResolver,
 }
 
 export type CreateInertiaAppSetupReturnType = ReactInstance|void;


### PR DESCRIPTION
This PR fixes an incorrect type for the resolve method on the createInertiaApp.

Currently this is typed as `resolve(name: string): PageResolver` since `PageResolver` is already a function this is wrongly defined as a "factory function" and this will cause issues, e.g.
```
resolve: (name) => import(`./Pages/${name}`) as React.ReactNode
```
results in
```
> No overload matches this call.
  Overload 1 of 2, '(options: InertiaAppOptionsForCSR<PageProps>): Promise<CreateInertiaAppSetupReturnType>', gave the following error.
    Type 'ReactNode' is not assignable to type 'PageResolver'.
      Type 'undefined' is not assignable to type 'PageResolver'.ts(2769)
index.d.ts(106, 5): The expected type comes from the return type of this signature.
```
The solution is to remove the parameter from the `resolve` definition so its typed as a parameter that is equal to `PageResolver` rather than a parameter that expects a `PageResolver` to be returned.