### PR TITLE
fix: declare @vue/runtime-core instead of vue for vue3

### DIFF
--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -99,7 +99,7 @@ export type InertiaHead = DefineComponent<{
 
 export declare const Head: InertiaHead
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     $inertia: typeof Inertia.Inertia
     $page: Inertia.Page


### PR DESCRIPTION
Hello,
Thanks for the hard work !
I have recently updated the packages and noticed a regression with Vue3 types here https://github.com/inertiajs/inertia/commit/82c927ff6640a5ecc7b39f32fe2f9ae9a62ae953#diff-68769ed64e5114a6520e6d1a040a8fc8a01230710d0daaa045949608398e7f01
I made this PR as it hasn't changed in Vue Docs (https://v3.vuejs.org/guide/typescript-support.html#typing-refs). Don't hesitate to ask for changes ! I have also opened a corresponding issue https://github.com/inertiajs/inertia/issues/850.
Have a nice day.