### PR TITLE
Add support for RootLess/Global mounting.

### DIFF
--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -25,10 +25,12 @@ export interface CreateInertiaAppProps {
     app: InertiaApp
     props: InertiaAppProps
     plugin: Plugin
+    provide?(app: VueApp)
   }) => void | VueApp
   title?: (title: string) => string
   page?: Inertia.Page
   render?: (app: VueApp) => Promise<string>
+  rootLess?: boolean
 }
 
 export declare function createInertiaApp(props: CreateInertiaAppProps): Promise<{ head: string[], body: string } | void>

--- a/packages/inertia-vue3/src/createInertiaApp.js
+++ b/packages/inertia-vue3/src/createInertiaApp.js
@@ -1,37 +1,52 @@
 import { createSSRApp, h } from 'vue'
 import App, { plugin } from './app'
 
-export default async function createInertiaApp({ id = 'app', resolve, setup, title, page, render }) {
+export default async function createInertiaApp({ id = 'app', resolve, setup, title, page, render, rootLess }) {
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
   const initialPage = page || JSON.parse(el.dataset.page)
-  const resolveComponent = name => Promise.resolve(resolve(name)).then(module => module.default || module)
+  const resolveComponent = (name) =>
+    Promise.resolve(resolve(name)).then((module) => module.default || module)
 
   let head = []
 
-  const vueApp = await resolveComponent(initialPage.component).then(initialComponent => {
-    return setup({
-      el,
-      app: App, // deprecated
-      App,
-      props: {
-        initialPage,
-        initialComponent,
-        resolveComponent,
-        titleCallback: title,
+  const onHeadUpdate = isServer ? (elements) => (head = elements) : null
+
+  const vueApp = await resolveComponent(initialPage.component).then(
+    (initialComponent) => {
+      return setup({
+        el,
+        app: !rootLess ? App : {}, // deprecated
+        App: !rootLess ? App : {},
+        provide: rootLess
+          ? function (app) {
+
+            app.provide('$initialPage', initialPage)
+            app.provide('$component', initialComponent)
+            app.provide('$titleCallback', title)
+            app.provide('$onHeadUpdate', onHeadUpdate)
+            app.provide('$resolveComponent', resolveComponent)
+          }
+          : null,
+        props: !rootLess
+          ? {
+            initialPage,
+            initialComponent,
+            resolveComponent,
+            titleCallback: title,
         onHeadUpdate: isServer ? elements => (head = elements) : null,
       },
-      plugin,
-    })
+        plugin,
+      })
   })
 
   if (isServer) {
     const body = await render(createSSRApp({
       render: () => h('div', {
-        id,
-        'data-page': JSON.stringify(initialPage),
-        innerHTML: render(vueApp),
-      }),
+            id,
+            'data-page': JSON.stringify(initialPage),
+            innerHTML: render(vueApp),
+          }),
     }))
 
     return { head, body }


### PR DESCRIPTION
This is a draft PR to support global mounting in Inertiajs. 

### Purpose
This feature resolves the issue of encapsulating everything in vue.js.  _Laravel Nova is a good example of how we can use global mounting to our advantage._ 

### Usage
```html
// app.blade.php
<div id="app" data-page="{...}">
    <aside>
        ...
    </aside>
    <div class="content">
        <header>...</header>
        <div class="view">
            <inertia-view></inertia-view> <-- Our page will be mounted here
        </div>
    </div>
</div>
```
```js
// app.js
createInertiaApp({
  resolve: name => require(`./Pages/${name}`),
  rootLess: true,
  setup({ el, props, plugin, provide, App }) {
    const app = createApp(App)

    app.use(plugin)
    provide(app)
    app.mount(el)

    return app
  },
})
```
### Why?
Because it is useful in many scenarios, mostly for backend dashboards.

### Support
- [x] Vue 3

_Currently only Vue3 is supported but Vue2 implementation is also similar. Can't say anything about React and Svelte._