### PR TITLE
Append empty array to formdata

### DIFF
--- a/packages/inertia/src/formData.ts
+++ b/packages/inertia/src/formData.ts
@@ -35,7 +35,7 @@ function append(form: FormData, key: string, value: FormDataConvertible): void {
     return form.append(key, value)
   } else if (typeof value === 'number') {
     return form.append(key, `${value}`)
-  } else if (value === null || value === undefined) {
+  } else if (value === null || value === undefined || (Array.isArray(value) && !value.length)) {
     return form.append(key, '')
   }
 

--- a/packages/inertia/src/formData.ts
+++ b/packages/inertia/src/formData.ts
@@ -22,7 +22,10 @@ function composeKey(parent: string|null, key: string): string {
 
 function append(form: FormData, key: string, value: FormDataConvertible): void {
   if (Array.isArray(value)) {
-    return Array.from(value.keys()).forEach(index => append(form, composeKey(key, index.toString()), value[index]))
+    if (value.length) {
+      return Array.from(value.keys()).forEach(index => append(form, composeKey(key, index.toString()), value[index]))
+    }
+    return form.append(key, '')
   } else if (value instanceof Date) {
     return form.append(key, value.toISOString())
   } else if (value instanceof File) {
@@ -35,7 +38,7 @@ function append(form: FormData, key: string, value: FormDataConvertible): void {
     return form.append(key, value)
   } else if (typeof value === 'number') {
     return form.append(key, `${value}`)
-  } else if (value === null || value === undefined || (Array.isArray(value) && !value.length)) {
+  } else if (value === null || value === undefined) {
     return form.append(key, '')
   }
 


### PR DESCRIPTION
## Summary

Currently empty arrays aren't appended to the FormData object, this means sending an empty array won't reach the server at all. It can be confusing when you have a form with an optional file, like so:
```js
const form = useForm({
  image: null,
  tags: [],
});
```
When the image is null, the tags property is received by Laravel as an empty array `[]`. However, when a file is present Inertia converts the object to a FormData object. Now the `tags` property won't be sent to the server at all, not even as a null value.

## FormData limitations

With FormData it seems to be impossible to send an empty array, at least with Laravel. For example doing `form.append('mykey', [])` results in the following:
```php
// $request->all();
[
  "mykey" => "[]"
]
```
Doing `form.append('mykey[]', '')` results in:
```php
// $request->all();
[
  "mykey" => [
    0 => null,
  ]
]
```

Sending a "normal" XHR request with a JSON payload would contain the following and results in an empty array: `{ "mykey": [] }`

This implementation send the key as an empty string, same as null and undefined values, so `$request->all()` will result in:
```php
[
  "mykey": null,
]
```