### PR TITLE
Fix useForm progress type

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -35,7 +35,7 @@ interface BaseInertiaLinkProps {
   onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
   onBefore?: () => void
   onStart?: () => void
-  onProgress?: (progress: number) => void
+  onProgress?: (progress: Inertia.Progress) => void
   onFinish?: () => void
   onCancel?: () => void
   onSuccess?: () => void
@@ -72,7 +72,7 @@ export interface InertiaFormProps<TForm = Record<string, any>> {
 	errors: Record<keyof TForm, string>
 	hasErrors: boolean
 	processing: boolean
-	progress: number
+	progress: Inertia.Progress | null
 	wasSuccessful: boolean
 	recentlySuccessful: boolean
 	setData: setDataByObject<TForm> & setDataByMethod<TForm> & setDataByKeyValuePair<TForm>

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -47,6 +47,8 @@ export type PageHandler = ({
 
 export type PreserveStateOption = boolean|string|((page: Page) => boolean)
 
+export type Progress = ProgressEvent & { percentage: number }
+
 export type LocationVisit = {
   preserveScroll: boolean,
 }

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -81,9 +81,9 @@ export type GlobalEventsMap = {
     result: void,
   },
   progress: {
-    parameters: [{ percentage: number }|undefined],
+    parameters: [Progress|undefined],
     details: {
-      progress: { percentage: number }|undefined,
+      progress: Progress|undefined,
     },
     result: void,
   },


### PR DESCRIPTION
`useForm`'s `progress` property is typed as a number in react package. I noticed it is actually a 
[`ProgressEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent) extended with the `percentage` in:
https://github.com/inertiajs/inertia/blob/1dc7fef4cdbd7c506b7213235a98ddb21d4f4db9/packages/inertia/src/router.ts#L287-L289

Based on this, I propose a new `Inertia.Progress` type so it can be used by the other packages.