### PR TITLE
Svelte: Add a key block around `<Render>` to prevent $page store updates in old components

### DIFF
--- a/packages/inertia-svelte/src/App.svelte
+++ b/packages/inertia-svelte/src/App.svelte
@@ -27,8 +27,9 @@
           .reduce((child, layout) => h(layout, $store.page.props, [child]))
       : h(layout, $store.page.props, [child])
     : child
+  $: rerenderKey = `${$store.key}.${$store.component?.default.name}`
 </script>
 
-{#key $store.key}
+{#key rerenderKey}
   <Render {...components} />
 {/key}

--- a/packages/inertia-svelte/src/App.svelte
+++ b/packages/inertia-svelte/src/App.svelte
@@ -29,4 +29,6 @@
     : child
 </script>
 
-<Render {...components} />
+{#key $store.key}
+  <Render {...components} />
+{/key}


### PR DESCRIPTION
Hey!

I'm currently porting an app over to use Inertia with Svelte. (Really liking it so far!)

Today, I noticed a weird behaviour where the `$page` store would update inside of page components when navigating away from the component. (This sounds like it's related to #522, but I'm not sure if #529 may have broken it again. I definitely hit the problems mentioned in #522, where state may just disappear.)

So, for example, if I had code like this, and `myProp === 1`:

```js
export let myProp
$: console.log(myProp, $page.props.myProp)
```

It would log `1, 1` on the console. (As expected!) 

But if I navigate away, and my new page has `myProp === 2`, then it logs (while leaving the page!): `1, 2`. (So the prop is still correct, but the `$page` store already updated.)

I'm also using a Layout to wrap my page, and in the layout, both values update at the same time.

After digging around a bit, I _think_ this is caused by the recursive call in the `Render` component. (This may be incorrect, but I think:) While the recursive rendering is still happening from the outside in, the `$page` store updates are already triggering in the old components that haven't been destroyed yet.

I was ultimately able to fix this with Svelte's [`key` block](https://svelte.dev/docs#key) and the `$store.key`. I don't know if this is the ideal solution – it may have some edge cases that I don't know of. But it fixed my problem, so I'm opening this PR so that we may find a better solution.