### PR TITLE
Change return type of transform helper on useForm to unknown

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -76,7 +76,7 @@ export interface InertiaFormProps<TForm = Record<string, any>> {
 	wasSuccessful: boolean
 	recentlySuccessful: boolean
 	setData: setDataByObject<TForm> & setDataByMethod<TForm> & setDataByKeyValuePair<TForm>
-	transform: (callback: (data: TForm) => TForm) => void
+	transform: (callback: (data: TForm) => unknown) => void
 	reset: (...fields: (keyof TForm)[]) => void
 	clearErrors: (...fields: (keyof TForm)[]) => void
 	submit: (method: Inertia.Method, url: string, options?: Inertia.VisitOptions) => Promise<void>


### PR DESCRIPTION
Currently the `transform` method should always return `TData` however that's problematic because that basically would prevent the user from transforming the data to any other structure than the original structure of the form.

I choose to replace it with `unknown` but it might be better to use a dedicated type for which data can be submitted with Inertia. Is `Record<string, FormDataConvertible>` from `inertia/formData.ts` the correct type for this? In that case it might also be good to replace all the other types like `InertiaFormProps<TForm = Record<string, any>>` to `Record<string, FormDataConvertible>` as well. If you'd like to have that I can do that in a follow up PR.