### PR TITLE
fix: use promised return type

### DIFF
--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -4,7 +4,7 @@ import { Ref, ComputedRef, App as VueApp, DefineComponent, Plugin } from 'vue'
 export interface InertiaAppProps {
   initialPage: Inertia.Page
   initialComponent?: object
-  resolveComponent?: (name: string) => Promise<DefineComponent>
+  resolveComponent?: (name: string) => DefineComponent | Promise<DefineComponent>
   onHeadUpdate?: (elements: string[]) => void
 }
 

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -4,7 +4,7 @@ import { Ref, ComputedRef, App as VueApp, DefineComponent, Plugin } from 'vue'
 export interface InertiaAppProps {
   initialPage: Inertia.Page
   initialComponent?: object
-  resolveComponent?: (name: string) => DefineComponent
+  resolveComponent?: (name: string) => Promise<DefineComponent>
   onHeadUpdate?: (elements: string[]) => void
 }
 


### PR DESCRIPTION
The result of `resolveComponent` can also be asynchronously.