### PR TITLE
Replace `inertia-link` with `Link` in console messages

### DIFF
--- a/packages/inertia-react/src/Link.js
+++ b/packages/inertia-react/src/Link.js
@@ -79,7 +79,7 @@ export default forwardRef(function InertiaLink({
   data = _data
 
   if (as === 'a' && method !== 'get') {
-    console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<InertiaLink href="${href}" method="${method}" as="button">...</InertiaLink>`)
+    console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<Link href="${href}" method="${method}" as="button">...</Link>`)
   }
 
   return createElement(as, {

--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -57,7 +57,7 @@ export default {
     const [href, propsData] = mergeDataIntoQueryString(method, props.href || '', props.data)
 
     if (as === 'a' && method !== 'get') {
-      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<inertia-link href="${href}" method="${method}" as="button">...</inertia-link>`)
+      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<Link href="${href}" method="${method}" as="button">...</Link>`)
     }
 
     return h(props.as, {

--- a/packages/inertia-vue/tests/cypress/integration/links.test.js
+++ b/packages/inertia-vue/tests/cypress/integration/links.test.js
@@ -995,7 +995,7 @@ describe('Links', () => {
         .should('be.calledWith',
           'Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\n' +
           'Please specify a more appropriate element using the "as" attribute. For example:\n\n' +
-          '<inertia-link href="/example" method="post" as="button">...</inertia-link>',
+          '<Link href="/example" method="post" as="button">...</Link>',
         )
     })
 
@@ -1021,7 +1021,7 @@ describe('Links', () => {
         .should('be.calledWith',
           'Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\n' +
           'Please specify a more appropriate element using the "as" attribute. For example:\n\n' +
-          '<inertia-link href="/example" method="put" as="button">...</inertia-link>',
+          '<Link href="/example" method="put" as="button">...</Link>',
         )
     })
 
@@ -1047,7 +1047,7 @@ describe('Links', () => {
         .should('be.calledWith',
           'Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\n' +
           'Please specify a more appropriate element using the "as" attribute. For example:\n\n' +
-          '<inertia-link href="/example" method="patch" as="button">...</inertia-link>',
+          '<Link href="/example" method="patch" as="button">...</Link>',
         )
     })
 
@@ -1073,7 +1073,7 @@ describe('Links', () => {
         .should('be.calledWith',
           'Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\n' +
           'Please specify a more appropriate element using the "as" attribute. For example:\n\n' +
-          '<inertia-link href="/example" method="delete" as="button">...</inertia-link>',
+          '<Link href="/example" method="delete" as="button">...</Link>',
         )
     })
 

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -47,7 +47,7 @@ export default {
       const [href, data] = mergeDataIntoQueryString(method, props.href || '', props.data)
 
       if (as === 'a' && method !== 'get') {
-        console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<inertia-link href="${href}" method="${method}" as="button">...</inertia-link>`)
+        console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<Link href="${href}" method="${method}" as="button">...</Link>`)
       }
 
       return h(props.as, {


### PR DESCRIPTION
Console alert messages still use the old `inertia-link` syntax. This PR replaces them with the new syntax.

(I hope I didn't break anything! :pray: )