### PR TITLE
Fix incorrect type for useForm methods

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -79,12 +79,12 @@ export interface InertiaFormProps<TForm = Record<string, any>> {
 	transform: (callback: (data: TForm) => TForm) => void
 	reset: (...fields: (keyof TForm)[]) => void
 	clearErrors: (...fields: (keyof TForm)[]) => void
-	submit: (method: Inertia.Method, url: string, options?: Inertia.VisitOptions) => Promise<void>
-	get: (url: string, options?: Inertia.VisitOptions) => Promise<void>
-	patch: (url: string, options?: Inertia.VisitOptions) => Promise<void>
-	post: (url: string, options?: Inertia.VisitOptions) => Promise<void>
-	put: (url: string, options?: Inertia.VisitOptions) => Promise<void>
-	delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
+	submit: (method: Inertia.Method, url: string, options?: Inertia.VisitOptions) => void
+	get: (url: string, options?: Inertia.VisitOptions) => void
+	patch: (url: string, options?: Inertia.VisitOptions) => void
+	post: (url: string, options?: Inertia.VisitOptions) => void
+	put: (url: string, options?: Inertia.VisitOptions) => void
+	delete: (url: string, options?: Inertia.VisitOptions) => void
 }
 
 export function useForm<TForm = Record<string, any>>(initialValues: TForm): InertiaFormProps<TForm>;


### PR DESCRIPTION
Hello,
This PR fix the return value for `useForm` methods (`submit`, `get`, `patch`, `post`, `put` and `delete`) because that methods need return `void` instead `Promise<void>` (that methods is not promise).

Thanks.