### PR TITLE
feat(vue): support `external` property

### DIFF
--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -22,6 +22,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    external: {
+      type: Boolean,
+      default: false,
+    },
     preserveScroll: {
       type: Boolean,
       default: false,
@@ -70,6 +74,10 @@ export default {
         ...data.on,
         click: event => {
           data.on.click(event)
+					
+          if (props.external) {
+            return
+          }
 
           if (shouldIntercept(event)) {
             event.preventDefault()

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -27,6 +27,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    external: {
+      type: Boolean,
+      default: false,
+    },
     preserveState: {
       type: Boolean,
       default: null,
@@ -54,6 +58,10 @@ export default {
         ...attrs,
         ...as === 'a' ? { href } : {},
         onClick: (event) => {
+          if (props.external) {
+            return
+          }
+					
           if (shouldIntercept(event)) {
             event.preventDefault()
 


### PR DESCRIPTION
On par with https://github.com/inertiajs/inertia/pull/926, this PR adds support for a (non-standard) `external` property, which allows to *not* call `preventDefault` and keep the `a`. 

My use case for this feature is that the navigation is generated in the back-end, and some of the links are not meant to be used with Inertia - they lead to an external web page. 

```html
<InertiaLink
	v-for="item in navigation.sidebar"
	:key="item.title"
	:href="item.url"
	:class="[
		item.active
			? 'bg-gray-900 text-white'
			: 'text-gray-100 hover:bg-gray-900 hover:text-white',
		'group w-full p-3 rounded-md flex flex-col items-center text-xs font-medium'
	]"
	:aria-current="item.active ? 'page' : undefined"
	:external="item.attributes.external"
>
	<!-- ... -->
</InertiaLink>
```

Without this `external` property, clicking on the link would do nothing, and there would be an error in the console since the target URL would not return a valid Inertia response. 

Thanks to this `external` property, I don't have to use Vue's `component` component or conditionally displaying a different link, resulting in leaner and more readable code.

--- 

Note: I'm unsure if the early return in the implementation for the Vue 2 adapter should be before the call to `data.on.click(event)` or not.