### PR TITLE
fix useForm with useRemember

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -87,7 +87,7 @@ export interface InertiaFormProps<TForm = Record<string, any>> {
 	delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
 }
 
-export function useForm<TForm = Record<string, any>>(initialValues: TForm, rememberKey?: string): InertiaFormProps<TForm>;
+export function useForm<TForm = Record<string, any>>(rememberKeyOrInitialValues: string | TForm, initialValues?: TForm): InertiaFormProps<TForm>;
 
 export type SetupOptions<ElementType, SharedProps> = {
     el: ElementType,

--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -87,7 +87,7 @@ export interface InertiaFormProps<TForm = Record<string, any>> {
 	delete: (url: string, options?: Inertia.VisitOptions) => Promise<void>
 }
 
-export function useForm<TForm = Record<string, any>>(initialValues: TForm): InertiaFormProps<TForm>;
+export function useForm<TForm = Record<string, any>>(initialValues: TForm, rememberKey?: string): InertiaFormProps<TForm>;
 
 export type SetupOptions<ElementType, SharedProps> = {
     el: ElementType,

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -3,11 +3,11 @@ import useRemember from './useRemember'
 import { Inertia } from '@inertiajs/inertia'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-export default function useForm(initialData, rememberKey) {
+export default function useForm(rememberKeyOrInitialData, initialData) {
   
   const isMounted = useRef(null)
-  const useRememberKey = typeof rememberKey === 'string' ? rememberKey : null
-  const defaults = initialData || {}
+  const useRememberKey = typeof rememberKey === 'string' ? rememberKeyOrInitialData : null
+  const defaults = useRememberKey === null ? rememberKeyOrInitialData:  initialData
   const cancelToken = useRef(null)
   const recentlySuccessfulTimeoutId = useRef(null)
   const [data, setData] = useRememberKey ? useRemember(defaults, `${useRememberKey}:data`) : useState(defaults)

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -3,14 +3,15 @@ import useRemember from './useRemember'
 import { Inertia } from '@inertiajs/inertia'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-export default function useForm(...args) {
+export default function useForm(initialData, rememberKey) {
+  
   const isMounted = useRef(null)
-  const rememberKey = typeof args[0] === 'string' ? args[0] : null
-  const defaults = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
+  const useRememberKey = typeof rememberKey === 'string' ? rememberKey : null
+  const defaults = initialData || {}
   const cancelToken = useRef(null)
   const recentlySuccessfulTimeoutId = useRef(null)
-  const [data, setData] = rememberKey ? useRemember(defaults, `${rememberKey}:data`) : useState(defaults)
-  const [errors, setErrors] = rememberKey ? useRemember({}, `${rememberKey}:errors`) : useState({})
+  const [data, setData] = useRememberKey ? useRemember(defaults, `${useRememberKey}:data`) : useState(defaults)
+  const [errors, setErrors] = useRememberKey ? useRemember({}, `${useRememberKey}:errors`) : useState({})
   const [hasErrors, setHasErrors] = useState(false)
   const [processing, setProcessing] = useState(false)
   const [progress, setProgress] = useState(null)

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -446,7 +446,7 @@ export class Router {
     this.replaceState({
       ...this.page,
       rememberedState: {
-        ...this.page.rememberedState,
+        ...this.page?.rememberedState,
         [key]: data,
       },
     })


### PR DESCRIPTION
Useform did not work in combination with useRemember. The types were wrong & the function used an odd way to trigger the useRemember function. This adds an extra param to the useForm to add an rememberkey (just like useRemember works).

You can now add an extra param to trigger the useRemember function.
If you do not add the param, it will use useState instead of useRemember.
```
const initialValues = {
      first_name: '',
      last_name: ''
}

const { data, setData } = useForm(initialValues, 'registerForm');
```



RememberedState also threw an error mentioned in https://github.com/inertiajs/inertia/issues/866 , made this optional to fix it.