### PR TITLE
fix: system to check whether a URL has host

### DIFF
--- a/packages/inertia/src/url.ts
+++ b/packages/inertia/src/url.ts
@@ -11,7 +11,7 @@ export function mergeDataIntoQueryString(
   href: URL|string,
   data: Record<string, FormDataConvertible>,
 ): [string, Record<string, FormDataConvertible>] {
-  const hasHost = href.toString().includes('http')
+  const hasHost = href.toString().startsWith('http://') ||  href.toString().startsWith('https://')
   const hasAbsolutePath = hasHost || href.toString().startsWith('/')
   const hasRelativePath = !hasAbsolutePath && !href.toString().startsWith('#') && !href.toString().startsWith('?')
   const hasSearch = href.toString().includes('?') || (method === Method.GET && Object.keys(data).length)


### PR DESCRIPTION
Right now `@inertiajs/inertia` detects whether a URL has `host` or not by simply checking if it includes the word `http`. Which causes an error when using a relative URL that includes the word `http` (see issue #963). This PR attempts to solve the issue by checking if the URL starts with `http://` or `https://`.
