### PR TITLE
Query String: Allow different 'Array' formatters

### DIFF
--- a/packages/inertia-react/src/Link.js
+++ b/packages/inertia-react/src/Link.js
@@ -14,6 +14,7 @@ export default forwardRef(function InertiaLink({
   replace = false,
   only = [],
   headers = {},
+  queryStringArrayFormat = 'brackets',
   onClick = noop,
   onCancelToken = noop,
   onBefore = noop,
@@ -74,7 +75,7 @@ export default forwardRef(function InertiaLink({
 
   as = as.toLowerCase()
   method = method.toLowerCase()
-  const [_href, _data] = mergeDataIntoQueryString(method, href || '', data)
+  const [_href, _data] = mergeDataIntoQueryString(method, href || '', data, queryStringArrayFormat)
   href = _href
   data = _data
 

--- a/packages/inertia-svelte/src/link.js
+++ b/packages/inertia-svelte/src/link.js
@@ -2,7 +2,7 @@ import { createEventDispatcher } from 'svelte'
 import { Inertia, mergeDataIntoQueryString, shouldIntercept } from '@inertiajs/inertia'
 
 export default (node, options = {}) => {
-  const [href, data] = mergeDataIntoQueryString(options.method || 'get', node.href || options.href || '', options.data || {})
+  const [href, data] = mergeDataIntoQueryString(options.method || 'get', node.href || options.href || '', options.data || {}, options.queryStringArrayFormat || 'brackets')
   node.href = href
   options.data = data
 

--- a/packages/inertia-svelte/src/link.js
+++ b/packages/inertia-svelte/src/link.js
@@ -27,7 +27,7 @@ export default (node, options = {}) => {
 
   return {
     update(newOptions) {
-      const [href, data] = mergeDataIntoQueryString(newOptions.method || 'get', node.href || newOptions.href, newOptions.data || {})
+      const [href, data] = mergeDataIntoQueryString(newOptions.method || 'get', node.href || newOptions.href, newOptions.data || {}, newOptions.queryStringArrayFormat || 'brackets')
       node.href = href
       newOptions.data = data
       options = newOptions

--- a/packages/inertia-vue/src/link.js
+++ b/packages/inertia-vue/src/link.js
@@ -38,6 +38,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    queryStringArrayFormat: {
+      type: String,
+      default: 'brackets',
+    },
   },
   render(h, { props, data, children }) {
     data.on = {
@@ -54,7 +58,7 @@ export default {
 
     const as = props.as.toLowerCase()
     const method = props.method.toLowerCase()
-    const [href, propsData] = mergeDataIntoQueryString(method, props.href || '', props.data)
+    const [href, propsData] = mergeDataIntoQueryString(method, props.href || '', props.data, props.queryStringArrayFormat)
 
     if (as === 'a' && method !== 'get') {
       console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<Link href="${href}" method="${method}" as="button">...</Link>`)

--- a/packages/inertia-vue/tests/app/Pages/Links/Data/Object.vue
+++ b/packages/inertia-vue/tests/app/Pages/Links/Data/Object.vue
@@ -7,5 +7,9 @@
     <inertia-link as="button" method="PUT" href="/dump/put" :data="{ baz: 'put' }" class="put">PUT Link</inertia-link>
     <inertia-link as="button" method="PATCH" href="/dump/patch" :data="{ foo: 'patch' }" class="patch">PATCH Link</inertia-link>
     <inertia-link as="button" method="DELETE" href="/dump/delete" :data="{ bar: 'delete' }" class="delete">DELETE Link</inertia-link>
+
+    <inertia-link href="/dump/get" :data="{ a: ['b', 'c'] }" class="qsaf-default">QSAF Defaults</inertia-link>
+    <inertia-link href="/dump/get" :data="{ a: ['b', 'c'] }" queryStringArrayFormat="indices" class="qsaf-indices">QSAF Indices</inertia-link>
+    <inertia-link href="/dump/get" :data="{ a: ['b', 'c'] }" queryStringArrayFormat="brackets" class="qsaf-brackets">QSAF Brackets</inertia-link>
   </div>
 </template>

--- a/packages/inertia-vue/tests/app/Pages/Visits/Data/Object.vue
+++ b/packages/inertia-vue/tests/app/Pages/Visits/Data/Object.vue
@@ -8,6 +8,10 @@
     <span @click="putMethod" class="put">PUT Link</span>
     <span @click="patchMethod" class="patch">PATCH Link</span>
     <span @click="deleteMethod" class="delete">DELETE Link</span>
+
+    <span @click="qsafDefault" class="qsaf-default">QSAF Defaults</span>
+    <span @click="qsafIndices" class="qsaf-indices">QSAF Indices</span>
+    <span @click="qsafBrackets" class="qsaf-brackets">QSAF Brackets</span>
   </div>
 </template>
 <script>
@@ -43,6 +47,23 @@ export default {
         data: { baz: 'delete' }
       })
     },
+    qsafDefault() {
+      this.$inertia.visit('/dump/get', {
+        data: { a: ['b', 'c'] },
+      });
+    },
+    qsafIndices() {
+      this.$inertia.visit('/dump/get', {
+        data: { a: ['b', 'c'] },
+        queryStringArrayFormat: 'indices',
+      });
+    },
+    qsafBrackets() {
+      this.$inertia.visit('/dump/get', {
+        data: { a: ['b', 'c'] },
+        queryStringArrayFormat: 'brackets',
+      });
+    }
   }
 }
 </script>

--- a/packages/inertia-vue/tests/cypress/integration/links.test.js
+++ b/packages/inertia-vue/tests/cypress/integration/links.test.js
@@ -139,47 +139,57 @@ describe('Links', () => {
   describe('Data', () => {
     describe('plain objects', () => {
       beforeEach(() => {
+        cy.intercept('/dump/**').as('spy')
         cy.visit('/links/data/object', {
-          onLoad: () => cy.on('window:load', () => { throw 'A location/non-SPA visit was detected' }),
+          onLoad: () => cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
         })
       })
 
-      it('passes data as params using the GET method', () => {
-        cy.get('.get').click()
-        cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+      describe('GET method', () => {
+        it('passes data as params', () => {
+          cy.get('.get').click()
 
-        cy.window().should('have.property', '_inertia_request_dump')
-        cy.window()
-          .then(window => window._inertia_request_dump)
-          .then(({ method, headers, form, files, query }) => {
-            expect(headers).to.contain.key('content-type')
-            expect(headers['content-type']).to.contain('application/json')
-
-            expect(method).to.eq('get')
-            expect(query).to.contain.key('foo')
-            expect(query.foo).to.eq('get')
-            expect(form).to.be.empty
-            expect(files).to.be.empty
+          cy.wait('@spy').then(({request, response}) => {
+            expect(request.url).to.eq(Cypress.config().baseUrl + '/dump/get?foo=get')
+            expect(request.headers).to.contain.key('content-type')
+            expect(request.headers['content-type']).to.contain('application/json')
+            expect(request.method).to.eq('GET')
+            expect(response.body.props.form).to.be.empty
+            expect(response.body.props.files).to.be.undefined
           })
+        })
+
+        describe('query string array formatter', () => {
+          it('can use the brackets query string array formatter', () => {
+            cy.get('.qsaf-brackets').click()
+            cy.wait('@spy').its('request.url').should('eq', Cypress.config().baseUrl + '/dump/get?a[]=b&a[]=c')
+          })
+
+          it('can use the indices query string array formatter', () => {
+            cy.get('.qsaf-indices').click()
+            cy.wait('@spy').its('request.url').should('eq', Cypress.config().baseUrl + '/dump/get?a[0]=b&a[1]=c')
+          })
+
+          it('defaults to using the brackets query string array formatter', () => {
+            cy.get('.qsaf-default').click()
+            cy.wait('@spy').its('request.url').should('eq', Cypress.config().baseUrl + '/dump/get?a[]=b&a[]=c')
+          })
+        })
       })
 
       it('can pass data using the POST method', () => {
         cy.get('.post').click()
-        cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
-
-        cy.window().should('have.property', '_inertia_request_dump')
-        cy.window()
-          .then(window => window._inertia_request_dump)
-          .then(({ method, headers, form, files, query }) => {
-            expect(headers).to.contain.key('content-type')
-            expect(headers['content-type']).to.contain('application/json')
-
-            expect(method).to.eq('post')
-            expect(query).to.be.empty
-            expect(form).to.contain.key('bar')
-            expect(form.bar).to.eq('post')
-            expect(files).to.be.empty
-          })
+        cy.wait('@spy').then(({ request, response }) => {
+          expect(request.url).to.eq(Cypress.config().baseUrl + '/dump/post')
+          expect(request.headers).to.contain.key('content-type')
+          expect(request.headers['content-type']).to.contain('application/json')
+          expect(request.method).to.eq('POST')
+          expect(response.body.props.form).to.contain.key('bar')
+          expect(response.body.props.form.bar).to.eq('post')
+          expect(response.body.props.files).to.be.undefined
+        })
       })
 
       it('can pass data using the PUT method', () => {

--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -39,12 +39,16 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    queryStringArrayFormat: {
+      type: String,
+      default: 'brackets',
+    },
   },
   setup(props, { slots, attrs }) {
     return props => {
       const as = props.as.toLowerCase()
       const method = props.method.toLowerCase()
-      const [href, data] = mergeDataIntoQueryString(method, props.href || '', props.data)
+      const [href, data] = mergeDataIntoQueryString(method, props.href || '', props.data, props.queryStringArrayFormat)
 
       if (as === 'a' && method !== 'get') {
         console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<Link href="${href}" method="${method}" as="button">...</Link>`)

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -211,6 +211,7 @@ export class Router {
     onCancel = () => {},
     onSuccess = () => {},
     onError = () => {},
+    queryStringArrayFormat = 'brackets',
   }: VisitOptions = {}): void {
     let url = typeof href === 'string' ? hrefToUrl(href) : href
 
@@ -219,7 +220,7 @@ export class Router {
     }
 
     if (!(data instanceof FormData)) {
-      const [_href, _data] = mergeDataIntoQueryString(method, url, data)
+      const [_href, _data] = mergeDataIntoQueryString(method, url, data, queryStringArrayFormat)
       url = hrefToUrl(_href)
       data = _data
     }
@@ -235,6 +236,7 @@ export class Router {
       headers,
       errorBag,
       forceFormData,
+      queryStringArrayFormat,
       cancelled: false,
       completed: false,
       interrupted: false,
@@ -251,7 +253,7 @@ export class Router {
     this.saveScrollPositions()
 
     const visitId = this.createVisitId()
-    this.activeVisit = { ...visit, onCancelToken, onBefore, onStart, onProgress, onFinish, onCancel, onSuccess, onError, cancelToken: Axios.CancelToken.source() }
+    this.activeVisit = { ...visit, onCancelToken, onBefore, onStart, onProgress, onFinish, onCancel, onSuccess, onError, queryStringArrayFormat, cancelToken: Axios.CancelToken.source() }
 
     onCancelToken({
       cancel: () => {

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -63,6 +63,7 @@ export type Visit = {
   headers: Record<string, string>
   errorBag: string|null,
   forceFormData: boolean,
+  queryStringArrayFormat: 'indices'|'brackets',
 }
 
 export type GlobalEventsMap = {

--- a/packages/inertia/src/url.ts
+++ b/packages/inertia/src/url.ts
@@ -10,7 +10,7 @@ export function mergeDataIntoQueryString(
   method: Method,
   href: URL|string,
   data: Record<string, FormDataConvertible>,
-  qsArrayFormat: 'indices'|'brackets'|'repeat'|'comma' = 'brackets',
+  qsArrayFormat: 'indices'|'brackets' = 'brackets',
 ): [string, Record<string, FormDataConvertible>] {
   const hasHost = href.toString().startsWith('http://') ||  href.toString().startsWith('https://')
   const hasAbsolutePath = hasHost || href.toString().startsWith('/')

--- a/packages/inertia/src/url.ts
+++ b/packages/inertia/src/url.ts
@@ -10,6 +10,7 @@ export function mergeDataIntoQueryString(
   method: Method,
   href: URL|string,
   data: Record<string, FormDataConvertible>,
+  qsArrayFormat: 'indices'|'brackets'|'repeat'|'comma' = 'brackets',
 ): [string, Record<string, FormDataConvertible>] {
   const hasHost = href.toString().startsWith('http://') ||  href.toString().startsWith('https://')
   const hasAbsolutePath = hasHost || href.toString().startsWith('/')
@@ -22,7 +23,7 @@ export function mergeDataIntoQueryString(
   if (method === Method.GET && Object.keys(data).length) {
     url.search = qs.stringify(deepmerge(qs.parse(url.search, { ignoreQueryPrefix: true }), data), {
       encodeValuesOnly: true,
-      arrayFormat: 'indices',
+      arrayFormat: qsArrayFormat,
     })
     data = {}
   }


### PR DESCRIPTION
This PR enables the ability to provide a different method of formatting query string when making GET-requests with URL params (data).

It allows for the following options, available with _all_ Inertia visit types. (The default is the "brackets" type):
```html
<Link href="/foo" :data="{ a: ['b', 'c'] }" queryStringArrayFormat="brackets">Example</Link>
<!-- Generated href: /foo?a[]=b&a[]=c -->

<Link href="/foo" :data="{ a: ['b', 'c'] }" queryStringArrayFormat="indices">Example</Link>
<!-- Generated href: /foo?a[0]=b&a[1]=c -->
```
