### PR TITLE
Add "setErrors" method to Form helper

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -89,6 +89,8 @@ export interface InertiaFormProps<TForm = Record<string, any>> {
 	transform: (callback: (data: TForm) => TForm) => void
 	reset: (...fields: (keyof TForm)[]) => void
 	clearErrors: (...fields: (keyof TForm)[]) => void
+    setError(field: string, value: string): void
+    setError(errors: Record<keyof TForm, string>): void
 	submit: (method: Inertia.Method, url: string, options?: Inertia.VisitOptions) => void
 	get: (url: string, options?: Inertia.VisitOptions) => void
 	patch: (url: string, options?: Inertia.VisitOptions) => void

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -18,6 +18,8 @@ export default function useForm(...args) {
   const [recentlySuccessful, setRecentlySuccessful] = useState(false)
   let transform = (data) => data
 
+  useEffect(() => setHasErrors(Object.keys(errors).length > 0), [errors])
+
   useEffect(() => {
     isMounted.current = true
     return () => {
@@ -64,7 +66,6 @@ export default function useForm(...args) {
             setProcessing(false)
             setProgress(null)
             setErrors({})
-            setHasErrors(false)
             setWasSuccessful(true)
             setRecentlySuccessful(true)
             recentlySuccessfulTimeoutId.current = setTimeout(() => {
@@ -83,7 +84,6 @@ export default function useForm(...args) {
             setProcessing(false)
             setProgress(null)
             setErrors(errors)
-            setHasErrors(true)
           }
 
           if (options.onError) {
@@ -159,24 +159,19 @@ export default function useForm(...args) {
       }
     },
     setError(key, value) {
-      setErrors({
+      setErrors(errors => ({
         ... errors,
-        ... (value ? { [key]: value } : key),
-      })
-
-      setHasErrors(Object.keys(errors).length > 0)
+        [key]: value,
+      }))
     },
     clearErrors(...fields) {
-      setErrors(
-        Object.keys(errors).reduce(
-          (carry, field) => ({
-            ...carry,
-            ...(fields.length > 0 && !fields.includes(field) ? { [field]: errors[field] } : {}),
-          }),
-          {},
-        ),
-      )
-      setHasErrors(Object.keys(errors).length > 0)
+      setErrors(errors => Object.keys(errors).reduce(
+        (carry, field) => ({
+          ...carry,
+          ...(fields.length > 0 && !fields.includes(field) ? { [field]: errors[field] } : {}),
+        }),
+        {},
+      ))
     },
     submit,
     get(url, options) {

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -158,6 +158,14 @@ export default function useForm(...args) {
         )
       }
     },
+    setError(key, value) {
+      setErrors({
+        ... errors,
+        ... (value ? { [key]: value } : key),
+      })
+
+      setHasErrors(Object.keys(errors).length > 0)
+    },
     clearErrors(...fields) {
       setErrors(
         Object.keys(errors).reduce(

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -137,6 +137,7 @@ export default function useForm(...args) {
     isDirty: !isEqual(data, defaults),
     errors,
     hasErrors,
+    setErrors,
     processing,
     progress,
     wasSuccessful,

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -137,7 +137,6 @@ export default function useForm(...args) {
     isDirty: !isEqual(data, defaults),
     errors,
     hasErrors,
-    setErrors,
     processing,
     progress,
     wasSuccessful,

--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -55,26 +55,21 @@ function useForm(...args) {
       return this
     },
     setError(key, value) {
-      const errors = {
+      this.setStore('errors', {
         ...this.errors,
         ...(value ? { [key]: value } : key),
-      }
-
-      this.setStore('errors', errors)
-      this.setStore('hasErrors', Object.keys(errors).length > 0)
+      })
 
       return this
     },
     clearErrors(...fields) {
-      const errors = Object
-        .keys(this.errors)
-        .reduce((carry, field) => ({
+      this.setStore('errors', Object.keys(this.errors).reduce(
+        (carry, field) => ({
           ...carry,
           ...(fields.length > 0 && !fields.includes(field) ? { [field] : this.errors[field] } : {}),
-        }), {})
-
-      this.setStore('errors', errors)
-      this.setStore('hasErrors', Object.keys(errors).length > 0)
+        }), 
+        {},
+      ))
 
       return this
     },
@@ -184,6 +179,11 @@ function useForm(...args) {
   store.subscribe(form => {
     if (form.isDirty === isEqual(form.data(), defaults)) {
       form.setStore('isDirty', !form.isDirty)
+    }
+
+    const hasErrors = Object.keys(form.errors).length > 0
+    if (form.hasErrors !== hasErrors) {
+      form.setStore('hasErrors', !form.hasErrors)
     }
 
     if (rememberKey) {

--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -54,6 +54,17 @@ function useForm(...args) {
 
       return this
     },
+    setError(key, value) {
+      const errors = {
+        ...this.errors,
+        ...(value ? { [key]: value } : key),
+      }
+
+      this.setStore('errors', errors)
+      this.setStore('hasErrors', Object.keys(errors).length > 0)
+
+      return this
+    },
     clearErrors(...fields) {
       const errors = Object
         .keys(this.errors)
@@ -117,8 +128,7 @@ function useForm(...args) {
         onError: errors => {
           this.setStore('processing', false)
           this.setStore('progress', null)
-          this.setStore('errors', errors)
-          this.setStore('hasErrors', true)
+          this.clearErrors().setError(errors)
 
           if (options.onError) {
             return options.onError(errors)

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -79,6 +79,8 @@ export interface InertiaFormProps<TForm> {
   transform(callback: (data: TForm) => object): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
+  setError(field: string, value: string): this
+  setError(errors: Record<keyof TForm, string>): this
   submit(method: string, url: string, options?: Partial<Inertia.VisitOptions>): void
   get(url: string, options?: Partial<Inertia.VisitOptions>): void
   post(url: string, options?: Partial<Inertia.VisitOptions>): void

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -56,6 +56,8 @@ export default function(...args) {
     setError(key, value) {
       Object.assign(this.errors, (value ? { [key]: value } : key))
 
+      this.hasErrors = Object.keys(this.errors).length > 0
+
       return this
     },
     clearErrors(...fields) {
@@ -65,6 +67,8 @@ export default function(...args) {
           ...carry,
           ...(fields.length > 0 && !fields.includes(field) ? { [field] : this.errors[field] } : {}),
         }), {})
+
+      this.hasErrors = Object.keys(this.errors).length > 0
 
       return this
     },
@@ -182,7 +186,6 @@ export default function(...args) {
   new Vue({
     created() {
       this.$watch(() => form, newValue => {
-        form.hasErrors = Object.keys(newValue.errors).length > 0
         form.isDirty = !isEqual(form.data(), defaults)
         if (rememberKey) {
           Inertia.remember(newValue.__remember(), rememberKey)

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -55,8 +55,6 @@ export default function(...args) {
     },
     setError(key, value) {
       Object.assign(this.errors, (value ? { [key]: value } : key))
-      
-      this.hasErrors = Object.keys(this.errors).length > 0
 
       return this
     },
@@ -67,8 +65,6 @@ export default function(...args) {
           ...carry,
           ...(fields.length > 0 && !fields.includes(field) ? { [field] : this.errors[field] } : {}),
         }), {})
-
-      this.hasErrors = Object.keys(this.errors).length > 0
 
       return this
     },
@@ -186,6 +182,7 @@ export default function(...args) {
   new Vue({
     created() {
       this.$watch(() => form, newValue => {
+        form.hasErrors = Object.keys(form.errors).length > 0
         form.isDirty = !isEqual(form.data(), defaults)
         if (rememberKey) {
           Inertia.remember(newValue.__remember(), rememberKey)

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -182,7 +182,7 @@ export default function(...args) {
   new Vue({
     created() {
       this.$watch(() => form, newValue => {
-        form.hasErrors = Object.keys(form.errors).length > 0
+        form.hasErrors = Object.keys(newValue.errors).length > 0
         form.isDirty = !isEqual(form.data(), defaults)
         if (rememberKey) {
           Inertia.remember(newValue.__remember(), rememberKey)

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -53,6 +53,13 @@ export default function(...args) {
 
       return this
     },
+    setError(key, value) {
+      Object.assign(this.errors, (value ? { [key]: value } : key))
+      
+      this.hasErrors = Object.keys(this.errors).length > 0
+
+      return this
+    },
     clearErrors(...fields) {
       this.errors = Object
         .keys(this.errors)
@@ -115,8 +122,7 @@ export default function(...args) {
         onError: errors => {
           this.processing = false
           this.progress = null
-          this.errors = errors
-          this.hasErrors = true
+          this.clearErrors().setError(errors)
 
           if (options.onError) {
             return options.onError(errors)
@@ -173,8 +179,7 @@ export default function(...args) {
     },
     __restore(restored) {
       Object.assign(this, restored.data)
-      Object.assign(this.errors, restored.errors)
-      this.hasErrors = Object.keys(this.errors).length > 0
+      this.setError(restored.errors)
     },
   })
 

--- a/packages/inertia-vue/tests/app/Pages/FormHelper/Errors.vue
+++ b/packages/inertia-vue/tests/app/Pages/FormHelper/Errors.vue
@@ -20,6 +20,8 @@
 
     <span @click="clearErrors" class="clear">Clear all errors</span>
     <span @click="clearError" class="clear-one">Clear one error</span>
+    <span @click="setErrors" class="set">Set errors</span>
+    <span @click="setError" class="set-one">Set one error</span>
 
     <span class="errors-status">Form has {{ form.hasErrors ? '' : 'no ' }}errors</span>
   </div>
@@ -44,6 +46,15 @@ export default {
     },
     clearError() {
       this.form.clearErrors('handle')
+    },
+    setErrors() {
+      this.form.setError({
+        name: 'Manually set Name error',
+        handle: 'Manually set Handle error',
+      })
+    },
+    setError() {
+      this.form.setError('handle', 'Manually set Handle error')
     }
   }
 }

--- a/packages/inertia-vue/tests/cypress/integration/form-helper.test.js
+++ b/packages/inertia-vue/tests/cypress/integration/form-helper.test.js
@@ -169,7 +169,7 @@ describe('Form Helper', () => {
       cy.get('#remember').check()
     })
 
-    it('can displays form errors', () => {
+    it('can display form errors', () => {
       cy.get('.name_error').should('not.exist')
       cy.get('.handle_error').should('not.exist')
       cy.get('.remember_error').should('not.exist')
@@ -261,6 +261,26 @@ describe('Form Helper', () => {
       cy.get('#name').should('have.value', 'A')
       cy.get('#handle').should('have.value', 'B')
       cy.get('#remember').should('be.checked')
+    })
+
+    it('can set a single error', () => {
+      cy.get('.set-one').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('have.text', 'Manually set Handle error')
+      cy.get('.remember_error').should('not.exist')
+    })
+
+    it('can set multiple errors', () => {
+      cy.get('.set').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Manually set Name error')
+      cy.get('.handle_error').should('have.text', 'Manually set Handle error')
+      cy.get('.remember_error').should('not.exist')
     })
   })
 

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -69,6 +69,8 @@ export interface InertiaFormProps<TForm> {
   transform(callback: (data: TForm) => object): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
+  setError(field: string, value: string): this
+  setError(errors: Record<keyof TForm, string>): this
   submit(method: string, url: string, options?: Partial<Inertia.VisitOptions>): void
   get(url: string, options?: Partial<Inertia.VisitOptions>): void
   post(url: string, options?: Partial<Inertia.VisitOptions>): void

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -53,6 +53,13 @@ export default function useForm(...args) {
 
       return this
     },
+    setError(key, value) {
+      Object.assign(this.errors, (value ? { [key]: value } : key))
+
+      this.hasErrors = Object.keys(this.errors).length > 0
+
+      return this
+    },
     clearErrors(...fields) {
       this.errors = Object
         .keys(this.errors)
@@ -115,8 +122,7 @@ export default function useForm(...args) {
         onError: errors => {
           this.processing = false
           this.progress = null
-          this.errors = errors
-          this.hasErrors = true
+          this.clearErrors().setError(errors)
 
           if (options.onError) {
             return options.onError(errors)
@@ -173,8 +179,7 @@ export default function useForm(...args) {
     },
     __restore(restored) {
       Object.assign(this, restored.data)
-      Object.assign(this.errors, restored.errors)
-      this.hasErrors = Object.keys(this.errors).length > 0
+      this.setError(restored.errors)
     },
   })
 

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -56,8 +56,6 @@ export default function useForm(...args) {
     setError(key, value) {
       Object.assign(this.errors, (value ? { [key]: value } : key))
 
-      this.hasErrors = Object.keys(this.errors).length > 0
-
       return this
     },
     clearErrors(...fields) {
@@ -67,8 +65,6 @@ export default function useForm(...args) {
           ...carry,
           ...(fields.length > 0 && !fields.includes(field) ? { [field] : this.errors[field] } : {}),
         }), {})
-
-      this.hasErrors = Object.keys(this.errors).length > 0
 
       return this
     },
@@ -184,6 +180,7 @@ export default function useForm(...args) {
   })
 
   watch(form, newValue => {
+    form.hasErrors = Object.keys(form.errors).length > 0
     form.isDirty = !isEqual(form.data(), defaults)
     if (rememberKey) {
       Inertia.remember(cloneDeep(newValue.__remember()), rememberKey)

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -56,6 +56,8 @@ export default function useForm(...args) {
     setError(key, value) {
       Object.assign(this.errors, (value ? { [key]: value } : key))
 
+      this.hasErrors = Object.keys(this.errors).length > 0
+
       return this
     },
     clearErrors(...fields) {
@@ -65,6 +67,8 @@ export default function useForm(...args) {
           ...carry,
           ...(fields.length > 0 && !fields.includes(field) ? { [field] : this.errors[field] } : {}),
         }), {})
+
+      this.hasErrors = Object.keys(this.errors).length > 0
 
       return this
     },
@@ -180,7 +184,6 @@ export default function useForm(...args) {
   })
 
   watch(form, newValue => {
-    form.hasErrors = Object.keys(newValue.errors).length > 0
     form.isDirty = !isEqual(form.data(), defaults)
     if (rememberKey) {
       Inertia.remember(cloneDeep(newValue.__remember()), rememberKey)

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -180,7 +180,7 @@ export default function useForm(...args) {
   })
 
   watch(form, newValue => {
-    form.hasErrors = Object.keys(form.errors).length > 0
+    form.hasErrors = Object.keys(newValue.errors).length > 0
     form.isDirty = !isEqual(form.data(), defaults)
     if (rememberKey) {
       Inertia.remember(cloneDeep(newValue.__remember()), rememberKey)


### PR DESCRIPTION
This PR adds the ability to set form errors manually, which can be useful in situations where you're (for example) using third-party API calls to upload a file in the background, and want to show the error as part of your Inertia form. Other uses include third-party client-side JS validation libraries, or just custom checks such as a network status check.

## Usage:
```js
const form = this.$inertia.form({ 
  username: 'reinink',
  password: '',
});

// Single error
form.setError('username', 'This username is not available.');

// Multiple errors
form.setError({
  username: 'This username is already taken.',
  password: 'The password field cannot be left blank.'
});
```