### PR TITLE
Add form.resetWith() function to vue packages

### DIFF
--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -78,6 +78,7 @@ export interface InertiaFormProps<TForm> {
   data(): TForm
   transform(callback: (data: TForm) => object): this
   reset(...fields: (keyof TForm)[]): this
+  resetWith(newDefaults: {[Property in keyof TForm]: string}): this
   clearErrors(...fields: (keyof TForm)[]): this
   submit(method: string, url: string, options?: Partial<Inertia.VisitOptions>): void
   get(url: string, options?: Partial<Inertia.VisitOptions>): void

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -53,6 +53,17 @@ export default function(...args) {
 
       return this
     },
+    resetWith(newDefaults) {
+      if (typeof newDefaults === 'object' && Object.keys(newDefaults).length > 0) {
+        Object.keys(newDefaults).forEach(key => {
+          if (this.data().hasOwnProperty(key)) {
+            this[key] = newDefaults[key]
+          }
+        })
+      }
+
+      return this
+    },
     clearErrors(...fields) {
       this.errors = Object
         .keys(this.errors)

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -68,6 +68,7 @@ export interface InertiaFormProps<TForm> {
   data(): TForm
   transform(callback: (data: TForm) => object): this
   reset(...fields: (keyof TForm)[]): this
+  resetWith(newDefaults: {[Property in keyof TForm]: string}): this
   clearErrors(...fields: (keyof TForm)[]): this
   submit(method: string, url: string, options?: Partial<Inertia.VisitOptions>): void
   get(url: string, options?: Partial<Inertia.VisitOptions>): void

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -53,6 +53,17 @@ export default function useForm(...args) {
 
       return this
     },
+    resetWith(newDefaults) {
+      if (typeof newDefaults === 'object' && Object.keys(newDefaults).length > 0) {
+        Object.keys(newDefaults).forEach(key => {
+          if (this.data().hasOwnProperty(key)) {
+            this[key] = newDefaults[key]
+          }
+        })
+      }
+
+      return this
+    },
     clearErrors(...fields) {
       this.errors = Object
         .keys(this.errors)


### PR DESCRIPTION
Currently the `form.reset()` does not allow the users to reset the `form.data()` with their desired values. This PR adds a `form.resetWith()` function that accepts an object as the first (and only) argument and resets the form data with the given values.

Ex:
```js
// form data before:
// {
//   name: 'avril',
//   email: 'avril@example.com'
// }

form.resetWith({
   email: 'johny@example.com'
})

// after:
// {
//   name: 'avril',
//   email: 'johny@example.com'
// }
```