### PR TITLE
Allows rich text information to be rendered when the page is refreshed

### DIFF
--- a/packages/inertia-react/src/createInertiaApp.js
+++ b/packages/inertia-react/src/createInertiaApp.js
@@ -4,7 +4,7 @@ import { createElement } from 'react'
 export default async function createInertiaApp({ id = 'app', resolve, setup, title, page, render }) {
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
-  const initialPage = page || JSON.parse(el.dataset.page)
+  const initialPage = page || JSON.parse(`${el.dataset.page}`)
   const resolveComponent = name => Promise.resolve(resolve(name)).then(module => module.default || module)
 
   let head = []

--- a/packages/inertia-svelte/src/createInertiaApp.js
+++ b/packages/inertia-svelte/src/createInertiaApp.js
@@ -3,7 +3,7 @@ import App from './App.svelte'
 export default async function createInertiaApp({ id = 'app', resolve, setup, page, render }) {
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
-  const initialPage = page || JSON.parse(el.dataset.page)
+  const initialPage = page || JSON.parse(`${el.dataset.page}`)
   const resolveComponent = name => Promise.resolve(resolve(name))
 
   let head = []

--- a/packages/inertia-vue/src/createInertiaApp.js
+++ b/packages/inertia-vue/src/createInertiaApp.js
@@ -4,7 +4,7 @@ import App, { plugin } from './app'
 export default async function createInertiaApp({ id = 'app', resolve, setup, title, page, render }) {
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
-  const initialPage = page || JSON.parse(el.dataset.page)
+  const initialPage = page || JSON.parse(`${el.dataset.page}`)
   const resolveComponent = name => Promise.resolve(resolve(name)).then(module => module.default || module)
 
   Vue.use(plugin)

--- a/packages/inertia-vue3/src/createInertiaApp.js
+++ b/packages/inertia-vue3/src/createInertiaApp.js
@@ -4,7 +4,7 @@ import App, { plugin } from './app'
 export default async function createInertiaApp({ id = 'app', resolve, setup, title, page, render }) {
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
-  const initialPage = page || JSON.parse(el.dataset.page)
+  const initialPage = page || JSON.parse(`${el.dataset.page}`)
   const resolveComponent = name => Promise.resolve(resolve(name)).then(module => module.default || module)
 
   let head = []


### PR DESCRIPTION
When refreshing the page, the returned content contains rich text information, which will result in JSON.parse() error.