### PR TITLE
Allow vite dev server to find the entrypoint

### DIFF
--- a/packages/inertia/package.json
+++ b/packages/inertia/package.json
@@ -20,6 +20,7 @@
   "files": ["dist", "types"],
   "source": "src/index.ts",
   "main": "dist/index.js",
+  "module": "src/index.ts",
   "unpkg": "dist/index.umd.js",
   "types": "types/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Vite dev server needs the `module` entry in package.json, otherwise it uses dist/index.js, which is not an ES module, resulting in an error when trying to load that file as a module in the browser