### PR TITLE
Add "defaults" method to Form helper

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -87,6 +87,8 @@ export interface InertiaFormProps<TForm = Record<string, any>> {
 	recentlySuccessful: boolean
 	setData: setDataByObject<TForm> & setDataByMethod<TForm> & setDataByKeyValuePair<TForm>
 	transform: (callback: (data: TForm) => TForm) => void
+    setDefaults(field: keyof TForm, value: string): this
+    setDefaults(fields: Record<keyof TForm, string>): this
 	reset: (...fields: (keyof TForm)[]) => void
 	clearErrors: (...fields: (keyof TForm)[]) => void
     setError(field: keyof TForm, value: string): void

--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -87,8 +87,9 @@ export interface InertiaFormProps<TForm = Record<string, any>> {
 	recentlySuccessful: boolean
 	setData: setDataByObject<TForm> & setDataByMethod<TForm> & setDataByKeyValuePair<TForm>
 	transform: (callback: (data: TForm) => TForm) => void
-    setDefaults(field: keyof TForm, value: string): this
-    setDefaults(fields: Record<keyof TForm, string>): this
+    setDefaults(): void
+    setDefaults(field: keyof TForm, value: string): void
+    setDefaults(fields: Record<keyof TForm, string>): void
 	reset: (...fields: (keyof TForm)[]) => void
 	clearErrors: (...fields: (keyof TForm)[]) => void
     setError(field: keyof TForm, value: string): void

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 export default function useForm(...args) {
   const isMounted = useRef(null)
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
-  const defaults = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
+  const [defaults, setDefaults] = useState((typeof args[0] === 'string' ? args[1] : args[0]) || {})
   const cancelToken = useRef(null)
   const recentlySuccessfulTimeoutId = useRef(null)
   const [data, setData] = rememberKey ? useRemember(defaults, `${rememberKey}:data`) : useState(defaults)
@@ -143,6 +143,12 @@ export default function useForm(...args) {
     recentlySuccessful,
     transform(callback) {
       transform = callback
+    },
+    setDefaults(key, value) {
+      setDefaults({
+        ... defaults,
+        ... (value ? { [key]: value } : key),
+      })
     },
     reset(...fields) {
       if (fields.length === 0) {

--- a/packages/inertia-react/src/useForm.js
+++ b/packages/inertia-react/src/useForm.js
@@ -145,10 +145,14 @@ export default function useForm(...args) {
       transform = callback
     },
     setDefaults(key, value) {
-      setDefaults({
-        ... defaults,
-        ... (value ? { [key]: value } : key),
-      })
+      if (typeof key === 'undefined') {
+        setDefaults(() => data)
+      } else {
+        setDefaults(defaults => ({
+          ... defaults,
+          ... (value ? { [key]: value } : key),
+        }))
+      }
     },
     reset(...fields) {
       if (fields.length === 0) {

--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -39,6 +39,12 @@ function useForm(...args) {
       return this
     },
     defaults(key, value) {
+      if (typeof key === 'undefined') {
+        defaults = Object.assign(defaults, this.data())
+
+        return this
+      }
+
       defaults = Object.assign(
         defaults,
         value ? ({ [key]: value }) : key,

--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -38,6 +38,14 @@ function useForm(...args) {
 
       return this
     },
+    defaults(key, value) {
+      defaults = Object.assign(
+        defaults,
+        value ? ({ [key]: value }) : key,
+      )
+
+      return this
+    },
     reset(...fields) {
       if (fields.length === 0) {
         this.setStore(defaults)

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -81,6 +81,7 @@ export interface InertiaFormProps<TForm> {
   defaults(field: keyof TForm, value: string): this
   defaults(fields: Record<keyof TForm, string>): this
   reset(...fields: (keyof TForm)[]): this
+  resetWith(newDefaults: {[Property in keyof TForm]: string}): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
   setError(errors: Record<keyof TForm, string>): this

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -81,7 +81,6 @@ export interface InertiaFormProps<TForm> {
   defaults(field: keyof TForm, value: string): this
   defaults(fields: Record<keyof TForm, string>): this
   reset(...fields: (keyof TForm)[]): this
-  resetWith(newDefaults: {[Property in keyof TForm]: string}): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
   setError(errors: Record<keyof TForm, string>): this

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -77,6 +77,7 @@ export interface InertiaFormProps<TForm> {
   recentlySuccessful: boolean
   data(): TForm
   transform(callback: (data: TForm) => object): this
+  defaults(): this
   defaults(field: keyof TForm, value: string): this
   defaults(fields: Record<keyof TForm, string>): this
   reset(...fields: (keyof TForm)[]): this

--- a/packages/inertia-vue/index.d.ts
+++ b/packages/inertia-vue/index.d.ts
@@ -77,6 +77,8 @@ export interface InertiaFormProps<TForm> {
   recentlySuccessful: boolean
   data(): TForm
   transform(callback: (data: TForm) => object): this
+  defaults(field: keyof TForm, value: string): this
+  defaults(fields: Record<keyof TForm, string>): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -62,6 +62,17 @@ export default function(...args) {
 
       return this
     },
+    resetWith(newDefaults) {
+      if (typeof newDefaults === 'object' && Object.keys(newDefaults).length > 0) {
+        Object.keys(newDefaults).forEach(key => {
+          if (this.data().hasOwnProperty(key)) {
+            this[key] = newDefaults[key]
+          }
+        })
+      }
+      
+      return this
+    },
     setError(key, value) {
       Object.assign(this.errors, (value ? { [key]: value } : key))
 

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -62,17 +62,6 @@ export default function(...args) {
 
       return this
     },
-    resetWith(newDefaults) {
-      if (typeof newDefaults === 'object' && Object.keys(newDefaults).length > 0) {
-        Object.keys(newDefaults).forEach(key => {
-          if (this.data().hasOwnProperty(key)) {
-            this[key] = newDefaults[key]
-          }
-        })
-      }
-      
-      return this
-    },
     setError(key, value) {
       Object.assign(this.errors, (value ? { [key]: value } : key))
 

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -35,11 +35,15 @@ export default function(...args) {
       return this
     },
     defaults(key, value) {
-      defaults = Object.assign(
-        {},
-        cloneDeep(defaults),
-        value ? ({ [key]: value }) : key,
-      )
+      if (typeof key === 'undefined') {
+        defaults = this.data()
+      } else {
+        defaults = Object.assign(
+          {},
+          cloneDeep(defaults),
+          value ? ({[key]: value}) : key,
+        )
+      }
 
       return this
     },

--- a/packages/inertia-vue/src/form.js
+++ b/packages/inertia-vue/src/form.js
@@ -34,6 +34,15 @@ export default function(...args) {
 
       return this
     },
+    defaults(key, value) {
+      defaults = Object.assign(
+        {},
+        cloneDeep(defaults),
+        value ? ({ [key]: value }) : key,
+      )
+
+      return this
+    },
     reset(...fields) {
       let clonedDefaults = cloneDeep(defaults)
       if (fields.length === 0) {

--- a/packages/inertia-vue/tests/app/Pages/FormHelper/Data.vue
+++ b/packages/inertia-vue/tests/app/Pages/FormHelper/Data.vue
@@ -21,7 +21,9 @@
     <span @click="resetAll" class="reset">Reset all data</span>
     <span @click="resetOne" class="reset-one">Reset one field</span>
 
-    <span @click="reassignDefaults" class="reassign-defaults">Reassign default values</span>
+    <span @click="reassign" class="reassign">Reassign current as defaults</span>
+    <span @click="reassignObject" class="reassign-object">Reassign default values</span>
+    <span @click="reassignSingle" class="reassign-single">Reassign single default</span>
 
     <span class="errors-status">Form has {{ form.hasErrors ? '' : 'no ' }}errors</span>
   </div>
@@ -47,12 +49,18 @@ export default {
     resetOne() {
       this.form.reset('handle')
     },
-    reassignDefaults() {
+    reassign() {
+      this.form.defaults()
+    },
+    reassignObject() {
       this.form.defaults({
         handle: 'updated handle',
         remember: true
       })
-    }
+    },
+    reassignSingle() {
+      this.form.defaults('name', 'single value')
+    },
   }
 }
 </script>

--- a/packages/inertia-vue/tests/app/Pages/FormHelper/Data.vue
+++ b/packages/inertia-vue/tests/app/Pages/FormHelper/Data.vue
@@ -21,6 +21,8 @@
     <span @click="resetAll" class="reset">Reset all data</span>
     <span @click="resetOne" class="reset-one">Reset one field</span>
 
+    <span @click="reassignDefaults" class="reassign-defaults">Reassign default values</span>
+
     <span class="errors-status">Form has {{ form.hasErrors ? '' : 'no ' }}errors</span>
   </div>
 </template>
@@ -44,6 +46,12 @@ export default {
     },
     resetOne() {
       this.form.reset('handle')
+    },
+    reassignDefaults() {
+      this.form.defaults({
+        handle: 'updated handle',
+        remember: true
+      })
     }
   }
 }

--- a/packages/inertia-vue/tests/cypress/integration/form-helper.test.js
+++ b/packages/inertia-vue/tests/cypress/integration/form-helper.test.js
@@ -378,24 +378,61 @@ describe('Form Helper', () => {
       cy.get('.remember_error').should('not.exist')
     })
 
-    it('can assign and reset new reset defaults', () => {
-      cy.get('#name').should('have.value', 'foo')
-      cy.get('#handle').should('have.value', 'example')
-      cy.get('#remember').should('not.be.checked')
+    describe('Update "reset" defaults', () => {
+      beforeEach(() => {
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'example')
+        cy.get('#remember').should('not.be.checked')
+      })
 
-      cy.get('.reassign-defaults').click()
+      it('can assign the current values as the new defaults', () => {
+        cy.get('#name').clear().type('A')
+        cy.get('#handle').clear().type('B')
+        cy.get('#remember').check()
 
-      cy.get('#name').should('have.value', 'foo')
-      cy.get('#handle').should('have.value', 'example')
-      cy.get('#remember').should('not.be.checked')
-      cy.get('.reset-one').click()
-      cy.get('#name').should('have.value', 'foo')
-      cy.get('#handle').should('have.value', 'updated handle')
-      cy.get('#remember').should('not.be.checked')
-      cy.get('.reset').click()
-      cy.get('#name').should('have.value', 'foo')
-      cy.get('#handle').should('have.value', 'updated handle')
-      cy.get('#remember').should('be.checked')
+        cy.get('.reassign').click()
+
+        cy.get('#name').clear().type('foo')
+        cy.get('#handle').clear().type('example')
+        cy.get('#remember').uncheck()
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'example')
+        cy.get('#remember').should('not.be.checked')
+
+        cy.get('.reset').click()
+
+        cy.get('#name').should('have.value', 'A')
+        cy.get('#handle').should('have.value', 'B')
+        cy.get('#remember').should('be.checked')
+      })
+
+      it('can assign new defaults for multiple fields', () => {
+        cy.get('.reassign-object').click()
+
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'example')
+        cy.get('#remember').should('not.be.checked')
+        cy.get('.reset-one').click()
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'updated handle')
+        cy.get('#remember').should('not.be.checked')
+        cy.get('.reset').click()
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'updated handle')
+        cy.get('#remember').should('be.checked')
+      })
+
+      it('can assign new default for a single field', () => {
+        cy.get('.reassign-single').click()
+
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'example')
+        cy.get('#remember').should('not.be.checked')
+        cy.get('.reset').click()
+        cy.get('#name').should('have.value', 'single value')
+        cy.get('#handle').should('have.value', 'example')
+        cy.get('#remember').should('not.be.checked')
+      })
     })
   })
 

--- a/packages/inertia-vue/tests/cypress/integration/form-helper.test.js
+++ b/packages/inertia-vue/tests/cypress/integration/form-helper.test.js
@@ -377,6 +377,26 @@ describe('Form Helper', () => {
       cy.get('.handle_error').should('have.text', 'The Handle was invalid')
       cy.get('.remember_error').should('not.exist')
     })
+
+    it('can assign and reset new reset defaults', () => {
+      cy.get('#name').should('have.value', 'foo')
+      cy.get('#handle').should('have.value', 'example')
+      cy.get('#remember').should('not.be.checked')
+
+      cy.get('.reassign-defaults').click()
+
+      cy.get('#name').should('have.value', 'foo')
+      cy.get('#handle').should('have.value', 'example')
+      cy.get('#remember').should('not.be.checked')
+      cy.get('.reset-one').click()
+      cy.get('#name').should('have.value', 'foo')
+      cy.get('#handle').should('have.value', 'updated handle')
+      cy.get('#remember').should('not.be.checked')
+      cy.get('.reset').click()
+      cy.get('#name').should('have.value', 'foo')
+      cy.get('#handle').should('have.value', 'updated handle')
+      cy.get('#remember').should('be.checked')
+    })
   })
 
   describe('Events', () => {

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -71,7 +71,6 @@ export interface InertiaFormProps<TForm> {
   defaults(field: keyof TForm, value: string): this
   defaults(fields: Record<keyof TForm, string>): this
   reset(...fields: (keyof TForm)[]): this
-  resetWith(newDefaults: {[Property in keyof TForm]: string}): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
   setError(errors: Record<keyof TForm, string>): this

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -67,6 +67,7 @@ export interface InertiaFormProps<TForm> {
   recentlySuccessful: boolean
   data(): TForm
   transform(callback: (data: TForm) => object): this
+  defaults(): this
   defaults(field: keyof TForm, value: string): this
   defaults(fields: Record<keyof TForm, string>): this
   reset(...fields: (keyof TForm)[]): this

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -67,6 +67,8 @@ export interface InertiaFormProps<TForm> {
   recentlySuccessful: boolean
   data(): TForm
   transform(callback: (data: TForm) => object): this
+  defaults(field: keyof TForm, value: string): this
+  defaults(fields: Record<keyof TForm, string>): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this

--- a/packages/inertia-vue3/index.d.ts
+++ b/packages/inertia-vue3/index.d.ts
@@ -71,6 +71,7 @@ export interface InertiaFormProps<TForm> {
   defaults(field: keyof TForm, value: string): this
   defaults(fields: Record<keyof TForm, string>): this
   reset(...fields: (keyof TForm)[]): this
+  resetWith(newDefaults: {[Property in keyof TForm]: string}): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
   setError(errors: Record<keyof TForm, string>): this

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -66,17 +66,6 @@ export default function useForm(...args) {
 
       return this
     },
-    resetWith(newDefaults) {
-      if (typeof newDefaults === 'object' && Object.keys(newDefaults).length > 0) {
-        Object.keys(newDefaults).forEach(key => {
-          if (this.data().hasOwnProperty(key)) {
-            this[key] = newDefaults[key]
-          }
-        })
-      }
-      
-      return this
-    },
     setError(key, value) {
       Object.assign(this.errors, (value ? { [key]: value } : key))
 

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -34,6 +34,15 @@ export default function useForm(...args) {
 
       return this
     },
+    defaults(key, value) {
+      defaults = Object.assign(
+        {},
+        cloneDeep(defaults),
+        value ? ({ [key]: value }) : key,
+      )
+
+      return this
+    },
     reset(...fields) {
       let clonedDefaults = cloneDeep(defaults)
       if (fields.length === 0) {

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -66,6 +66,17 @@ export default function useForm(...args) {
 
       return this
     },
+    resetWith(newDefaults) {
+      if (typeof newDefaults === 'object' && Object.keys(newDefaults).length > 0) {
+        Object.keys(newDefaults).forEach(key => {
+          if (this.data().hasOwnProperty(key)) {
+            this[key] = newDefaults[key]
+          }
+        })
+      }
+      
+      return this
+    },
     setError(key, value) {
       Object.assign(this.errors, (value ? { [key]: value } : key))
 

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -35,11 +35,15 @@ export default function useForm(...args) {
       return this
     },
     defaults(key, value) {
-      defaults = Object.assign(
-        {},
-        cloneDeep(defaults),
-        value ? ({ [key]: value }) : key,
-      )
+      if (typeof key === 'undefined') {
+        defaults = this.data()
+      } else {
+        defaults = Object.assign(
+          {},
+          cloneDeep(defaults),
+          value ? ({ [key]: value }) : key,
+        )
+      }
 
       return this
     },


### PR DESCRIPTION
This PR adds a "defaults" method to the Form Helper, allowing people to reset the default values without initializing the form. Do note that it does not reset the form, but only changes the defaults that are used when the form (or some of it's fields) are reset.

Signatures:
```js
setDefaults()
setDefaults(field: string, value: string)
setDefaults(fields: object)
```


Here's some examples of how you can use this:

## Vue 2 / Vue 3
```js
export default {
  data() {
    return {
      form: this.$inertia.form({
        email: 'johndoe@example.com',
        password: 'secret',
        remember: false,
      }),
    }
  },
  methods: {
    submit() {
      this.form.post('/login', {
        onSuccess: () => {
          // Set the current values as the new defaults
          this.form.defaults()

          // Only change the email field
          this.form.defaults('email', 'foo@example.com')

          // Change the defaults to multiple fields
          this.form.defaults({
            email: 'bar@example.com',
            password: 'hunter2',
          })
        },
      })
    },
  },
}
```


## React
```js
const { post, setDefaults } = useForm({
  email: 'johndoe@example.com',
  password: 'secret',
  remember: true
});

post('/login', {
  onSuccess: () => {
    // Set the current values as the new defaults
    setDefaults()

    // Only change the email field
    setDefaults('email', 'foo@example.com')

    // Change the defaults to multiple fields
    setDefaults({
      email: 'bar@example.com',
      password: 'hunter2',
    })
  }
}
```

## Svelte
```js
const form = useForm({
  email: 'johndoe@example.com',
  password: 'secret',
  remember: false,
})

function login() {
  $form.post(route('login.store'), {
    onSuccess: () => {
      // Set the current values as the new defaults
      $form.defaults()

      // Only change the email field
      $form.defaults('email', 'foo@example.com')

      // Change the defaults to multiple fields
      $form.defaults({
        email: 'bar@example.com',
        password: 'hunter2',
      })
    }
  })
```