### PR TITLE
POC - Form (re)hydration

### DIFF
--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -4,8 +4,9 @@ import cloneDeep from 'lodash.clonedeep'
 import { Inertia } from '@inertiajs/inertia'
 
 export default function useForm(...args) {
-  const rememberKey = typeof args[0] === 'string' ? args[0] : null
-  const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
+  const rememberKey = typeof args[0] === 'string' ? args[0] : null  
+  const hydratorFunc = typeof args[rememberKey ? 1 : 0] === 'function' ? args[rememberKey ? 1 : 0] : () => args[rememberKey ? 1 : 0]
+  let data = hydratorFunc()
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
   let defaults = cloneDeep(data)
   let cancelToken = null
@@ -46,6 +47,9 @@ export default function useForm(...args) {
       }
 
       return this
+    },
+    hydrate() {
+      data = hydratorFunc()
     },
     reset(...fields) {
       let clonedDefaults = cloneDeep(defaults)
@@ -129,6 +133,10 @@ export default function useForm(...args) {
 
           const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
           defaults = cloneDeep(this.data())
+          
+          if (options.rehydrate) {
+            this.hydrate()
+          }
           this.isDirty = false
           return onSuccess
         },


### PR DESCRIPTION
⚠️ The code in this PR is a proof of concept - NOT mergeable ⚠️ 

---

Inertia encourages to be used similarly as a classic server-side application. Form requests are made and the server should redirect back to the same page. The form helper is a great aid.

But there's still something to be aware of. When the form is initially filled with prop values in `data()` and a successful form submission redirects back to the same page, the props are updated but the form **still has the client-side requested values** as the form initialisation doesn't run again. This feels somehow counterintuitive if a server-side approach should be considered.

(Vue Options API code)
```js
props: ['model'],

data() {
    return {
       form: this.$inertia.form({
           field: this.model.field,
       })
    }
}
```
This could be fine in the majority of cases, but there might also be situations where the server did some formatting or applied logic on certain values, and you want those to be reflected in the form as well (as would be the case with regular server-side responses).

Solution: let's just handle that in the `onSuccess` hook:

```js
methods: {
    submit() {
        this.form.post('/some/route', {
            onSuccess: () => {
                this.form.field = this.model.field
            },
        })
    }
}
```

But that's code duplication. We can extract that to a dedicated method.


```js
props: ['model'],

data() {
    return {
       form: this.$inertia.form(this.hydratedFormAttributes())
    }
}

methods: {
    hydratedFormAttributes() {
        return { field: this.model.field }
    },

    submit() {
        this.form.post('/some/route', {
            onSuccess: () => {
                this.form = this.$inertia.form(this.hydratedFormAttributes())
            },
        })
    }
}
```

And that makes me wondering if it would be useful to "move this up" to its initial definition by means of a function. That way we can instruct the form to rehydrate itself after submission by just plainly re-evaluating that function under the hood.

```js
props: ['model'],

data() {
    return {
       form: this.$inertia.form(() => {
           field: this.model.field,
       }))
    }
}

methods: {
    submit() {
        this.form.post('/some/route', {
            // Option
            rehydrate: true,
            // OR explicitly in onSuccess
            onSuccess: () => {
                this.form.hydrate()
            }
        })
    }
}
```

Ultimately one could even consider revisiting the `reset()` method to handle data closures properly. After all, if form data is defined as a closure, shouldn't `reset()` then rerun that closure? If so, then the implementation of this POC becomes quite trivial and userland code reuses known features.

```js
props: ['model'],

data() {
    return {
       form: this.$inertia.form(() => {
           field: this.model.field,
       }))
    }
}

methods: {
    submit() {
        this.form.post('/some/route', {
            onSuccess: () => {
                this.form.reset()
            }
        })
    }
}
```

---

This is quickly hacked together - I didn't consider the various reactive bits and pieces such as recentlySuccessful, isDirty, and so on.

Side-note: I think this is what #590 and #884 are all about. But the implementation suggested in there is quite opinionated (response is assumed to be exactly in form structure).
