### PR TITLE
Add Changelog files

### DIFF
--- a/packages/inertia-react/CHANGELOG.md
+++ b/packages/inertia-react/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/inertiajs/inertia/compare/inertia-react@0.7.1...HEAD)
+
+### Added
+
+- Visits and `Link` components now accept a 'queryStringArrayFormat' option ([#994](https://github.com/inertiajs/inertia/pull/994))
+- Add `setError` method to Form helper to manually set errors ([#999](https://github.com/inertiajs/inertia/pull/999))
+- Add `defaults` method to Form helper to 'redefine' the defaults ([#1019](https://github.com/inertiajs/inertia/pull/1019))
+- Add Types for `<Head>` component ([#855](https://github.com/inertiajs/inertia/pull/855))
+
+### Changed
+
+- We now keep a changelog here on GitHub :tada: For earlier releases, please see [the releases page of inertiajs.com](https://inertiajs.com/releases?all=true#inertia-react).
+- Types: Use `@inertiajs/inertia`'s new 'Progress' type ([#877](https://github.com/inertiajs/inertia/pull/877))
+
+### Fixed
+
+- Console warnings still referenced `<inertia-link>` instead of `<Link>` ([#916](https://github.com/inertiajs/inertia/pull/916))
+- "rememberedState of undefined" occurred on visits where `useRemember` was used ([#949](https://github.com/inertiajs/inertia/pull/949))
+- `useForm` overload types were incorrect for remember key ([#949](https://github.com/inertiajs/inertia/pull/949), [`b98ee6`](https://github.com/inertiajs/inertia/commit/b98ee69339a6f3af3bc7d331b5add726e5405ea0))
+- Incorrect types for `createInertiaApp` ([#847](https://github.com/inertiajs/inertia/pull/847))
+- Incorrect types for `useForm` methods ([#922](https://github.com/inertiajs/inertia/pull/922))

--- a/packages/inertia-svelte/CHANGELOG.md
+++ b/packages/inertia-svelte/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/inertiajs/inertia/compare/inertia-svelte@0.7.4...HEAD)
+
+### Added
+
+- Visits and `Link` components now accept a 'queryStringArrayFormat' option ([#994](https://github.com/inertiajs/inertia/pull/994))
+- Add `setError` method to Form helper to manually set errors ([#999](https://github.com/inertiajs/inertia/pull/999))
+- Add `defaults` method to Form helper to 'redefine' the defaults ([#1019](https://github.com/inertiajs/inertia/pull/1019))
+
+### Changed
+
+- We now keep a changelog here on GitHub :tada: For earlier releases, please see [the releases page of inertiajs.com](https://inertiajs.com/releases?all=true#inertia-svelte).
+
+### Fixed
+
+- `onSuccess` event no longer automatically resets the "default" values ([`eee2a5`](https://github.com/inertiajs/inertia/commit/eee2a5849bb107f34fe48672091e2b63ff15a8f7))

--- a/packages/inertia-vue/CHANGELOG.md
+++ b/packages/inertia-vue/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/inertiajs/inertia/compare/inertia-vue@0.7.2...HEAD)
+
+### Added
+
+- Visits and `Link` components now accept a 'queryStringArrayFormat' option ([#994](https://github.com/inertiajs/inertia/pull/994))
+- Add `setError` method to Form helper to manually set errors ([#999](https://github.com/inertiajs/inertia/pull/999))
+- Add `defaults` method to Form helper to 'redefine' the defaults ([#1019](https://github.com/inertiajs/inertia/pull/1019))
+
+### Changed
+
+- We now keep a changelog here on GitHub :tada: For earlier releases, please see [the releases page of inertiajs.com](https://inertiajs.com/releases?all=true#inertia-vue).
+- Types: Use `@inertiajs/inertia`'s new 'Progress' type ([#877](https://github.com/inertiajs/inertia/pull/877))
+
+### Fixed
+
+- Console warnings still referenced `<inertia-link>` instead of `<Link>` ([#916](https://github.com/inertiajs/inertia/pull/916))
+- Push Inertia "plugin" to userland instead of auto-registering, similar to Vue 3 ([`425663`](https://github.com/inertiajs/inertia/commit/4256638b215e5a67d951baeab89aa6043c27e85d))

--- a/packages/inertia-vue3/CHANGELOG.md
+++ b/packages/inertia-vue3/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - We now keep a changelog here on GitHub :tada: For earlier releases, please see [the releases page of inertiajs.com](https://inertiajs.com/releases?all=true#inertia-vue3).
 - Types: Use `@inertiajs/inertia`'s new 'Progress' type ([#877](https://github.com/inertiajs/inertia/pull/877))
 
-
 ### Fixed
 
 - `resolveComponent` should be able to occur asynchronously ([#911](https://github.com/inertiajs/inertia/pull/911))

--- a/packages/inertia-vue3/CHANGELOG.md
+++ b/packages/inertia-vue3/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/inertiajs/inertia/compare/inertia-vue3@0.5.2...HEAD)
+
+### Added
+
+- Visits and `Link` components now accept a 'queryStringArrayFormat' option ([#994](https://github.com/inertiajs/inertia/pull/994))
+- Add `setError` method to Form helper to manually set errors ([#999](https://github.com/inertiajs/inertia/pull/999))
+- Add `defaults` method to Form helper to 'redefine' the defaults ([#1019](https://github.com/inertiajs/inertia/pull/1019))
+
+### Changed
+
+- We now keep a changelog here on GitHub :tada: For earlier releases, please see [the releases page of inertiajs.com](https://inertiajs.com/releases?all=true#inertia-vue3).
+- Types: Use `@inertiajs/inertia`'s new 'Progress' type ([#877](https://github.com/inertiajs/inertia/pull/877))
+
+
+### Fixed
+
+- `resolveComponent` should be able to occur asynchronously ([#911](https://github.com/inertiajs/inertia/pull/911))
+- Console warnings still referenced `<inertia-link>` instead of `<Link>` ([#916](https://github.com/inertiajs/inertia/pull/916))
+- Type regression with Vue 3 ([#849](https://github.com/inertiajs/inertia/pull/849))

--- a/packages/inertia/CHANGELOG.md
+++ b/packages/inertia/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/inertiajs/inertia/compare/inertia@0.10.1...HEAD)
+
+### Added
+
+- Allow choosing query string 'array' formatters ([#994](https://github.com/inertiajs/inertia/pull/994))
+- New `Progress` type ([#877](https://github.com/inertiajs/inertia/pull/877))
+- New `InertiaAppResponse` type for use in [`@inertiajs/server`](https://github.com/inertiajs/server/) ([`199423`](https://github.com/inertiajs/inertia/commit/19942367b4f728e58decf581cdd93f674c7b35e5))
+
+### Changed
+
+- We now keep a changelog here on GitHub :tada: For earlier releases, please see [the releases page of inertiajs.com](https://inertiajs.com/releases?all=true#inertia).
+- Types: Use a ProgressEvent instead of a generic object ([#877](https://github.com/inertiajs/inertia/pull/877))
+
+### Fixed
+
+- `<Link>` Component automatically added `http://localhost` as a prefix when it contains 'http' in it's path ([#964](https://github.com/inertiajs/inertia/pull/964))
+- "rememberedState of undefined" occurred on visits where `useRemember` was used ([#949](https://github.com/inertiajs/inertia/pull/949))


### PR DESCRIPTION
This PR adds CHANGELOG.md files to every package in this repository, similar to [how the team over at TailwindCSS handles their changes](https://github.com/tailwindlabs/tailwindcss/blob/master/CHANGELOG.md). 

The main benefit of this, is that it makes the tracking of (breaking) changes and additions easier, which in turn makes releases easier, as well as that it allows for @reinink and I to go over certain things faster when we catch up on what's happening