### PR TITLE
Forms: 'ReferenceError: window is not defined'

### DIFF
--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -7,6 +7,8 @@ import { hrefToUrl, mergeDataIntoQueryString, urlWithoutHash } from './url'
 import { ActiveVisit, GlobalEvent, GlobalEventNames, GlobalEventResult, LocationVisit, Method, Page, PageHandler, PageResolver, PendingVisit, PreserveStateOption, RequestPayload, VisitId, VisitOptions } from './types'
 import { fireBeforeEvent, fireErrorEvent, fireExceptionEvent, fireFinishEvent, fireInvalidEvent, fireNavigateEvent, fireProgressEvent, fireStartEvent, fireSuccessEvent } from './events'
 
+const isServer = typeof window === 'undefined'
+
 export class Router {
   protected resolveComponent!: PageResolver
   protected swapComponent!: PageHandler
@@ -445,6 +447,10 @@ export class Router {
   }
 
   public remember(data: unknown, key = 'default'): void {
+    if (isServer) {
+      return
+    }
+
     this.replaceState({
       ...this.page,
       rememberedState: {
@@ -455,6 +461,10 @@ export class Router {
   }
 
   public restore(key = 'default'): unknown {
+    if (isServer) {
+      return
+    }
+
     return window.history.state?.rememberedState?.[key]
   }
 


### PR DESCRIPTION
When using Inertia's form helper with it's remember functionality during SSR, it'll throw an error in the Console.

```js
 someForm: this.$inertia.form('someFormRememberKey', {
   key: 'value',
})
```

```
[Vue warn]: Error in data(): "ReferenceError: window is not defined"

found in

---> <Anonymous>
       <Anonymous>
         <Anonymous>
           <Inertia>
             <Root>
ReferenceError: window is not defined
    at e.n.restore (/Users/claudiodekker/Code/demo/node_modules/@inertiajs/inertia/dist/index.js:1:13330)
    at e.s [as form] (/Users/claudiodekker/Code/demo/node_modules/@inertiajs/inertia-vue/dist/index.js:1:530)
    at VueComponent.data (/Users/claudiodekker/Code/demo/public/js/ssr.js:1:468776)
    at getData (/Users/claudiodekker/Code/demo/node_modules/vue/dist/vue.runtime.common.dev.js:4745:17)
    at initData (/Users/claudiodekker/Code/demo/node_modules/vue/dist/vue.runtime.common.dev.js:4702:7)
    at initState (/Users/claudiodekker/Code/demo/node_modules/vue/dist/vue.runtime.common.dev.js:4641:5)
    at VueComponent.Vue._init (/Users/claudiodekker/Code/demo/node_modules/vue/dist/vue.runtime.common.dev.js:5001:5)
    at new VueComponent (/Users/claudiodekker/Code/demo/node_modules/vue/dist/vue.runtime.common.dev.js:5148:12)
    at createComponentInstanceForVnode (/Users/claudiodekker/Code/demo/node_modules/vue-server-renderer/build.dev.js:8213:10)
    at renderComponentInner (/Users/claudiodekker/Code/demo/node_modules/vue-server-renderer/build.dev.js:8437:40)
```

This is caused by Inertia called the `Inertia.remember` and `Inertia.restore` methods on instantiation. This PR solves this, by detecting server mode and bailing early.