### PR TITLE
Events: Allow 'void' return types

### DIFF
--- a/packages/inertia/CHANGELOG.md
+++ b/packages/inertia/CHANGELOG.md
@@ -16,10 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - We now keep a changelog here on GitHub :tada: For earlier releases, please see [the releases page of inertiajs.com](https://inertiajs.com/releases?all=true#inertia).
-- Types: Use a ProgressEvent instead of a generic object ([#877](https://github.com/inertiajs/inertia/pull/877))
+- Types: Use a ProgressEvent instead of a generic object ([#877](https://github.com/inertiajs/inertia/pull/877)
 
 ### Fixed
 
 - `<Link>` Component automatically added `http://localhost` as a prefix when it contains 'http' in it's path ([#964](https://github.com/inertiajs/inertia/pull/964))
 - "rememberedState of undefined" occurred on visits where `useRemember` was used ([#949](https://github.com/inertiajs/inertia/pull/949))
 - Forms with remember keys were giving `ReferenceError: window is not defined` during SSR ([#1036](https://github.com/inertiajs/inertia/pull/1036))
+- Certain events always required 'bool' return types, while 'void' (falsy) should be possible too ([#1037](https://github.com/inertiajs/inertia/pull/1037))

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -127,14 +127,14 @@ export type GlobalEventsMap = {
     details: {
         response: AxiosResponse
     },
-    result: boolean,
+    result: boolean|void,
   },
   exception: {
     parameters: [Error],
     details: {
         exception: Error
     },
-    result: boolean,
+    result: boolean|void,
   },
 }
 


### PR DESCRIPTION
Fixes #951

Certain events always required 'bool' return types, while 'void' (falsy) should be possible too