### PR TITLE
Enable preserveState for partial reloaded links

### DIFF
--- a/packages/inertia-vue3/src/link.js
+++ b/packages/inertia-vue3/src/link.js
@@ -25,7 +25,7 @@ export default {
     },
     preserveScroll: {
       type: Boolean,
-      default: false,
+      default: null,
     },
     preserveState: {
       type: Boolean,
@@ -65,8 +65,8 @@ export default {
               data: data,
               method: method,
               replace: props.replace,
-              preserveScroll: props.preserveScroll,
-              preserveState: props.preserveState ?? (method !== 'get'),
+              preserveScroll: (props.only && props.only.length && props.preserveScroll == null) ? true : props.preserveScroll ?? false,
+              preserveState: (props.only && props.only.length && props.preserveState == null) ? true : props.preserveState ?? (method !== 'get'),
               only: props.only,
               headers: props.headers,
               onCancelToken: attrs.onCancelToken || (() => ({})),


### PR DESCRIPTION
I noticed Inertia's `Link` component currently does not set `preserveScroll` and `preserveState` to `true` when the `only` prop is provided ( which indicates they're doing a partial reload ). Since `preserveScroll` and `preserveState` are enabled by default for the `Inertia.reload()` method, I believe the same behavior should be applied to the `Link`.