### PR TITLE
Fix default <head> title tag

### DIFF
--- a/packages/inertia-react/src/App.js
+++ b/packages/inertia-react/src/App.js
@@ -21,7 +21,7 @@ export default function App({
     return createHeadManager(
       typeof window === 'undefined',
       titleCallback || (title => title),
-      onHeadUpdate || (() => {})
+      onHeadUpdate || (() => {}),
     )
   }, [])
 
@@ -37,6 +37,8 @@ export default function App({
         }))
       },
     })
+
+    Inertia.on('navigate', () => headManager.forceUpdate())
   }, [])
 
   if (!current.component) {

--- a/packages/inertia-vue/src/app.js
+++ b/packages/inertia-vue/src/app.js
@@ -52,6 +52,8 @@ export default {
           this.key = preserveState ? this.key : Date.now()
         },
       })
+
+      Inertia.on('navigate', () => headManager.forceUpdate())
     }
   },
   render(h) {

--- a/packages/inertia-vue3/src/app.js
+++ b/packages/inertia-vue3/src/app.js
@@ -52,6 +52,8 @@ export default {
           key.value = args.preserveState ? key.value : Date.now()
         },
       })
+
+      Inertia.on('navigate', () => headManager.forceUpdate())
     }
 
     return () => {


### PR DESCRIPTION
This PR fixes the `<head>` title tag not defaulting to the `createInertiaApp` when the `title` callback is defined.