### PR TITLE
Add Realtime Validation feature

### DIFF
--- a/packages/inertia-vue3/package.json
+++ b/packages/inertia-vue3/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
+    "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -211,17 +211,26 @@ export default function useForm(...args) {
   }, { immediate: true, deep: true })
 
   const runRealtimeValidation = debounce((newValue, prevValue) => {
+    // Check if realtimeValidation options are not empty.
     let optionsNotEmpty = form.realtimeValidationOptions !== {}
+    // Check if realtime validation is enabled.
     let enabled = typeof form.realtimeValidationOptions.enabled == 'boolean' ? form.realtimeValidationOptions.enabled : optionsNotEmpty
+    // Check if a valid method is provided.
     let method = typeof form.realtimeValidationOptions.method == 'string' && ['get', 'post', 'put', 'patch'].includes(form.realtimeValidationOptions.method) ? form.realtimeValidationOptions.method : undefined
+    // Set the url.
     let url = typeof form.realtimeValidationOptions.url == 'string' ? form.realtimeValidationOptions.url : undefined
+    // Set the data. The data needs to exist in the form.
     let data = form.realtimeValidationOptions.data?.length ? form.realtimeValidationOptions.data.filter((element) => Object.keys(newValue).includes(element)) : undefined
+    // Check if all necessary arguments are provided.
     if (optionsNotEmpty && enabled === true && method && url && data?.length) {
+      // Find the form data that has changed since last watch update.
       let changedData = data.filter((element) => newValue[element] != prevValue[element])
+      // Check if the changed data is not empty.
       if(changedData?.length) {
         Inertia[method](url, {
           _realtimeValidation: true,
           ...data.reduce((carry, key) => {
+            // Only set the key/value pairs that have changed.
             if(newValue[key] != prevValue[key]) carry[key] = newValue[key]
             return carry
           }, {})
@@ -240,7 +249,7 @@ export default function useForm(...args) {
       }
     }
   }, 150)
-
+  // Watcher for realtime validation.
   watch(() => form.data(), (newValue, prevValue) => runRealtimeValidation(newValue, prevValue), { immediate: false, deep: true })
 
   return form

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -215,8 +215,8 @@ export default function useForm(...args) {
     let enabled = typeof form.realtimeValidationOptions.enabled == 'boolean' ? form.realtimeValidationOptions.enabled : optionsNotEmpty
     let method = typeof form.realtimeValidationOptions.method == 'string' && ['get', 'post', 'put', 'patch'].includes(form.realtimeValidationOptions.method) ? form.realtimeValidationOptions.method : undefined
     let url = typeof form.realtimeValidationOptions.url == 'string' ? form.realtimeValidationOptions.url : undefined
-    let data = form.realtimeValidationOptions.data?.length != 0 ? form.realtimeValidationOptions.data : undefined
-    if (optionsNotEmpty && enabled === true && method && url && data) {
+    let data = form.realtimeValidationOptions.data?.length != 0 ? form.realtimeValidationOptions.data.filter((element) => Object.keys(newValue).includes(element)) : undefined
+    if (optionsNotEmpty && enabled === true && method && url && data?.length != 0) {
       let changedData = data.filter((element) => newValue[element] != prevValue[element])
       Inertia[method](url, {
         _realtimeValidation: true,

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -22,7 +22,7 @@ export default function useForm(...args) {
     progress: null,
     wasSuccessful: false,
     recentlySuccessful: false,
-    realtimeValidationOptions: {},
+    validateOptions: {},
     data() {
       return Object
         .keys(data)
@@ -196,9 +196,9 @@ export default function useForm(...args) {
       Object.assign(this, restored.data)
       this.setError(restored.errors)
     },
-    realtimeValidation(options) {
+    validate(options) {
       if(typeof options === 'object') {
-        this.realtimeValidationOptions = options
+        this.validateOptions = options
       }
     }
   })
@@ -210,17 +210,17 @@ export default function useForm(...args) {
     }
   }, { immediate: true, deep: true })
 
-  const runRealtimeValidation = debounce((newValue, prevValue) => {
-    // Check if realtimeValidation options are not empty.
-    let optionsNotEmpty = form.realtimeValidationOptions !== {}
+  const runValidate = debounce((newValue, prevValue) => {
+    // Check if validate options are not empty.
+    let optionsNotEmpty = form.validateOptions !== {}
     // Check if realtime validation is enabled.
-    let enabled = typeof form.realtimeValidationOptions.enabled == 'boolean' ? form.realtimeValidationOptions.enabled : optionsNotEmpty
+    let enabled = typeof form.validateOptions.enabled == 'boolean' ? form.validateOptions.enabled : optionsNotEmpty
     // Check if a valid method is provided.
-    let method = typeof form.realtimeValidationOptions.method == 'string' && ['get', 'post', 'put', 'patch', 'delete'].includes(form.realtimeValidationOptions.method.toLowerCase()) ? form.realtimeValidationOptions.method : undefined
+    let method = typeof form.validateOptions.method == 'string' && ['get', 'post', 'put', 'patch', 'delete'].includes(form.validateOptions.method.toLowerCase()) ? form.validateOptions.method : undefined
     // Set the url.
-    let url = typeof form.realtimeValidationOptions.url == 'string' ? form.realtimeValidationOptions.url : undefined
+    let url = typeof form.validateOptions.url == 'string' ? form.validateOptions.url : undefined
     // Set the data. The data needs to exist in the form.
-    let data = form.realtimeValidationOptions.data?.length ? form.realtimeValidationOptions.data.filter((element) => Object.keys(newValue).includes(element)) : undefined
+    let data = form.validateOptions.data?.length ? form.validateOptions.data.filter((element) => Object.keys(newValue).includes(element)) : undefined
     // Check if all necessary arguments are provided.
     if (optionsNotEmpty && enabled === true && method && url && data?.length) {
       // Find the form data that has changed since last watch update.
@@ -237,7 +237,7 @@ export default function useForm(...args) {
         let _options = {
           preserveState: true,
           preserveScroll: true,
-          realtimeValidation: changedData,
+          validate: changedData,
           only: ['errors'],
           onStart: () => {
             form.processing = true
@@ -273,7 +273,7 @@ export default function useForm(...args) {
     }
   }, 150)
   // Watcher for realtime validation.
-  watch(() => form.data(), (newValue, prevValue) => runRealtimeValidation(newValue, prevValue), { immediate: false, deep: true })
+  watch(() => form.data(), (newValue, prevValue) => runValidate(newValue, prevValue), { immediate: false, deep: true })
 
   return form
 }

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -239,11 +239,29 @@ export default function useForm(...args) {
           preserveScroll: true,
           realtimeValidation: changedData,
           only: ['errors'],
-          onError: errors => {
-            form.clearErrors(...changedData).setError(errors)
+          onStart: () => {
+            form.processing = true
+          },
+          onProgress: event => {
+            form.progress = event
           },
           onSuccess: () => {
+            form.processing = false
+            form.progress = null
             form.clearErrors(...changedData)
+          },
+          onError: errors => {
+            form.processing = false
+            form.progress = null
+            form.clearErrors(...changedData).setError(errors)
+          },
+          onCancel: () => {
+            form.processing = false
+            form.progress = null
+          },
+          onFinish: () => {
+            form.processing = false
+            form.progress = null
           },
         })
       }

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -220,7 +220,7 @@ export default function useForm(...args) {
     // Set the url.
     let url = typeof form.validateOptions.url == 'string' ? form.validateOptions.url : undefined
     // Set the data. The data needs to exist in the form.
-    let data = form.validateOptions.data?.length ? form.validateOptions.data.filter((element) => Object.keys(newValue).includes(element)) : undefined
+    let data = form.validateOptions.data?.length ? form.validateOptions.data.filter((element) => Object.keys(newValue).includes(element)) : Object.keys(form.data())
     // Set the option to control whether the processing state of form should be updated during validation.
     let processing = typeof form.validateOptions.processing == 'boolean' ? form.validateOptions.processing : false
     // Set the option to control whether the progress state of form should be updated during validation.
@@ -275,7 +275,7 @@ export default function useForm(...args) {
         }
       }
     }
-  }, 150)
+  }, 400)
   // Watcher for realtime validation.
   watch(() => form.data(), (newValue, prevValue) => runValidate(newValue, prevValue), { immediate: false, deep: true })
 

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -221,6 +221,10 @@ export default function useForm(...args) {
     let url = typeof form.validateOptions.url == 'string' ? form.validateOptions.url : undefined
     // Set the data. The data needs to exist in the form.
     let data = form.validateOptions.data?.length ? form.validateOptions.data.filter((element) => Object.keys(newValue).includes(element)) : undefined
+    // Set the option to control whether the processing state of form should be updated during validation.
+    let processing = typeof form.validateOptions.processing == 'boolean' ? form.validateOptions.processing : false
+    // Set the option to control whether the progress state of form should be updated during validation.
+    let progress = typeof form.validateOptions.progress == 'boolean' ? form.validateOptions.progress : false
     // Check if all necessary arguments are provided.
     if (optionsNotEmpty && enabled === true && method && url && data?.length) {
       // Find the form data that has changed since last watch update.
@@ -240,28 +244,28 @@ export default function useForm(...args) {
           validate: changedData,
           only: ['errors'],
           onStart: () => {
-            form.processing = true
+            if (processing) form.processing = true
           },
           onProgress: event => {
-            form.progress = event
+            if (progress) form.progress = event
           },
           onSuccess: () => {
-            form.processing = false
-            form.progress = null
+            if (processing) form.processing = false
+            if (progress) form.progress = null
             form.clearErrors(...changedData)
           },
           onError: errors => {
-            form.processing = false
-            form.progress = null
+            if (processing) form.processing = false
+            if (progress) form.progress = null
             form.clearErrors(...changedData).setError(errors)
           },
           onCancel: () => {
-            form.processing = false
-            form.progress = null
+            if (processing) form.processing = false
+            if (progress) form.progress = null
           },
           onFinish: () => {
-            form.processing = false
-            form.progress = null
+            if (processing) form.processing = false
+            if (progress) form.progress = null
           },
         }
         if(method === 'delete') {

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -218,21 +218,23 @@ export default function useForm(...args) {
     let data = form.realtimeValidationOptions.data?.length ? form.realtimeValidationOptions.data.filter((element) => Object.keys(newValue).includes(element)) : undefined
     if (optionsNotEmpty && enabled === true && method && url && data?.length) {
       let changedData = data.filter((element) => newValue[element] != prevValue[element])
-      Inertia[method](url, {
-        _realtimeValidation: true,
-        ...data.reduce((carry, key) => {
-          if(newValue[key] != prevValue[key]) carry[key] = newValue[key]
-          return carry
-        }, {})
-      },{
-        only: ['errors'],
-        onError: errors => {
-          form.setError(errors)
-        },
-        onSuccess: () => {
-          form.clearErrors(changedData.join())
-        },
-      })
+      if(changedData?.length) {
+        Inertia[method](url, {
+          _realtimeValidation: true,
+          ...data.reduce((carry, key) => {
+            if(newValue[key] != prevValue[key]) carry[key] = newValue[key]
+            return carry
+          }, {})
+        },{
+          only: ['errors'],
+          onError: errors => {
+            form.setError(errors)
+          },
+          onSuccess: () => {
+            form.clearErrors(changedData.join())
+          },
+        })
+      }
     }
   }, 150)
 

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -215,8 +215,8 @@ export default function useForm(...args) {
     let enabled = typeof form.realtimeValidationOptions.enabled == 'boolean' ? form.realtimeValidationOptions.enabled : optionsNotEmpty
     let method = typeof form.realtimeValidationOptions.method == 'string' && ['get', 'post', 'put', 'patch'].includes(form.realtimeValidationOptions.method) ? form.realtimeValidationOptions.method : undefined
     let url = typeof form.realtimeValidationOptions.url == 'string' ? form.realtimeValidationOptions.url : undefined
-    let data = form.realtimeValidationOptions.data?.length != 0 ? form.realtimeValidationOptions.data.filter((element) => Object.keys(newValue).includes(element)) : undefined
-    if (optionsNotEmpty && enabled === true && method && url && data?.length != 0) {
+    let data = form.realtimeValidationOptions.data?.length ? form.realtimeValidationOptions.data.filter((element) => Object.keys(newValue).includes(element)) : undefined
+    if (optionsNotEmpty && enabled === true && method && url && data?.length) {
       let changedData = data.filter((element) => newValue[element] != prevValue[element])
       Inertia[method](url, {
         _realtimeValidation: true,

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -228,7 +228,6 @@ export default function useForm(...args) {
       // Check if the changed data is not empty.
       if(changedData?.length) {
         let _data = {
-          _realtimeValidation: true,
           ...data.reduce((carry, key) => {
             // Only set the key/value pairs that have changed.
             if(newValue[key] != prevValue[key]) carry[key] = newValue[key]

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -226,12 +226,15 @@ export default function useForm(...args) {
             return carry
           }, {})
         },{
+          preserveState: true,
+          preserveScroll: true,
+          realtimeValidation: changedData,
           only: ['errors'],
           onError: errors => {
-            form.setError(errors)
+            form.clearErrors(...changedData).setError(errors)
           },
           onSuccess: () => {
-            form.clearErrors(changedData.join())
+            form.clearErrors(...changedData)
           },
         })
       }

--- a/packages/inertia-vue3/src/useForm.js
+++ b/packages/inertia-vue3/src/useForm.js
@@ -216,7 +216,7 @@ export default function useForm(...args) {
     // Check if realtime validation is enabled.
     let enabled = typeof form.realtimeValidationOptions.enabled == 'boolean' ? form.realtimeValidationOptions.enabled : optionsNotEmpty
     // Check if a valid method is provided.
-    let method = typeof form.realtimeValidationOptions.method == 'string' && ['get', 'post', 'put', 'patch'].includes(form.realtimeValidationOptions.method) ? form.realtimeValidationOptions.method : undefined
+    let method = typeof form.realtimeValidationOptions.method == 'string' && ['get', 'post', 'put', 'patch', 'delete'].includes(form.realtimeValidationOptions.method.toLowerCase()) ? form.realtimeValidationOptions.method : undefined
     // Set the url.
     let url = typeof form.realtimeValidationOptions.url == 'string' ? form.realtimeValidationOptions.url : undefined
     // Set the data. The data needs to exist in the form.
@@ -227,14 +227,15 @@ export default function useForm(...args) {
       let changedData = data.filter((element) => newValue[element] != prevValue[element])
       // Check if the changed data is not empty.
       if(changedData?.length) {
-        Inertia[method](url, {
+        let _data = {
           _realtimeValidation: true,
           ...data.reduce((carry, key) => {
             // Only set the key/value pairs that have changed.
             if(newValue[key] != prevValue[key]) carry[key] = newValue[key]
             return carry
           }, {})
-        },{
+        }
+        let _options = {
           preserveState: true,
           preserveScroll: true,
           realtimeValidation: changedData,
@@ -263,7 +264,12 @@ export default function useForm(...args) {
             form.processing = false
             form.progress = null
           },
-        })
+        }
+        if(method === 'delete') {
+          Inertia.delete(url, { ..._options, _data })
+        } else {
+          Inertia[method](url, _data, _options)
+        }
       }
     }
   }, 150)

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -207,7 +207,7 @@ export class Router {
       preserveScroll: false,
       preserveState: false,
       only: [],
-      realtimeValidation: [],
+      validate: [],
       headers: {},
       errorBag: '',
       forceFormData: false,
@@ -227,7 +227,7 @@ export class Router {
 
     const prepared = this.visitOptions(options, url) || options
 
-    const { method, replace, only, realtimeValidation, headers, errorBag, forceFormData, queryStringArrayFormat, onCancelToken, onBefore, onStart, onProgress, onFinish, onCancel, onSuccess, onError } = prepared
+    const { method, replace, only, validate, headers, errorBag, forceFormData, queryStringArrayFormat, onCancelToken, onBefore, onStart, onProgress, onFinish, onCancel, onSuccess, onError } = prepared
     let { data, preserveScroll, preserveState } = prepared
 
     if ((hasFiles(data) || forceFormData) && !(data instanceof FormData)) {
@@ -248,7 +248,7 @@ export class Router {
       preserveScroll,
       preserveState,
       only,
-      realtimeValidation,
+      validate,
       headers,
       errorBag,
       forceFormData,
@@ -297,8 +297,8 @@ export class Router {
           'X-Inertia-Partial-Component': this.page.component,
           'X-Inertia-Partial-Data': only.join(','),
         } : {}),
-        ...(realtimeValidation.length ? {
-          'X-Inertia-Real-Time-Validation': realtimeValidation,
+        ...(validate.length ? {
+          'X-Inertia-Validate': validate,
         } : {}),
         ...(errorBag && errorBag.length ? { 'X-Inertia-Error-Bag': errorBag } : {}),
         ...(this.page.version ? { 'X-Inertia-Version': this.page.version } : {}),
@@ -320,13 +320,13 @@ export class Router {
         pageResponse.props = { ...this.page.props, ...pageResponse.props }
         // The reason for this snippet here is that we want to prevent losing non-realtime-validation that were previously set in $page.props.errors
         // Check if we're doing a realtime validation
-        if (realtimeValidation.length) {
+        if (validate.length) {
           // We go through the current page.props.errors and pass it to pageResponse.props.errors key by key
           // By only 2 conditions:
-          // 1. If the key is not in realtimeValidation, we set the key (it's a non-realtime-validation error)
-          // 2. If the key is in realtimeValidation, and if it's in pageResponse.props.errors, we set the key
+          // 1. If the key is not in validate, we set the key (it's a non-realtime-validation error)
+          // 2. If the key is in validate, and if it's in pageResponse.props.errors, we set the key
           Object.keys(this.page.props.errors).forEach((key) => {
-            if(!realtimeValidation.includes(key) || realtimeValidation.includes(key) && Object.keys(pageResponse.props.errors).includes(key)) {
+            if(!validate.includes(key) || validate.includes(key) && Object.keys(pageResponse.props.errors).includes(key)) {
               pageResponse.props.errors[key] = this.page.props.errors[key]
             }
           })

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -297,6 +297,9 @@ export class Router {
           'X-Inertia-Partial-Component': this.page.component,
           'X-Inertia-Partial-Data': only.join(','),
         } : {}),
+        ...(realtimeValidation.length ? {
+          'X-Inertia-Real-Time-Validation': realtimeValidation,
+        } : {}),
         ...(errorBag && errorBag.length ? { 'X-Inertia-Error-Bag': errorBag } : {}),
         ...(this.page.version ? { 'X-Inertia-Version': this.page.version } : {}),
       },

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -207,6 +207,7 @@ export class Router {
       preserveScroll: false,
       preserveState: false,
       only: [],
+      realtimeValidation: [],
       headers: {},
       errorBag: '',
       forceFormData: false,
@@ -226,7 +227,7 @@ export class Router {
 
     const prepared = this.visitOptions(options, url) || options
 
-    const { method, replace, only, headers, errorBag, forceFormData, queryStringArrayFormat, onCancelToken, onBefore, onStart, onProgress, onFinish, onCancel, onSuccess, onError } = prepared
+    const { method, replace, only, realtimeValidation, headers, errorBag, forceFormData, queryStringArrayFormat, onCancelToken, onBefore, onStart, onProgress, onFinish, onCancel, onSuccess, onError } = prepared
     let { data, preserveScroll, preserveState } = prepared
 
     if ((hasFiles(data) || forceFormData) && !(data instanceof FormData)) {
@@ -247,6 +248,7 @@ export class Router {
       preserveScroll,
       preserveState,
       only,
+      realtimeValidation,
       headers,
       errorBag,
       forceFormData,
@@ -313,6 +315,19 @@ export class Router {
       const pageResponse: Page = response.data
       if (only.length && pageResponse.component === this.page.component) {
         pageResponse.props = { ...this.page.props, ...pageResponse.props }
+        // The reason for this snippet here is that we want to prevent losing non-realtime-validation that were previously set in $page.props.errors
+        // Check if we're doing a realtime validation
+        if (realtimeValidation.length) {
+          // We go through the current page.props.errors and pass it to pageResponse.props.errors key by key
+          // By only 2 conditions:
+          // 1. If the key is not in realtimeValidation, we set the key (it's a non-realtime-validation error)
+          // 2. If the key is in realtimeValidation, and if it's in pageResponse.props.errors, we set the key
+          Object.keys(this.page.props.errors).forEach((key) => {
+            if(!realtimeValidation.includes(key) || realtimeValidation.includes(key) && Object.keys(pageResponse.props.errors).includes(key)) {
+              pageResponse.props.errors[key] = this.page.props.errors[key]
+            }
+          })
+        }
       }
       preserveScroll = this.resolvePreserveOption(preserveScroll, pageResponse) as boolean
       preserveState = this.resolvePreserveOption(preserveState, pageResponse)

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -60,7 +60,7 @@ export type Visit = {
   preserveScroll: PreserveStateOption,
   preserveState: PreserveStateOption,
   only: Array<string>,
-  realtimeValidation: Array<string>,
+  validate: Array<string>,
   headers: Record<string, string>
   errorBag: string|null,
   forceFormData: boolean,

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -60,6 +60,7 @@ export type Visit = {
   preserveScroll: PreserveStateOption,
   preserveState: PreserveStateOption,
   only: Array<string>,
+  realtimeValidation: Array<string>,
   headers: Record<string, string>
   errorBag: string|null,
   forceFormData: boolean,


### PR DESCRIPTION
This PR which works in junction with this [PR](https://github.com/inertiajs/inertia-laravel/pull/358) is to add real-time ⚡ validation feature to Inertia's form. Note that the validation is done on the backend.
Basically after you initialize the form, you call the `validate()` method and after that, every time you change the form data, it will send a request to the backend to check if that specific input is passing the validation rules.

Here is how the api looks like at a glance:
![Controller (2) (Small)](https://user-images.githubusercontent.com/15275787/150968356-3ebd9371-a930-4f93-af01-f737dc6a2a04.png)


Here is the demo:
![Inertia-Realtime-Validation-Demo2](https://user-images.githubusercontent.com/15275787/150971735-ad688551-2bda-4fb6-a42e-a05e9798af8d.gif)



```js
// Validate specific fields
form.validate({
   data: ['first_name', 'last_name'], // Form data that needs to be validated
   url: '/contacts', // Route to check the validation against, needs the backend implementation to work
   method: 'post', // Request method
})

// Validate all fields
form.validate({ url: '/contacts', method: 'post'})

// Full options you can access
form.validate({
   data: ['first_name', 'last_name'],
   url: '/contacts',
   method: 'post',

   enabled: true, // Option to enable/disable the validation, default: true
   processing: true, // Updates form.processing, default: false
   progress: true, // Updates form.progress, default: false
})
// You only call the validate function once
// Currently validate has a default debounce delay of 400ms
```
I've tested this with the PingCRM example and it works just fine ✅👍

- [x] Add the backend implementation PR
- [x] Improve the arguments/options of `validate`
- [x] Improve `validate` method to avoid clearing existing `page.errors`
- [x] Add `delete` method support
- [x] Write logic to check if provided data to `validate` is in the `form.data()`
- [x] Copy `submit` events behavior (selectively) to make `validate` behave similar
- [x] Add option to control whether the form's `processing` and `progress` should be updated during validation
- [x] Add ability to validate all form data at once ( without the need to specify each input name )
- [ ] Add ability to define custom debounce delay
- [ ] Try to add support for `keyup` or `blur` event on inputs as a way to trigger the validation method, instead of watching the `form.data()`

Any feedbacks would be appreciated 💜😄