### PR TITLE
Change to preferring element.scrollTo

### DIFF
--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -79,8 +79,9 @@ export class Router {
   protected resetScrollPositions(): void {
     window.scrollTo(0, 0)
     this.scrollRegions().forEach(region => {
-      if (canScrollTo) region.scrollTo({ top: 0, left: 0 })
-      else {
+      if (typeof region.scrollTo === 'function') {
+        region.scrollTo(0, 0)
+      } else {
         region.scrollTop = 0
         region.scrollLeft = 0
       }

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -97,10 +97,13 @@ export class Router {
     if (this.page.scrollRegions) {
       this.scrollRegions().forEach((region: Element, index: number) => {
         const scrollPosition = this.page.scrollRegions[index]
-        if (scrollPosition && canScrollTo) {
-          region.scrollTo({ top: scrollPosition.top, left: scrollPosition.left })
+        if (! scrollPosition) {
+          return
         }
-        else if (scrollPosition) {
+
+        if (canScrollTo) {
+          region.scrollTo(scrollPosition.top, scrollPosition.left)
+        } else {
           region.scrollTop = scrollPosition.top
           region.scrollLeft = scrollPosition.left
         }

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -77,11 +77,18 @@ export class Router {
   }
 
   protected resetScrollPositions(): void {
-    document.documentElement.scrollTop = 0
-    document.documentElement.scrollLeft = 0
+    const canScrollTo = typeof document.documentElement.scrollTo === 'function'
+    if (canScrollTo) document.documentElement.scrollTo({ top: 0, left: 0 })
+    else {
+      document.documentElement.scrollTop = 0
+      document.documentElement.scrollLeft = 0
+    }
     this.scrollRegions().forEach(region => {
-      region.scrollTop = 0
-      region.scrollLeft = 0
+      if (canScrollTo) region.scrollTo({ top: 0, left: 0 })
+      else {
+        region.scrollTop = 0
+        region.scrollLeft = 0
+      }
     })
     this.saveScrollPositions()
     if (window.location.hash) {
@@ -90,10 +97,14 @@ export class Router {
   }
 
   protected restoreScrollPositions(): void {
+    const canScrollTo = typeof document.documentElement.scrollTo === 'function'
     if (this.page.scrollRegions) {
       this.scrollRegions().forEach((region: Element, index: number) => {
         const scrollPosition = this.page.scrollRegions[index]
-        if (scrollPosition) {
+        if (scrollPosition && canScrollTo) {
+          region.scrollTo({ top: scrollPosition.top, left: scrollPosition.left })
+        }
+        else if (scrollPosition) {
           region.scrollTop = scrollPosition.top
           region.scrollLeft = scrollPosition.left
         }

--- a/packages/inertia/src/router.ts
+++ b/packages/inertia/src/router.ts
@@ -77,12 +77,7 @@ export class Router {
   }
 
   protected resetScrollPositions(): void {
-    const canScrollTo = typeof document.documentElement.scrollTo === 'function'
-    if (canScrollTo) document.documentElement.scrollTo({ top: 0, left: 0 })
-    else {
-      document.documentElement.scrollTop = 0
-      document.documentElement.scrollLeft = 0
-    }
+    window.scrollTo(0, 0)
     this.scrollRegions().forEach(region => {
       if (canScrollTo) region.scrollTo({ top: 0, left: 0 })
       else {


### PR DESCRIPTION
Scroll position can fail to update in Firefox when setting it via `element.scrollTop` and `element.scrollLeft`. Change to preferring `element.scrollTo` with a fallback for the previous method to ensure backwards compatibility.

Resolves #1079