### PR TITLE
Add `undefined` as a valid option FormDataConvertable

### DIFF
--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -3,7 +3,7 @@ import { AxiosResponse, CancelTokenSource } from 'axios'
 export type Errors = Record<string, string>
 export type ErrorBag = Record<string, Errors>
 
-export type FormDataConvertible = Array<FormDataConvertible>|Blob|FormDataEntryValue|Date|boolean|number|null
+export type FormDataConvertible = Array<FormDataConvertible>|Blob|FormDataEntryValue|Date|boolean|number|null|undefined
 
 export enum Method {
   GET = 'get',


### PR DESCRIPTION
Doing a reload and sending across `undefined` explicitly for a key in data works, it will remove it from the url.
But the type doesn't allow it

E.g. the following works in straight js
```js
// page is /hello

Inertia.reload({data: {test: 5}});
//page is now /hello?test=5

Inertia.reload({data: {test: null}});
//page is now /hello?test=

Inertia.reload({data: {test: undefined}});
//page is now /hello
```