### PR TITLE
Bump Axios to ^0.27.0

### DIFF
--- a/packages/inertia/package.json
+++ b/packages/inertia/package.json
@@ -31,7 +31,7 @@
     "watch": "microbundle watch --format cjs"
   },
   "dependencies": {
-    "axios": "^0.26.0",
+    "axios": "^0.27.0",
     "deepmerge": "^4.0.0",
     "qs": "^6.9.0"
   },


### PR DESCRIPTION
Bumps Axios to the latest 0.27.x release. As far as I can see there's no impact for Inertia

Release notes:
- [v0.27.0](https://github.com/axios/axios/releases/tag/v0.27.0)
- [v0.27.1](https://github.com/axios/axios/releases/tag/v0.27.1)
- [v0.27.2](https://github.com/axios/axios/releases/tag/v0.27.2)