### PR TITLE
Svelte: De-duplicate calls to Inertia.remember

### DIFF
--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -200,7 +200,12 @@ function useForm(...args) {
     }
 
     if (rememberKey) {
-      Inertia.remember({ data: form.data(), errors: form.errors }, rememberKey)
+      const currentState = Inertia.restore(rememberKey)
+      const newState = { data: form.data(), errors: form.errors }
+
+      if (!isEqual(currentState, newState)) {
+        Inertia.remember({ data: form.data(), errors: form.errors }, rememberKey)
+      }
     }
   })
 


### PR DESCRIPTION
This change attempts to solve the `useForm` `history.replaceState` `SecurityError` described in
https://github.com/inertiajs/inertia/issues/1106 by ensuring we only call `Inertia.remember` when the state has changed.

This should more closely match the React implementation which uses a `useEffect` call with the `state` in the dependencies array. My guess is the Vue3 implementation has similar logic via the `watch` wrapper in that implementation's `useForm`.

Note: There is also https://github.com/inertiajs/inertia/pull/411/files open which attempts to solve this issue by debouncing. Debouncing is likely a more complete solution, but has a tradeoff of potential race conditions that might cause incorrect state values.