### PR TITLE
Explicitly add children to InertiaHeadProps type definition

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -46,6 +46,7 @@ type InertiaLinkProps = BaseInertiaLinkProps & Omit<React.HTMLAttributes<HTMLEle
 type InertiaLink = React.FunctionComponent<InertiaLinkProps>
 	
 type InertiaHeadProps = {
+    children?: React.ReactNode
     title?: string
 }
 


### PR DESCRIPTION
The current type definition for the Head component relies on React.FC, which as of React version 18 does not implicitly include the `children` prop. This results in typescript errors when using the Head component with children as in the example on the Inertia docs site. 