### PR TITLE
Issue #1325: Fix error missing children props in InertiaHeadProps type for Head component

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -46,7 +46,8 @@ type InertiaLinkProps = BaseInertiaLinkProps & Omit<React.HTMLAttributes<HTMLEle
 type InertiaLink = React.FunctionComponent<InertiaLinkProps>
 	
 type InertiaHeadProps = {
-    title?: string
+    title?: string,
+    children?: React.ReactNode | React.ReactNode[];
 }
 
 type InertiaHead = React.FunctionComponent<InertiaHeadProps>


### PR DESCRIPTION
For this issue the problem I raised here [#1325](https://github.com/inertiajs/inertia/issues/1325), 

I patch it by adding ReactNode and ReactNode[] types to the InertiaHeadProps type of the source code at the index.d.ts file.

**Note**: _I was see the PR https://github.com/inertiajs/inertia/pull/1315 of another contributor but it's missing ReactNode[] types for passing array elements to children. In many cases, we need to passing one or many element to children props._