### PR TITLE
Modifies useForm to handle nested data

### DIFF
--- a/packages/inertia-react/package.json
+++ b/packages/inertia-react/package.json
@@ -43,6 +43,6 @@
     "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "lodash.isequal": "^4.5.0"
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
In relation to [this discussion ](https://github.com/inertiajs/inertia/discussions/1174), here's a proposal for using nested form data in the react package. This uses @sbc640964's suggestion to utilize lodash methods, which made sense to me since lodash was already a dependency.

This also adds a `getData` function which is essentially just an alias for the lodash `get` function. Purely a convenience method which will help to build custom form and input components.

Since part of the goal is to make the form hook more compatible with backend data, I also included a sanitizer which processes the data passed in. React doesn't like when a controlled input's value changes from null or undefined to a value, it wants empty inputs to be an empty string. Converting null and undefined values into empty strings allows us to directly pass in empty objects from our controllers, which mimics how one might build a form in a vanilla Rails project.