### PR TITLE
Improve Svelte use:inertia and <Link />

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "packages/*"
   ],
   "dependencies": {
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "prettier-plugin-svelte": "^2.8.1"
   }
 }

--- a/packages/svelte/src/App.svelte
+++ b/packages/svelte/src/App.svelte
@@ -12,9 +12,9 @@
       store.update((current) => ({
         component,
         page,
-        key: preserveState ? current.key : Date.now()
+        key: preserveState ? current.key : Date.now(),
       }))
-    }
+    },
   })
 
   $: child = $store.component && h($store.component.default, $store.page.props)

--- a/packages/svelte/src/Link.svelte
+++ b/packages/svelte/src/Link.svelte
@@ -46,6 +46,14 @@
   on:mouseout
   on:mouseover
   on:mouseup
+  on:cancel-token
+  on:before
+  on:start
+  on:progress
+  on:finish
+  on:cancel
+  on:success
+  on:error
 >
   <slot />
 </svelte:element>

--- a/packages/svelte/src/Link.svelte
+++ b/packages/svelte/src/Link.svelte
@@ -30,7 +30,7 @@
     method,
     replace,
     preserveScroll,
-    preserveState,
+    preserveState: preserveState ?? method !== 'get',
     only,
     headers,
     queryStringArrayFormat,

--- a/packages/svelte/src/Link.svelte
+++ b/packages/svelte/src/Link.svelte
@@ -16,7 +16,7 @@
   beforeUpdate(() => {
     if (as === 'a' && method.toLowerCase() !== 'get') {
       console.warn(
-        `Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<Link href="${href}" method="${method}" as="button">...</Link>`
+        `Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<Link href="${href}" method="${method}" as="button">...</Link>`,
       )
     }
   })
@@ -35,7 +35,7 @@
     headers,
     queryStringArrayFormat,
   }}
-  {...(as === 'a' ? { href } : {})}
+  {...as === 'a' ? { href } : {}}
   {...$$restProps}
   on:focus
   on:blur

--- a/packages/svelte/src/Link.svelte
+++ b/packages/svelte/src/Link.svelte
@@ -1,49 +1,51 @@
 <script>
-  import { mergeDataIntoQueryString, router, shouldIntercept } from '@inertiajs/core'
-  import { beforeUpdate, createEventDispatcher } from 'svelte'
+  import { beforeUpdate } from 'svelte'
+  import { default as inertia } from './link'
 
-  const dispatch = createEventDispatcher()
-
-  export let
-    data = {},
-    href,
-    method = 'get',
-    replace = false,
-    preserveScroll = false,
-    preserveState = null,
-    only = [],
-    headers = {}
+  export let href
+  export let as = 'a'
+  export let data = {}
+  export let method = 'get'
+  export let replace = false
+  export let preserveScroll = false
+  export let preserveState = null
+  export let only = []
+  export let headers = {}
+  export let queryStringArrayFormat = 'brackets'
 
   beforeUpdate(() => {
-    method = method.toLowerCase()
-    const [_href, _data] = mergeDataIntoQueryString(method, href, data)
-    href = _href
-    data = _data
-
-    if (method !== 'get') {
-      console.warn(`Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "inertia" directive. For example:\n\n<button use:inertia={{ method: 'post', href: '${href}' }}>...</button>`)
+    if (as === 'a' && method.toLowerCase() !== 'get') {
+      console.warn(
+        `Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<Link href="${href}" method="${method}" as="button">...</Link>`
+      )
     }
   })
-
-  function visit(event) {
-    dispatch('click', event)
-
-    if (shouldIntercept(event)) {
-      event.preventDefault()
-
-      router.visit(href, {
-        data,
-        method,
-        preserveScroll,
-        preserveState: preserveState !== null ? preserveState : (method !== 'get'),
-        replace,
-        only,
-        headers,
-      })
-    }
-  }
 </script>
 
-<a {...$$restProps} {href} on:click={visit}>
+<svelte:element
+  this={as}
+  use:inertia={{
+    ...(as !== 'a' ? { href } : {}),
+    data,
+    method,
+    replace,
+    preserveScroll,
+    preserveState,
+    only,
+    headers,
+    queryStringArrayFormat,
+  }}
+  {...(as === 'a' ? { href } : {})}
+  {...$$restProps}
+  on:focus
+  on:blur
+  on:click
+  on:dblclick
+  on:mousedown
+  on:mousemove
+  on:mouseout
+  on:mouseover
+  on:mouseup
+>
   <slot />
-</a>
+</svelte:element>

--- a/packages/svelte/src/Render.svelte
+++ b/packages/svelte/src/Render.svelte
@@ -3,7 +3,7 @@
     return {
       component,
       ...(props ? { props } : {}),
-      ...(children ? { children } : {})
+      ...(children ? { children } : {}),
     }
   }
 </script>

--- a/packages/svelte/src/link.js
+++ b/packages/svelte/src/link.js
@@ -5,6 +5,10 @@ export default (node, options = {}) => {
   node.href = href
   options.data = data
 
+  function fireEvent(name, eventOptions = {}) {
+    return node.dispatchEvent(new CustomEvent(name, eventOptions))
+  }
+
   function hrefAndData(options) {
     return mergeDataIntoQueryString(
       options.method || 'get',
@@ -22,7 +26,17 @@ export default (node, options = {}) => {
     if (shouldIntercept(event)) {
       event.preventDefault()
 
-      router.visit(node.href, options)
+      router.visit(node.href, {
+        onCancelToken: () => fireEvent('cancel-token'),
+        onBefore: (visit) => fireEvent('before', { detail: { visit }}),
+        onStart: (visit) => fireEvent('start', { detail: { visit }}),
+        onProgress: (progress) => fireEvent('progress', { detail: { progress }}),
+        onFinish: (visit) => fireEvent('finish', { detail: { visit }}),
+        onCancel: () => fireEvent('cancel'),
+        onSuccess: (page) => fireEvent('success', { detail: { page }}),
+        onError: (errors) => fireEvent('error', { detail: { errors }}),
+        ...options,
+      })
     }
   }
 

--- a/packages/svelte/src/link.js
+++ b/packages/svelte/src/link.js
@@ -1,5 +1,4 @@
 import { mergeDataIntoQueryString, router, shouldIntercept } from '@inertiajs/core'
-import { createEventDispatcher } from 'svelte'
 
 export default (node, options = {}) => {
   const [href, data] = hrefAndData(options)
@@ -16,8 +15,6 @@ export default (node, options = {}) => {
   }
 
   function visit(event) {
-    dispatch('click', event)
-
     if (!node.href) {
       throw new Error('Option "href" is required')
     }

--- a/packages/svelte/src/link.js
+++ b/packages/svelte/src/link.js
@@ -28,13 +28,13 @@ export default (node, options = {}) => {
 
       router.visit(node.href, {
         onCancelToken: () => fireEvent('cancel-token'),
-        onBefore: (visit) => fireEvent('before', { detail: { visit }}),
-        onStart: (visit) => fireEvent('start', { detail: { visit }}),
-        onProgress: (progress) => fireEvent('progress', { detail: { progress }}),
-        onFinish: (visit) => fireEvent('finish', { detail: { visit }}),
+        onBefore: (visit) => fireEvent('before', { detail: { visit } }),
+        onStart: (visit) => fireEvent('start', { detail: { visit } }),
+        onProgress: (progress) => fireEvent('progress', { detail: { progress } }),
+        onFinish: (visit) => fireEvent('finish', { detail: { visit } }),
         onCancel: () => fireEvent('cancel'),
-        onSuccess: (page) => fireEvent('success', { detail: { page }}),
-        onError: (errors) => fireEvent('error', { detail: { errors }}),
+        onSuccess: (page) => fireEvent('success', { detail: { page } }),
+        onError: (errors) => fireEvent('error', { detail: { errors } }),
         ...options,
       })
     }

--- a/packages/svelte/src/link.js
+++ b/packages/svelte/src/link.js
@@ -2,29 +2,30 @@ import { mergeDataIntoQueryString, router, shouldIntercept } from '@inertiajs/co
 import { createEventDispatcher } from 'svelte'
 
 export default (node, options = {}) => {
-  const [href, data] = mergeDataIntoQueryString(
-    options.method || 'get',
-    node.href || options.href || '',
-    options.data || {},
-    options.queryStringArrayFormat || 'brackets',
-  )
+  const [href, data] = hrefAndData(options)
   node.href = href
   options.data = data
 
-  const dispatch = createEventDispatcher()
+  function hrefAndData(options) {
+    return mergeDataIntoQueryString(
+      options.method || 'get',
+      node.href || options.href || '',
+      options.data || {},
+      options.queryStringArrayFormat || 'brackets',
+    )
+  }
 
   function visit(event) {
     dispatch('click', event)
 
-    const href = node.href || options.href
-
-    if (!href) {
+    if (!node.href) {
       throw new Error('Option "href" is required')
     }
 
     if (shouldIntercept(event)) {
       event.preventDefault()
-      router.visit(href, options)
+
+      router.visit(node.href, options)
     }
   }
 
@@ -32,15 +33,9 @@ export default (node, options = {}) => {
 
   return {
     update(newOptions) {
-      const [href, data] = mergeDataIntoQueryString(
-        newOptions.method || 'get',
-        node.href || newOptions.href,
-        newOptions.data || {},
-        newOptions.queryStringArrayFormat || 'brackets',
-      )
+      const [href, data] = hrefAndData(newOptions)
       node.href = href
-      newOptions.data = data
-      options = newOptions
+      options = { ...newOptions, data }
     },
     destroy() {
       node.removeEventListener('click', visit)


### PR DESCRIPTION
This PR brings a bunch of improvements to the `use:inertia` action and `<Link />` component.

## `use:inertia`

### Simplify options merge logic ([#9eb66f6](https://github.com/inertiajs/inertia/commit/9eb66f6ce5288da6ce2c2135fb8c1ca33791a8b5))

### Stop dispatching the click event ([#640f690](https://github.com/inertiajs/inertia/commit/640f69055c06c34102297cf9ce7165e8de231a6b))

It was a mistake to dispatch the `click` event with `createEventDispatcher` from the action in first place. Its use is [intended for components](https://svelte.dev/docs#template-syntax-component-directives). We ran into an edge-case bug because of this in our own app.

The element where `use:inertia` is used on can still have an `on:click` handler or an event forwarder.

### Dispatch Inertia events on the HTML node ([#00a4fa2](https://github.com/inertiajs/inertia/commit/00a4fa213756c108f8727795f89fd59f2c9b559e))

This allows you to listen to Inertia event callbacks the Svelte way when using `use:inertia`.
  
```svelte
<button
  use:inertia={{ method: 'PUT', href: '/posts' }}
  type="button"
  on:start={({ detail }) => console.log(detail.visit)}
  on:finish={({ detail }) => console.log(detail.visit)}
>
  Create post
</button>
```

All [event callbacks](https://inertiajs.com/manual-visits#event-callbacks) are supported: `on:cancel-token`, `on:before`, `on:start`, `on:progress`, `on:finish`, `on:cancel`, `on:success`, and `on:error`. They also receive the same `detail` parameters as the Inertia event callbacks.
  
## `<Link />`

### Add `as` prop ([#7ff652a](https://github.com/inertiajs/inertia/commit/7ff652a377d1a1879f745bd40289ed0831a4f02b))

You can now specify which HTML element the `<Link />` component should render.

```svelte
<Link as="a" href="/home">Home</Link>
<Link as="button" href="/home">Home</Link>
```

The `as` prop defaults to the `a` HTML element.

### Remove duplicated logic ([#7ff652a](https://github.com/inertiajs/inertia/commit/7ff652a377d1a1879f745bd40289ed0831a4f02b))

Previously the `<Link />` component and `use:inertia` action had a bunch of duplicated code. Now all this logic only exists on the action. The `<Link />` component uses the action under the hood. This will make it easy to maintain both.

### Forward all Inertia callback events ([#85d6704](https://github.com/inertiajs/inertia/commit/85d67044981932a60061a61c1b5ace6b80c5ac57))

```svelte
<Link
  as="button"
  type="button"
  href="/posts"
  method="PUT"
  on:start={({ detail }) => console.log(detail.visit)}
  on:finish={({ detail }) => console.log(detail.visit)}
>
  Create post
</Link>
```