### PR TITLE
Allow ignoring of "popstate" event

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -472,6 +472,10 @@ export class Router {
 
   protected handlePopstateEvent(event: PopStateEvent): void {
     if (event.state !== null) {
+      if (event.state['inertia-ignore'] === true) {
+        return
+      }
+
       const page = event.state
       const visitId = this.createVisitId()
       Promise.resolve(this.resolveComponent(page.component)).then((component) => {


### PR DESCRIPTION
I've made a very small & simple change to the core router to allow other scripts to handle the popstate event by passing `'inertia-ignore': true` in the `history.state` this would allow custom routers to be made for pages. 

Currently I am creating a very simple router that can route components after a `#` is added to the page url. It utilizes the `popstate` event and `history.pushState(...)` but on every `popstate` event inertia remounts the page (using vue) and this is causing page flickering and some odd behavior with the history.state
