### PR TITLE
Simplify `usePage()` hook in Vue 3 adapter

### DIFF
--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -1,16 +1,5 @@
-import { createHeadManager, Page, PageProps, router } from '@inertiajs/core'
-import {
-  computed,
-  ComputedRef,
-  DefineComponent,
-  defineComponent,
-  h,
-  markRaw,
-  Plugin,
-  PropType,
-  ref,
-  shallowRef,
-} from 'vue'
+import { createHeadManager, Page, router } from '@inertiajs/core'
+import { DefineComponent, defineComponent, h, markRaw, Plugin, PropType, ref, shallowRef } from 'vue'
 import remember from './remember'
 import { VuePageHandlerArgs } from './types'
 import useForm from './useForm'
@@ -126,16 +115,6 @@ export const plugin: Plugin = {
   },
 }
 
-export function usePage(): {
-  props: ComputedRef<PageProps>
-  url: ComputedRef<string>
-  component: ComputedRef<string>
-  version: ComputedRef<string | null>
-} {
-  return {
-    props: computed(() => page.value.props),
-    url: computed(() => page.value.url),
-    component: computed(() => page.value.component),
-    version: computed(() => page.value.version),
-  }
+export function usePage() {
+  return page.value
 }

--- a/playgrounds/vue3/resources/js/Components/Layout.vue
+++ b/playgrounds/vue3/resources/js/Components/Layout.vue
@@ -2,7 +2,7 @@
 import { Link, usePage } from '@inertiajs/vue3'
 import { computed } from 'vue'
 
-const appName = computed(() => usePage().props.value.appName)
+const appName = computed(() => usePage().props.appName)
 </script>
 
 <template>


### PR DESCRIPTION
This PR simplifies the `usePage()` hook in the Vue 3 adapter. We use to run `computed()` on each value in the `page` object (in the root `<App>` component):

```js
export function usePage() {
  return {
    props: computed(() => page.value.props),
    url: computed(() => page.value.url),
    component: computed(() => page.value.component),
    version: computed(() => page.value.version),
  }
```

In hindsight I honestly don't know why we did this. As far as I can tell you still always need to use `usePage()` in conjunction with a `computed()` call within your own components anyway, so this is redundant. Here's what you need to do today:

```js
import { computed } from 'vue'

const appName = computed(() => usePage().props.value.appName)
                                          //  ^
                                          //  |- I hate that this .value is required
```

This would be worth it if you didn't need to still use `computed()` in your own components. But since you do, we might as well simplify `usePage` to this:

```js
export function usePage() {
  return page.value
}
```

Doing that makes this hook easier to consume in your own components, because you no longer need to know that `.value` is required after each top level property:

```js
import { computed } from 'vue'

const appName = computed(() => usePage().props.appName)
                                          //  ^
                                          //  |- No more .value required!
```

To me this is *much* better, but it's a breaking change. Obviously we're on the brink of an official 1.0 release, so now is the time to do it. It just means a slightly more difficult upgrade process for folks.

The upgrade process would just involve removing `.value` from their `usePage()` calls:

```diff
- const appName = computed(() => usePage().props.value.appName)
+ const appName = computed(() => usePage().props.appName)
```

Worth it? 🤔 