### PR TITLE
Update axios to 1.x

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.27.0",
+    "axios": "^1.2.0",
     "deepmerge": "^4.0.0",
     "nprogress": "^0.2.0",
     "qs": "^6.9.0"

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -355,8 +355,8 @@ export class Router {
         ...(this.page.version ? { 'X-Inertia-Version': this.page.version } : {}),
       },
       onUploadProgress: (progress) => {
-        if (data instanceof FormData && progress.total) {
-          progress.percentage = Math.round((progress.loaded / progress.total) * 100)
+        if (data instanceof FormData) {
+          progress.percentage = progress.progress ? Math.round(progress.progress * 100) : 0
           fireProgressEvent(progress)
           onProgress(progress)
         }

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -355,7 +355,7 @@ export class Router {
         ...(this.page.version ? { 'X-Inertia-Version': this.page.version } : {}),
       },
       onUploadProgress: (progress) => {
-        if (data instanceof FormData) {
+        if (data instanceof FormData && progress.total) {
           progress.percentage = Math.round((progress.loaded / progress.total) * 100)
           fireProgressEvent(progress)
           onProgress(progress)

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -246,6 +246,12 @@ export class Router {
     }
   }
 
+  public cancel(): void {
+    if (this.activeVisit) {
+      this.cancelVisit(this.activeVisit, { cancelled: true })
+    }
+  }
+
   public visit(
     href: string | URL,
     {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -216,7 +216,7 @@ export class Router {
     { cancelled = false, interrupted = false }: { cancelled?: boolean; interrupted?: boolean },
   ): void {
     if (activeVisit && !activeVisit.completed && !activeVisit.cancelled && !activeVisit.interrupted) {
-      activeVisit.cancelToken.cancel()
+      activeVisit.cancelToken.abort()
       activeVisit.onCancel()
       activeVisit.completed = false
       activeVisit.cancelled = cancelled
@@ -320,7 +320,7 @@ export class Router {
       onSuccess,
       onError,
       queryStringArrayFormat,
-      cancelToken: Axios.CancelToken.source(),
+      cancelToken: new AbortController(),
     }
 
     onCancelToken({
@@ -339,7 +339,7 @@ export class Router {
       url: urlWithoutHash(url).href,
       data: method === Method.GET ? {} : data,
       params: method === Method.GET ? data : {},
-      cancelToken: this.activeVisit.cancelToken.token,
+      signal: this.activeVisit.cancelToken.signal,
       headers: {
         ...headers,
         Accept: 'text/html, application/xhtml+xml',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,10 @@
-import { AxiosResponse, CancelTokenSource } from 'axios'
+import { AxiosProgressEvent, AxiosResponse, CancelTokenSource } from 'axios'
+
+declare module 'axios' {
+  export interface AxiosProgressEvent {
+    percentage: number | undefined
+  }
+}
 
 export type Errors = Record<string, string>
 export type ErrorBag = Record<string, Errors>
@@ -56,7 +62,7 @@ export type PageHandler = ({
 
 export type PreserveStateOption = boolean | string | ((page: Page) => boolean)
 
-export type Progress = ProgressEvent & { percentage: number }
+export type Progress = AxiosProgressEvent
 
 export type LocationVisit = {
   preserveScroll: boolean

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-import { AxiosProgressEvent, AxiosResponse, CancelTokenSource } from 'axios'
+import { AxiosProgressEvent, AxiosResponse } from 'axios'
 
 declare module 'axios' {
   export interface AxiosProgressEvent {
@@ -192,7 +192,7 @@ export type PendingVisit = Visit & {
 
 export type ActiveVisit = PendingVisit &
   Required<VisitOptions> & {
-    cancelToken: CancelTokenSource
+    cancelToken: AbortController
   }
 
 export type VisitId = unknown

--- a/packages/vue2/tests/cypress/integration/events.test.js
+++ b/packages/vue2/tests/cypress/integration/events.test.js
@@ -16,7 +16,6 @@ const assertPageObject = (page) => {
   expect(page).to.have.property('version')
 }
 const assertProgressObject = (progress) => {
-  expect(progress).to.have.property('isTrusted')
   expect(progress).to.have.property('percentage')
   expect(progress).to.have.property('total')
   expect(progress).to.have.property('loaded')

--- a/packages/vue2/tests/cypress/integration/events.test.js
+++ b/packages/vue2/tests/cypress/integration/events.test.js
@@ -565,7 +565,7 @@ describe('Events', () => {
         const assertExceptionObject = (detail) => {
           expect(detail).to.be.an('object')
           expect(detail).to.have.property('exception')
-          expect(detail.exception).to.be.an('Error')
+          expect(detail.exception.code).to.eq('ERR_NETWORK')
         }
         const assertGlobalEvent = (event) => {
           expect(event).to.be.an('CustomEvent')

--- a/packages/vue2/tests/cypress/integration/form-helper.test.js
+++ b/packages/vue2/tests/cypress/integration/form-helper.test.js
@@ -545,7 +545,6 @@ describe('Form Helper', () => {
           .then(() => {
             expect(alert.getCall(3)).to.be.calledWith('onProgress')
             tap(alert.getCall(4).lastArg, (event) => {
-              expect(event).to.have.property('isTrusted')
               expect(event).to.have.property('percentage')
               expect(event).to.have.property('total')
               expect(event).to.have.property('loaded')
@@ -583,7 +582,6 @@ describe('Form Helper', () => {
 
             expect(alert.getCall(6)).to.be.calledWith('onProgress')
             tap(alert.getCall(7).lastArg, (event) => {
-              expect(event).to.have.property('isTrusted')
               expect(event).to.have.property('percentage')
               expect(event).to.have.property('total')
               expect(event).to.have.property('loaded')
@@ -644,7 +642,6 @@ describe('Form Helper', () => {
           .then(() => {
             expect(alert.getCall(6)).to.be.calledWith('onProgress')
             tap(alert.getCall(7).lastArg, (event) => {
-              expect(event).to.have.property('isTrusted')
               expect(event).to.have.property('percentage')
               expect(event).to.have.property('total')
               expect(event).to.have.property('loaded')
@@ -761,7 +758,6 @@ describe('Form Helper', () => {
           .then(() => {
             expect(alert.getCall(6)).to.be.calledWith('onProgress')
             tap(alert.getCall(7).lastArg, (event) => {
-              expect(event).to.have.property('isTrusted')
               expect(event).to.have.property('percentage')
               expect(event).to.have.property('total')
               expect(event).to.have.property('loaded')


### PR DESCRIPTION
This PR updates axios to 1.x.

As part of this update we've replaced the internal `cancelToken` handling with the new `AbortController` handling available in the newer versions of axios, as cancel tokens have been deprecated. However, the external API (`onCancelToken()` visit callback) has not changed for backwards compatibility reasons.

Also included with this update is a fancy new `router.cancel()` method that lets you easily cancel the currently active visit, effectively removing the need to ever use the `onCancelToken()` visit callback again.

```js
import { router } from '@inertiajs/vue3'

router.cancel()
```