### PR TITLE
Adds `clearChangedErrors` method to clear changed fields errors

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -23,6 +23,7 @@ export interface InertiaFormProps<TForm extends Record<string, unknown>> {
   setDefaults(fields: Record<keyof TForm, string>): void
   reset: (...fields: (keyof TForm)[]) => void
   clearErrors: (...fields: (keyof TForm)[]) => void
+  clearChangedErrors: () => void
   setError(field: keyof TForm, value: string): void
   setError(errors: Record<keyof TForm, string>): void
   submit: (method: Method, url: string, options?: VisitOptions) => void
@@ -237,6 +238,12 @@ export default function useForm<TForm extends Record<string, unknown>>(
         setHasErrors(Object.keys(newErrors).length > 0)
         return newErrors
       })
+    },
+    clearChangedErrors() {
+      const changed = (Object.entries(data) as [string, any][])
+          .filter(([field, value]: [string, any]) => !isEqual(value, defaults[field]))
+          .map(([field]: [string, any]) => field)
+      this.clearErrors(...changed)
     },
     submit,
     get(url, options) {

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -240,10 +240,14 @@ export default function useForm<TForm extends Record<string, unknown>>(
       })
     },
     clearChangedErrors() {
-      const changed = (Object.entries(data) as [string, any][])
-          .filter(([field, value]: [string, any]) => !isEqual(value, defaults[field]))
-          .map(([field]: [string, any]) => field)
-      this.clearErrors(...changed)
+      setErrors((errors) => {
+        const newErrors = Object.fromEntries(
+          (Object.entries(errors) as Array<[keyof TForm, string]>)
+              .filter(([field]) => isEqual(data[field], defaults[field]))
+        ) as { [K in keyof TForm]: string }
+        setHasErrors(Object.keys(newErrors).length > 0)
+        return newErrors
+      })
     },
     submit,
     get(url, options) {

--- a/packages/svelte/src/useForm.js
+++ b/packages/svelte/src/useForm.js
@@ -85,6 +85,15 @@ function useForm(...args) {
 
       return this
     },
+    clearChangedErrors() {
+      const changed = Object.entries(this.data())
+          .filter(([field, value]) => !isEqual(value, defaults[field]))
+          .map(([field]) => field)
+
+      this.clearErrors(...changed)
+
+      return this
+    },
     submit(method, url, options = {}) {
       const data = transform(this.data())
       const _options = {

--- a/packages/svelte/src/useForm.js
+++ b/packages/svelte/src/useForm.js
@@ -86,11 +86,13 @@ function useForm(...args) {
       return this
     },
     clearChangedErrors() {
-      const changed = Object.entries(this.data())
-          .filter(([field, value]) => !isEqual(value, defaults[field]))
-          .map(([field]) => field)
-
-      this.clearErrors(...changed)
+      const data = this.data()
+      this.setStore(
+        'errors',
+        Object.fromEntries(
+          Object.entries(this.errors).filter(([field]) => isEqual(data[field], defaults[field]))
+        )
+      )
 
       return this
     },

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -18,6 +18,7 @@ interface InertiaFormProps<TForm> {
   defaults(fields: Record<keyof TForm, string>): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
+  clearChangedErrors(): this
   setError(field: keyof TForm, value: string): this
   setError(errors: Record<keyof TForm, string>): this
   submit(method: string, url: string, options?: Partial<VisitOptions>): void
@@ -111,6 +112,15 @@ export default function useForm<TForm>(...args): InertiaForm<TForm> {
       )
 
       this.hasErrors = Object.keys(this.errors).length > 0
+
+      return this
+    },
+    clearChangedErrors() {
+      const changed = Object.entries(this.data())
+          .filter(([field, value]) => !isEqual(value, defaults[field]))
+          .map(([field]) => field)
+
+      this.clearErrors(...changed)
 
       return this
     },

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -116,11 +116,13 @@ export default function useForm<TForm>(...args): InertiaForm<TForm> {
       return this
     },
     clearChangedErrors() {
-      const changed = Object.entries(this.data())
-          .filter(([field, value]) => !isEqual(value, defaults[field]))
-          .map(([field]) => field)
+      const data = this.data()
 
-      this.clearErrors(...changed)
+      this.errors = Object.fromEntries(
+        Object.entries(this.errors).filter(([field]) => isEqual(data[field], defaults[field]))
+      )
+
+      this.hasErrors = Object.keys(this.errors).length > 0
 
       return this
     },

--- a/packages/vue2/tests/app/Pages/FormHelper/Errors.vue
+++ b/packages/vue2/tests/app/Pages/FormHelper/Errors.vue
@@ -22,6 +22,7 @@
     <span @click="clearError" class="clear-one">Clear one error</span>
     <span @click="setErrors" class="set">Set errors</span>
     <span @click="setError" class="set-one">Set one error</span>
+    <span @click="clearChangedErrors" class="clear-changed">Clear changed fields errors</span>
 
     <span class="errors-status">Form has {{ form.hasErrors ? '' : 'no ' }}errors</span>
   </div>
@@ -46,6 +47,9 @@ export default {
     },
     clearError() {
       this.form.clearErrors('handle')
+    },
+    clearChangedErrors() {
+      this.form.clearChangedErrors()
     },
     setErrors() {
       this.form.setError({

--- a/packages/vue2/tests/cypress/integration/form-helper.test.js
+++ b/packages/vue2/tests/cypress/integration/form-helper.test.js
@@ -249,6 +249,24 @@ describe('Form Helper', () => {
       cy.get('.remember_error').should('not.exist')
     })
 
+    it('can clear form errors from changed fields', () => {
+      cy.get('.submit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('#name').clear().type('foo')
+      cy.get('.clear-changed').click()
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('not.exist')
+      cy.get('.remember_error').should('not.exist')
+    })
+
     it('does not reset fields back to their initial values when it clears a subset of form errors', () => {
       cy.get('.submit').click()
       cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -124,11 +124,13 @@ export default function useForm<TForm extends Record<string, unknown>>(
       return this
     },
     clearChangedErrors() {
-      const changed = Object.entries(this.data())
-          .filter(([field, value]) => !isEqual(value, defaults[field]))
-          .map(([field]) => field)
+      const data = this.data()
 
-      this.clearErrors(...changed)
+      this.errors = Object.fromEntries(
+        Object.entries(this.errors).filter(([field]) => isEqual(data[field], defaults[field]))
+      )
+
+      this.hasErrors = Object.keys(this.errors).length > 0
 
       return this
     },

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -18,6 +18,7 @@ interface InertiaFormProps<TForm extends Record<string, unknown>> {
   defaults(fields: Record<keyof TForm, string>): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
+  clearChangedErrors(): this
   setError(field: keyof TForm, value: string): this
   setError(errors: Record<keyof TForm, string>): this
   submit(method: string, url: string, options?: Partial<VisitOptions>): void
@@ -119,6 +120,15 @@ export default function useForm<TForm extends Record<string, unknown>>(
       )
 
       this.hasErrors = Object.keys(this.errors).length > 0
+
+      return this
+    },
+    clearChangedErrors() {
+      const changed = Object.entries(this.data())
+          .filter(([field, value]) => !isEqual(value, defaults[field]))
+          .map(([field]) => field)
+
+      this.clearErrors(...changed)
 
       return this
     },


### PR DESCRIPTION
This PR adds a new method called `clearChangedErrors`.

It will clear errors from any changed fields. 

This is useful when resubmitting a form where a user tried to correct its errors, and validation is performed server-side.

Take this snippet as an example:

```js
function handleSubmit() {
    if (! this.form.isDirty) {
        return alert('No changes made');
    }
    
    // as .clearChangedErrors() returns 
    // the form instance (on Vue 2, Vue 3 and Svelte) 
    // we can check if there are still uncorrected fields
    // while cleaning any changed fields
    if (this.form.clearChangedErrors().hasErrors) {
        return alert('Please correct all fields with errors');
    } else {
        this.form.defaults();
    }

    this.form.post('https://...');
}
```

This PR:
- adds the method `clearChangedErrors` to all current adapters (Vue 2, Vue 3, Svelte, and React) 
- adds a test case to the Vue 2 test suite (the only adapter with a test suite as of the present time)


