### PR TITLE
Restore Vue 3 `usePage` generic type

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,7 +27,7 @@ export interface PageProps {
   [key: string]: unknown
 }
 
-export interface Page<SharedProps = PageProps> {
+export interface Page<SharedProps extends PageProps = PageProps> {
   component: string
   props: PageProps &
     SharedProps & {

--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -9,13 +9,13 @@ type ReactComponent = ReactNode
 type HeadManagerOnUpdate = (elements: string[]) => void // TODO: When shipped, replace with: Inertia.HeadManagerOnUpdate
 type HeadManagerTitleCallback = (title: string) => string // TODO: When shipped, replace with: Inertia.HeadManagerTitleCallback
 
-type AppType<SharedProps = PageProps> = FunctionComponent<
+type AppType<SharedProps extends PageProps = PageProps> = FunctionComponent<
   {
     children?: (props: { Component: ComponentType; key: Key; props: Page<SharedProps>['props'] }) => ReactNode
   } & SetupOptions<unknown, SharedProps>['props']
 >
 
-export type SetupOptions<ElementType, SharedProps> = {
+export type SetupOptions<ElementType, SharedProps extends PageProps> = {
   el: ElementType
   App: AppType
   props: {
@@ -33,7 +33,7 @@ type BaseInertiaAppOptions = {
 }
 
 type CreateInertiaAppSetupReturnType = ReactInstance | void
-type InertiaAppOptionsForCSR<SharedProps> = BaseInertiaAppOptions & {
+type InertiaAppOptionsForCSR<SharedProps extends PageProps> = BaseInertiaAppOptions & {
   id?: string
   page?: Page | string
   render?: undefined
@@ -49,7 +49,7 @@ type InertiaAppOptionsForCSR<SharedProps> = BaseInertiaAppOptions & {
 }
 
 type CreateInertiaAppSSRContent = { head: string[]; body: string }
-type InertiaAppOptionsForSSR<SharedProps> = BaseInertiaAppOptions & {
+type InertiaAppOptionsForSSR<SharedProps extends PageProps> = BaseInertiaAppOptions & {
   id?: undefined
   page: Page | string
   render: typeof renderToString
@@ -57,13 +57,13 @@ type InertiaAppOptionsForSSR<SharedProps> = BaseInertiaAppOptions & {
   setup(options: SetupOptions<null, SharedProps>): ReactInstance
 }
 
-export default async function createInertiaApp<SharedProps = PageProps>(
+export default async function createInertiaApp<SharedProps extends PageProps = PageProps>(
   options: InertiaAppOptionsForCSR<SharedProps>,
 ): Promise<CreateInertiaAppSetupReturnType>
-export default async function createInertiaApp<SharedProps = PageProps>(
+export default async function createInertiaApp<SharedProps extends PageProps = PageProps>(
   options: InertiaAppOptionsForSSR<SharedProps>,
 ): Promise<CreateInertiaAppSSRContent>
-export default async function createInertiaApp<SharedProps = PageProps>({
+export default async function createInertiaApp<SharedProps extends PageProps = PageProps>({
   id = 'app',
   resolve,
   setup,

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -15,7 +15,7 @@ export interface InertiaAppProps {
 export type InertiaApp = DefineComponent<InertiaAppProps>
 
 const component = ref(null)
-const page = ref<Partial<Page>>({})
+const page = ref<Page>(null)
 const layout = shallowRef(null)
 const key = ref(null)
 let headManager = null
@@ -115,6 +115,6 @@ export const plugin: Plugin = {
   },
 }
 
-export function usePage() {
+export function usePage<T>(): Page<T> {
   return page.value
 }

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -115,6 +115,6 @@ export const plugin: Plugin = {
   },
 }
 
-export function usePage<T extends PageProps>(): Page<T> {
+export function usePage<SharedProps extends PageProps>(): Page<SharedProps> {
   return page.value
 }

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -1,4 +1,4 @@
-import { createHeadManager, Page, router } from '@inertiajs/core'
+import { createHeadManager, Page, PageProps, router } from '@inertiajs/core'
 import { DefineComponent, defineComponent, h, markRaw, Plugin, PropType, ref, shallowRef } from 'vue'
 import remember from './remember'
 import { VuePageHandlerArgs } from './types'
@@ -115,6 +115,6 @@ export const plugin: Plugin = {
   },
 }
 
-export function usePage<T>(): Page<T> {
+export function usePage<T extends PageProps>(): Page<T> {
   return page.value
 }

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -15,7 +15,7 @@ export interface InertiaAppProps {
 export type InertiaApp = DefineComponent<InertiaAppProps>
 
 const component = ref(null)
-const page = ref<Page>(null)
+const page = ref<Page<any>>(null)
 const layout = shallowRef(null)
 const key = ref(null)
 let headManager = null

--- a/playgrounds/vue3/resources/js/Components/Layout.vue
+++ b/playgrounds/vue3/resources/js/Components/Layout.vue
@@ -2,7 +2,7 @@
 import { Link, usePage } from '@inertiajs/vue3'
 import { computed } from 'vue'
 
-const appName = computed(() => usePage().props.appName)
+const appName = computed(() => usePage<{ appName: string }>().props.appName)
 </script>
 
 <template>


### PR DESCRIPTION
When converting the adapters to TypeScript, I forgot to copy over the existing type definition for `usePage` which used a generic.

This PR attempts to restore this, however, I can't currently get it to build.

Fixes #1381