### PR TITLE
Fix: export types correctly

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,9 @@
   },
   "typesVersions": {
     "*": {
-      "server": ["types/server.d.ts"]
+      "server": [
+        "types/server.d.ts"
+      ]
     }
   },
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,10 +26,12 @@
   "types": "types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/index.esm.js",
       "require": "./dist/index.js"
     },
     "./server": {
+      "types": "./types/server.d.ts",
       "import": "./dist/server.esm.js",
       "require": "./dist/server.js"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,13 +27,16 @@
   "exports": {
     ".": {
       "import": "./dist/index.esm.js",
-      "require": "./dist/index.js",
-      "types": "./types/index.d.js"
+      "require": "./dist/index.js"
     },
     "./server": {
       "import": "./dist/server.esm.js",
-      "require": "./dist/server.js",
-      "types": "./types/server.d.js"
+      "require": "./dist/server.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "server": ["types/server.d.ts"]
     }
   },
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,10 +25,12 @@
   "types": "types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/index.esm.js",
       "require": "./dist/index.js"
     },
     "./server": {
+      "types": "./types/server.d.ts",
       "import": "./dist/server.esm.js",
       "require": "./dist/server.js"
     }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,7 +37,9 @@
   },
   "typesVersions": {
     "*": {
-      "server": ["types/server.d.ts"]
+      "server": [
+        "types/server.d.ts"
+      ]
     }
   },
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,13 +26,16 @@
   "exports": {
     ".": {
       "import": "./dist/index.esm.js",
-      "require": "./dist/index.js",
-      "types": "./types/index.d.js"
+      "require": "./dist/index.js"
     },
     "./server": {
       "import": "./dist/server.esm.js",
-      "require": "./dist/server.js",
-      "types": "./types/server.d.js"
+      "require": "./dist/server.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "server": ["types/server.d.ts"]
     }
   },
   "scripts": {

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/index.ts"],
+  "include": ["src/index.ts", "src/server.ts"],
   "compilerOptions": {
     "rootDir": "src",
     "noEmitOnError": true,

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -38,7 +38,9 @@
   },
   "typesVersions": {
     "*": {
-      "server": ["types/server.d.ts"]
+      "server": [
+        "types/server.d.ts"
+      ]
     }
   },
   "scripts": {

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -26,10 +26,12 @@
   "types": "types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/index.esm.js",
       "require": "./dist/index.js"
     },
     "./server": {
+      "types": "./types/server.d.ts",
       "import": "./dist/server.esm.js",
       "require": "./dist/server.js"
     }

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -27,13 +27,16 @@
   "exports": {
     ".": {
       "import": "./dist/index.esm.js",
-      "require": "./dist/index.js",
-      "types": "./types/index.d.js"
+      "require": "./dist/index.js"
     },
     "./server": {
       "import": "./dist/server.esm.js",
-      "require": "./dist/server.js",
-      "types": "./types/server.d.js"
+      "require": "./dist/server.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "server": ["types/server.d.ts"]
     }
   },
   "scripts": {

--- a/packages/vue2/tsconfig.json
+++ b/packages/vue2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/index.ts"],
+  "include": ["src/index.ts", "src/server.ts"],
   "compilerOptions": {
     "rootDir": "src",
     "noEmitOnError": true,

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -24,10 +24,12 @@
   "types": "types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/index.esm.js",
       "require": "./dist/index.js"
     },
     "./server": {
+      "types": "./types/server.d.ts",
       "import": "./dist/server.esm.js",
       "require": "./dist/server.js"
     }

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -36,7 +36,9 @@
   },
   "typesVersions": {
     "*": {
-      "server": ["types/server.d.ts"]
+      "server": [
+        "types/server.d.ts"
+      ]
     }
   },
   "scripts": {

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -25,13 +25,16 @@
   "exports": {
     ".": {
       "import": "./dist/index.esm.js",
-      "require": "./dist/index.js",
-      "types": "./types/index.d.js"
+      "require": "./dist/index.js"
     },
     "./server": {
       "import": "./dist/server.esm.js",
-      "require": "./dist/server.js",
-      "types": "./types/server.d.js"
+      "require": "./dist/server.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "server": ["types/server.d.ts"]
     }
   },
   "scripts": {

--- a/packages/vue3/tsconfig.json
+++ b/packages/vue3/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/index.ts"],
+  "include": ["src/index.ts", "src/server.ts"],
   "compilerOptions": {
     "rootDir": "src",
     "noEmitOnError": true,

--- a/playgrounds/vue3/resources/js/ssr.ts
+++ b/playgrounds/vue3/resources/js/ssr.ts
@@ -1,10 +1,8 @@
 import { createInertiaApp } from '@inertiajs/vue3'
-// @ts-expect-error
 import createServer from '@inertiajs/vue3/server'
 import { renderToString } from '@vue/server-renderer'
 import { createSSRApp, h, type DefineComponent } from 'vue'
 
-// @ts-expect-error
 createServer((page) =>
   createInertiaApp({
     page,


### PR DESCRIPTION
The "exports" field of the package.json was misused for the type-declarations. Also, the type-declarations of secondary entrypoint (server.ts) of the platform packages was not generated.

Docs:
- https://2ality.com/2021/06/typescript-esm-nodejs.html#mapping-a-directory-to-a-file
- https://dev.to/binjospookie/exports-in-package-json-1fl2