### PR TITLE
Add ability to use a custom component with <Link>

### DIFF
--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -7,12 +7,12 @@ import {
   router,
   shouldIntercept,
 } from '@inertiajs/core'
-import { createElement, forwardRef, useCallback } from 'react'
+import { createElement, forwardRef, useCallback, ComponentType } from 'react'
 
 const noop = () => undefined
 
 interface BaseInertiaLinkProps {
-  as?: string
+  as?: string | ComponentType,
   data?: Record<string, FormDataConvertible>
   href: string
   method?: Method
@@ -43,7 +43,7 @@ const Link: InertiaLink = forwardRef<unknown, InertiaLinkProps>(
   (
     {
       children,
-      as = 'a',
+      as: Element = 'a',
       data = {},
       href,
       method = Method.GET,
@@ -113,27 +113,30 @@ const Link: InertiaLink = forwardRef<unknown, InertiaLinkProps>(
       ],
     )
 
-    as = as.toLowerCase()
     method = method.toLowerCase() as Method
     const [_href, _data] = mergeDataIntoQueryString(method, href || '', data, queryStringArrayFormat)
     href = _href
     data = _data
+  
+    if (typeof as === 'string') {
+      Element = Element.toLowerCase()
 
-    if (as === 'a' && method !== 'get') {
-      console.warn(
-        `Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<Link href="${href}" method="${method}" as="button">...</Link>`,
-      )
+      if (Element === 'a' && method !== 'get') {
+        console.warn(
+          `Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\nPlease specify a more appropriate element using the "as" attribute. For example:\n\n<Link href="${href}" method="${method}" as="button">...</Link>`,
+        )
+      }
     }
 
-    return createElement(
-      as,
-      {
-        ...props,
-        ...(as === 'a' ? { href } : {}),
-        ref,
-        onClick: visit,
-      },
-      children,
+    return (
+      <Element
+        {...props}
+        href={Element === 'a' ? href : undefined}
+        ref={ref}
+        onClick={visit}
+      >
+        {children}
+      </Element>
     )
   },
 )


### PR DESCRIPTION
Adding the option to use either a string **or a React component** as a rendering option for `<Link>` component using `as` attribute.
This allows for greater customization, as seen in the examples below:

**Use HTML tag as a wrapper**
_(current implementation)_
```jsx
import { Link } from '@inertiajs/react'

<Link href="/logout" method="post" as="button" type="button">Logout</Link>

// Renders as... 
<button type="button">Logout</button>
```

**Use a custom component**
```jsx
import { Link } from '@inertiajs/react'
import { MyCustomButton } from "./buttons/my-custom-button";

<Link href="/logout" method="post" as={MyCustomButton} foo="bar">Logout</Link>

// Renders as... 
<MyCustomButton foo="bar">Logout</MyCustomButton>
```

This addresses issue #1082 and improves overall functionality.
Any feedback or suggestions for improvement are welcomed!