### PR TITLE
Make usePage a generic

### DIFF
--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -115,6 +115,6 @@ export const plugin: Plugin = {
   },
 }
 
-export function usePage() {
-  return page.value
+export function usePage<SharedProps>(): Page<SharedProps> {
+  return page.value as Page<SharedProps>
 }


### PR DESCRIPTION
The fix brings a generic to the `usePage` method.

Example usage:

```ts
const props = usePage<{ notification?: string }>().props;

const notification = props.notification;
```