### PR TITLE
Fix CreateInertiaAppProps interface in Vue2 package

### DIFF
--- a/packages/vue2/src/createInertiaApp.ts
+++ b/packages/vue2/src/createInertiaApp.ts
@@ -7,7 +7,7 @@ interface CreateInertiaAppProps {
   resolve: (name: string) => Component | Promise<Component> | { default: Component }
   setup: (props: {
     el: Element
-    app: InertiaApp
+    App: InertiaApp
     props: {
       attrs: { id: string; 'data-page': string }
       props: InertiaProps


### PR DESCRIPTION
Uppercase `App` in `setup` function props in CreateInertiaAppProps interface.