### PR TITLE
Fix props is undefined in extended Inertia's Head

### DIFF
--- a/packages/react/src/Head.ts
+++ b/packages/react/src/Head.ts
@@ -85,7 +85,7 @@ const Head: InertiaHead = function ({ children, title }) {
   }
 
   function renderNodes(nodes) {
-    const computed = (Array.isArray(nodes) ? nodes : [nodes]).filter((node) => node).map((node) => renderNode(node))
+    const computed = React.Children.toArray(nodes).filter((node) => node).map((node) => renderNode(node))
     if (title && !computed.find((tag) => tag.startsWith('<title'))) {
       computed.push(`<title inertia>${title}</title>`)
     }


### PR DESCRIPTION
According to the [documentation ](https://inertiajs.com/title-and-meta#head-extension)you can extend Inertia's Head component.
Here is the example from the docs.
```JavaScript
// AppHead.js
import { Head } from '@inertiajs/react'

const Site = ({ title, children }) => {
  return (
    <Head>
      <title>{title ? `${title} - My App` : 'My App'}</title>
      {children}
    </Head>
  )
}

export default Site
```
And then use that extended component like this:
```JavaScript
import AppHead from './AppHead'

<AppHead title="About">
```
**The problem**
As you can see AppHead can receive children. But if you try to pass more than one child to that extended Head component, you will get an error in the console:  `TypeError: e.props is undefined`

Here is the example of such usage that throws an error

```JavaScript
import AppHead from "./AppHead";

export default function HomePage() {
    return (
        <>
            <AppHead title="Your page title">
                <meta name="description" content="Your page description" />
                <link rel="stylesheet" href="./styles.css" />
            </AppHead>
            <div>Some content here</div>
        </>
    );
}
```
This pull request fixes the problem of multiple children in extended Head component