### PR TITLE
Export `axios` as httpClient for general use

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,5 +6,6 @@ export { default as shouldIntercept } from './shouldIntercept'
 export * from './types'
 export { hrefToUrl, mergeDataIntoQueryString, urlWithoutHash } from './url'
 export { type Router }
+export { default as httpClient } from 'axios'
 
 export const router = new Router()


### PR DESCRIPTION
### This PR
- [x] Exports `axios` from inertia build to users for general use

We found ourselves installing `axios` even though it is a core library used in Inertia so exposing it to users would remove unnecessary installing and users would just import httpClient from Inertia core.
Example: 

```js
import { httpClient } from '@intertiajs/core'

httpClient.get('/api')
```