### PR TITLE
Add children to InertiaHeadProps type

### DIFF
--- a/packages/react/src/Head.ts
+++ b/packages/react/src/Head.ts
@@ -3,6 +3,7 @@ import HeadContext from './HeadContext'
 
 type InertiaHeadProps = {
   title?: string
+  children?: React.ReactNode
 }
 
 type InertiaHead = FunctionComponent<InertiaHeadProps>


### PR DESCRIPTION
PR for Issue #1437 

### The Problem
In React 18, the `React.FC` interface removed the `children` prop. Therefore, as seen in the issue, any use of children in Inertia `Head` component will produce a type error. The use of children in this component is required to set `meta` tags as shown in the official Inertia documentation:

```
import { Head } from '@inertiajs/react'

<Head>
  <title>Your page title</title>
  <meta name="description" content="Your page description" />
</Head>
```

However, this code results in the following error:
`Type '{ children: Element[]; }' has no properties in common with type 'IntrinsicAttributes & InertiaHeadProps'.`

### Replication
1. Install dependencies:[@types/react](https://www.npmjs.com/package/@types/react) and [@types/react-dom](https://www.npmjs.com/package/@types/react-dom)  (credit to @nogenem)
2. View error in Inertia React TypeScript playground

### Fix

This PR explicitly adds the `children` props to the `InertiaHeadProps` type which resolves the type issue when using children to set `title` or  `meta` tags in the `Head` component. 