### PR TITLE
Improve React `usePage` generic type

### DIFF
--- a/packages/react/src/usePage.ts
+++ b/packages/react/src/usePage.ts
@@ -1,8 +1,8 @@
-import { Page } from '@inertiajs/core'
+import { Page, PageProps } from '@inertiajs/core'
 import { useContext } from 'react'
 import PageContext from './PageContext'
 
-export default function usePage<TPage extends Page = Page>(): TPage {
+export default function usePage<TPageProps extends PageProps = PageProps>(): Page<TPageProps> {
   const page = useContext(PageContext)
 
   if (!page) {

--- a/playgrounds/react/resources/js/Components/Layout.tsx
+++ b/playgrounds/react/resources/js/Components/Layout.tsx
@@ -1,7 +1,7 @@
 import { Link, usePage } from '@inertiajs/react'
 
 export default function Layout({ children }) {
-  const { appName } = usePage().props
+  const { appName } = usePage<{ appName: string }>().props
 
   return (
     <>


### PR DESCRIPTION
In #1396, the `usePage` generic type was (re)introduced for the React adapter.

When trying to use this, I've found it to be quite inconvenient because it's expecting us to pass in an entire `Page` type, which has things like the `url`, `component`, etc. with the props being nested under a `props` key.

This PR aims to solve that by changing the generic type to just accept the `PageProps` type.

This would also make the usage consistent with the Vue version.