### PR TITLE
Fix import issue with React `InertiaHeadProps` type

### DIFF
--- a/packages/react/src/Head.ts
+++ b/packages/react/src/Head.ts
@@ -1,10 +1,9 @@
-import React, { FunctionComponent, useContext, useEffect, useMemo } from 'react'
+import React, { FunctionComponent, PropsWithChildren, useContext, useEffect, useMemo } from 'react'
 import HeadContext from './HeadContext'
 
-type InertiaHeadProps = {
+type InertiaHeadProps = PropsWithChildren<{
   title?: string
-  children?: React.ReactNode
-}
+}>
 
 type InertiaHead = FunctionComponent<InertiaHeadProps>
 


### PR DESCRIPTION
In #1448, the `InertiaHeadProps` type was updated to include React's `children` prop.

While the adapters built fine, this caused an issue when building the React playground:

```
../../packages/react/types/Head.d.ts:1:8 - error TS1259: Module '"/home/jess/Code/inertiajs/inertia/node_modules/@types/react/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag

1 import React, { FunctionComponent } from 'react';
         ~~~~~
```

Although #1448 didn't change the import of `React` in `Head.ts`, the change did result in the generated types for that file now also needing to import `React` when it previously didn't.

Rather than use the `allowSyntheticDefaultImports` flag, I've changed the `InertiaHeadProps` type to not depend on the `React` import directly. Also, rather than manually typing the `children` prop, I've used React's [`PropsWithChildren`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d076add9f29db350a19bd94c37b197729cc02f87/types/react/index.d.ts#L822) type which has the same end result.