### PR TITLE
Add `preserveUrl` option.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3841,7 +3841,7 @@
       "requires": {
         "@inertiajs/react": "^1.0.0-beta.2",
         "@types/react": "^16.14.35",
-        "@types/react-dom": "^16.9.17",
+        "@types/react-dom": "^16.9.18",
         "@vitejs/plugin-react": "^3.0.0",
         "autoprefixer": "^10.4.13",
         "axios": "^1.1.2",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,6 +61,7 @@ export type Progress = AxiosProgressEvent
 
 export type LocationVisit = {
   preserveScroll: boolean
+  preserveUrl: boolean
 }
 
 export type Visit = {
@@ -69,6 +70,7 @@ export type Visit = {
   replace: boolean
   preserveScroll: PreserveStateOption
   preserveState: PreserveStateOption
+  preserveUrl: PreserveStateOption
   only: Array<string>
   headers: Record<string, string>
   errorBag: string | null

--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -20,6 +20,7 @@ interface BaseInertiaLinkProps {
   onClick?: (event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>) => void
   preserveScroll?: PreserveStateOption
   preserveState?: PreserveStateOption
+  preserveUrl?: PreserveStateOption
   replace?: boolean
   only?: string[]
   onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
@@ -49,6 +50,7 @@ const Link: InertiaLink = forwardRef<unknown, InertiaLinkProps>(
       method = 'get',
       preserveScroll = false,
       preserveState = null,
+      preserveUrl = false,
       replace = false,
       only = [],
       headers = {},
@@ -78,6 +80,7 @@ const Link: InertiaLink = forwardRef<unknown, InertiaLinkProps>(
             method,
             preserveScroll,
             preserveState: preserveState ?? method !== 'get',
+            preserveUrl,
             replace,
             only,
             headers,
@@ -98,6 +101,7 @@ const Link: InertiaLink = forwardRef<unknown, InertiaLinkProps>(
         method,
         preserveScroll,
         preserveState,
+        preserveUrl,
         replace,
         only,
         headers,

--- a/packages/svelte/src/Link.svelte
+++ b/packages/svelte/src/Link.svelte
@@ -9,6 +9,7 @@
   export let replace = false
   export let preserveScroll = false
   export let preserveState = null
+  export let preserveUrl = false
   export let only = []
   export let headers = {}
   export let queryStringArrayFormat = 'brackets'
@@ -31,6 +32,7 @@
     replace,
     preserveScroll,
     preserveState: preserveState ?? method !== 'get',
+    preserveUrl,
     only,
     headers,
     queryStringArrayFormat,

--- a/packages/vue2/src/link.ts
+++ b/packages/vue2/src/link.ts
@@ -18,6 +18,7 @@ export interface InertiaLinkProps {
   onClick?: (event: MouseEvent | KeyboardEvent) => void
   preserveScroll?: PreserveStateOption
   preserveState?: PreserveStateOption
+  preserveUrl?: PreserveStateOption
   replace?: boolean
   only?: string[]
   onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
@@ -61,6 +62,10 @@ const Link: InertiaLink = {
     preserveState: {
       type: Boolean,
       default: null,
+    },
+    preserveUrl: {
+      type: Boolean,
+      default: false,
     },
     only: {
       type: Array,
@@ -126,6 +131,7 @@ const Link: InertiaLink = {
                 replace: props.replace,
                 preserveScroll: props.preserveScroll,
                 preserveState: props.preserveState ?? method !== 'get',
+                preserveUrl: props.preserveUrl,
                 only: props.only,
                 headers: props.headers,
                 // @ts-expect-error

--- a/packages/vue2/tests/app/Pages/Visits/PreserveUrl.vue
+++ b/packages/vue2/tests/app/Pages/Visits/PreserveUrl.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <span @click="preserve" class="preserve">Preserve Url</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    preserve() {
+      this.$inertia.get('/visits/preserve-url?page=2', {}, {
+        preserveUrl: true,
+      })
+    },
+  }
+}
+</script>

--- a/packages/vue2/tests/app/server.js
+++ b/packages/vue2/tests/app/server.js
@@ -97,6 +97,9 @@ app.get('/visits/headers/version', (req, res) =>
   inertia.render(req, res, { component: 'Visits/Headers', version: 'example-version-header' }),
 )
 
+app.all('/visits/preserve-url', (req, res) =>
+  inertia.render(req, res, { component: 'Visits/PreserveUrl' }))
+
 app.post('/remember/form-helper/default', (req, res) =>
   inertia.render(req, res, {
     component: 'Remember/FormHelper/Default',

--- a/packages/vue2/tests/cypress/integration/manual-visits.test.js
+++ b/packages/vue2/tests/cypress/integration/manual-visits.test.js
@@ -1209,6 +1209,15 @@ describe('Manual Visits', () => {
     })
   })
 
+  describe('Preserve url', () => {
+    it('does preserves the url if the perserveUrl flag is passed', () => {
+      cy.visit('/visits/preserve-url')
+
+      cy.get('.preserve').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-url')
+    });
+  })
+
   describe('URL fragment navigation (& automatic scrolling)', () => {
     /** @see https://github.com/inertiajs/inertia/pull/257 */
 

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -10,6 +10,7 @@ export interface InertiaLinkProps {
   onClick?: (event: MouseEvent | KeyboardEvent) => void
   preserveScroll?: boolean | ((props: PageProps) => boolean)
   preserveState?: boolean | ((props: PageProps) => boolean) | null
+  preserveUrl?: boolean | ((props: PageProps) => boolean)
   replace?: boolean
   only?: string[]
   onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
@@ -55,6 +56,10 @@ const Link: InertiaLink = defineComponent({
       type: Boolean,
       default: null,
     },
+    preserveUrl: {
+      type: Boolean,
+      default: false,
+    },
     only: {
       type: Array<string>,
       default: () => [],
@@ -95,6 +100,7 @@ const Link: InertiaLink = defineComponent({
                 replace: props.replace,
                 preserveScroll: props.preserveScroll,
                 preserveState: props.preserveState ?? method !== 'get',
+                preserveUrl: props.preserveUrl,
                 only: props.only,
                 headers: props.headers,
                 // @ts-expect-error


### PR DESCRIPTION
This PR adds an option to preserve the current url. 

This is specially useful when there is an **infinite scroll pagination**.

## Before

To the infinite scrolls using Inertia we had to do something similar to this:

```js
const allPosts = ref(props.posts.data);
const nextPageUrl = ref(props.posts.next_page_url || null);
const loading = ref(false);

const load = () => {
    if (nextPageUrl.value === null) {
        return;
    }

    loading.value = true;
    axios.get(nextPageUrl.value, {
        headers: {
            'X-Inertia': true,
            'X-Inertia-Partial-Component': 'Posts/Index',
            'X-Inertia-Partial-Data': 'posts',
            'X-Requested-With': 'XMLHttpRequest',
            'X-Inertia-Version': usePage().version,
        },
    }).then(({ data }) => {
        nextPageUrl.value = data.props.posts.next_page_url;
        allPosts.value.push(...data.props.posts.data);
        loading.value = false;
    }).catch(() => {
        loading.value = false;
        router.get(nextPageUrl.value);
    })
}

let observer;

onMounted(() => {
    observer = new IntersectionObserver(
        entries => entries.forEach(entry => entry.isIntersecting && load()),
    );

    observer.observe(document.querySelector('footer'));
});
```

## After

This this addiction, we can take advantage of the `preserveUrl` option, and pass it on the `router.get` method, like this:

```js
const allPosts = ref(props.posts.data);

const load = () => {
    if (props.posts.next_page_url === null) {
        return;
    }

    router.get(props.posts.next_page_url, {}, {
        preserveState: true,
        preserveScroll: true,
        preserveUrl: true,
        only: ['posts'],
        onSuccess: () => allPosts.value.push(...props.posts.data)
    })
}

onMounted(() => {
    observer = new IntersectionObserver(
        entries => entries.forEach(entry => entry.isIntersecting && load()),
    );

    observer.observe(document.querySelector('footer'));
});
```

Without the `preserveUrl` it adds the `?page=2` to the url and if the user refreshes the page it will just show the `page=2` content instead of both pages.

Let me know what you guys think about this feature.

Thanks,
Francisco.