### PR TITLE
Fix `usePage()` reactivity in Vue 3 adapter

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,8 +37,9 @@ export interface Page<SharedProps extends PageProps = PageProps> {
   url: string
   version: string | null
 
-  // Refactor away
+  /** @internal */
   scrollRegions: Array<{ top: number; left: number }>
+  /** @internal */
   rememberedState: Record<string, unknown>
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,7 +40,6 @@ export interface Page<SharedProps extends PageProps = PageProps> {
   // Refactor away
   scrollRegions: Array<{ top: number; left: number }>
   rememberedState: Record<string, unknown>
-  resolvedErrors: Errors
 }
 
 export type PageResolver = (name: string) => Component

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "preserveConstEnums": true,
-    "removeComments": true,
+    "removeComments": false,
     "typeRoots": ["./node_modules/@types"],
     "strict": true
   }

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -1,5 +1,16 @@
 import { createHeadManager, Page, PageProps, router } from '@inertiajs/core'
-import { computed, DefineComponent, defineComponent, h, markRaw, Plugin, PropType, reactive, ref, shallowRef } from 'vue'
+import {
+  computed,
+  DefineComponent,
+  defineComponent,
+  h,
+  markRaw,
+  Plugin,
+  PropType,
+  reactive,
+  ref,
+  shallowRef,
+} from 'vue'
 import remember from './remember'
 import { VuePageHandlerArgs } from './types'
 import useForm from './useForm'

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -1,5 +1,5 @@
 import { createHeadManager, Page, PageProps, router } from '@inertiajs/core'
-import { DefineComponent, defineComponent, h, markRaw, Plugin, PropType, ref, shallowRef } from 'vue'
+import { DefineComponent, defineComponent, h, markRaw, Plugin, PropType, reactive, ref, shallowRef } from 'vue'
 import remember from './remember'
 import { VuePageHandlerArgs } from './types'
 import useForm from './useForm'
@@ -15,7 +15,7 @@ export interface InertiaAppProps {
 export type InertiaApp = DefineComponent<InertiaAppProps>
 
 const component = ref(null)
-const page = ref<Page<any>>(null)
+const page = reactive({} as Page<any>)
 const layout = shallowRef(null)
 const key = ref(null)
 let headManager = null
@@ -48,7 +48,7 @@ const App: InertiaApp = defineComponent({
   },
   setup({ initialPage, initialComponent, resolveComponent, titleCallback, onHeadUpdate }) {
     component.value = initialComponent ? markRaw(initialComponent) : null
-    page.value = initialPage
+    Object.assign(page, initialPage)
     key.value = null
 
     const isServer = typeof window === 'undefined'
@@ -60,7 +60,7 @@ const App: InertiaApp = defineComponent({
         resolveComponent,
         swapComponent: async (args: VuePageHandlerArgs) => {
           component.value = markRaw(args.component)
-          page.value = args.page
+          Object.assign(page, args.page)
           key.value = args.preserveState ? key.value : Date.now()
         },
       })
@@ -73,7 +73,7 @@ const App: InertiaApp = defineComponent({
         component.value.inheritAttrs = !!component.value.inheritAttrs
 
         const child = h(component.value, {
-          ...page.value.props,
+          ...page.props,
           key: key.value,
         })
 
@@ -92,7 +92,7 @@ const App: InertiaApp = defineComponent({
             .reverse()
             .reduce((child, layout) => {
               layout.inheritAttrs = !!layout.inheritAttrs
-              return h(layout, { ...page.value.props }, () => child)
+              return h(layout, { ...page.props }, () => child)
             })
         }
 
@@ -108,7 +108,7 @@ export const plugin: Plugin = {
     router.form = useForm
 
     Object.defineProperty(app.config.globalProperties, '$inertia', { get: () => router })
-    Object.defineProperty(app.config.globalProperties, '$page', { get: () => page.value })
+    Object.defineProperty(app.config.globalProperties, '$page', { get: () => page })
     Object.defineProperty(app.config.globalProperties, '$headManager', { get: () => headManager })
 
     app.mixin(remember)
@@ -116,5 +116,5 @@ export const plugin: Plugin = {
 }
 
 export function usePage<SharedProps extends PageProps>(): Page<SharedProps> {
-  return page.value
+  return page
 }

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -134,6 +134,5 @@ export function usePage<SharedProps extends PageProps>(): Page<SharedProps> {
     version: computed(() => page.value.version),
     scrollRegions: computed(() => page.value.scrollRegions),
     rememberedState: computed(() => page.value.rememberedState),
-    resolvedErrors: computed(() => page.value.resolvedErrors),
   })
 }

--- a/playgrounds/vue3/resources/js/Components/Layout.vue
+++ b/playgrounds/vue3/resources/js/Components/Layout.vue
@@ -2,7 +2,9 @@
 import { Link, usePage } from '@inertiajs/vue3'
 import { computed } from 'vue'
 
-const appName = computed(() => usePage<{ appName: string }>().props.appName)
+const page = usePage()
+
+const appName = computed(() => page.props.appName)
 </script>
 
 <template>


### PR DESCRIPTION
Hi,
Thanks for your great work on this package.

## Why
This PR fixes the lack of reactivity of `usePage` function return in Vue3 adapter.

Indeed, by returning `page.value`, we're losing the link with the page ref. 
When the page value is fully replaced, the props don't change in the component.

You can find a full simplified example [here](https://codesandbox.io/p/sandbox/nameless-http-78bf43?selection=%5B%7B%22endColumn%22%3A12%2C%22endLineNumber%22%3A16%2C%22startColumn%22%3A12%2C%22startLineNumber%22%3A16%7D%5D&file=%2Fsrc%2Fcomponents%2FNew.vue) with a comparison before/after.

References: 
- Discussion https://github.com/inertiajs/inertia/pull/1373#issuecomment-1400488273,
- Fix #1432
- [Another demo of the issue](https://stackblitz.com/edit/vue-n9k9av?file=src/App.vue)

## How
- Transform the page object to a reactive
- Set each other page key independently (with `Object.assign`)
- Return the reactive object

Ideally (cf [vue docs](https://vuejs.org/guide/reusability/composables.html#conventions-and-best-practices)), it would have been better to return refs, as it was previously (the [previous behaviour](https://github.com/inertiajs/inertia/blob/41b3c76337bce4ea1a02354af95ab39feec74ac1/packages/vue3/src/app.ts#L136-L139) was the recommended one, unfortunately).
However making this would involve a breaking change. To destructure people can use `toRefs(page)` (see [demo](https://codesandbox.io/p/sandbox/nameless-http-78bf43?selection=%5B%7B%22endColumn%22%3A31%2C%22endLineNumber%22%3A15%2C%22startColumn%22%3A31%2C%22startLineNumber%22%3A15%7D%5D&file=%2Fsrc%2Fcomponents%2FNew.vue))

## Result

```js
const page = usePage()

const { props, component } = toRefs(page)

const posts = computed(() => page.props.posts)
const user = computed(() => props.value.user)
```

