### PR TITLE
fix: Stores transform method in useRef

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -58,7 +58,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
   const [progress, setProgress] = useState(null)
   const [wasSuccessful, setWasSuccessful] = useState(false)
   const [recentlySuccessful, setRecentlySuccessful] = useState(false)
-  let transform = (data) => data
+  const transformRef = useRef<(data: TForm) => Record<string, any>>(data => data)
 
   useEffect(() => {
     isMounted.current = true
@@ -157,9 +157,9 @@ export default function useForm<TForm extends Record<string, unknown>>(
       }
 
       if (method === 'delete') {
-        router.delete(url, { ..._options, data: transform(data) })
+        router.delete(url, { ..._options, data: transformRef.current(data) })
       } else {
-        router[method](url, transform(data), _options)
+        router[method](url, transformRef.current(data), _options)
       }
     },
     [data, setErrors],
@@ -184,7 +184,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
     wasSuccessful,
     recentlySuccessful,
     transform(callback) {
-      transform = callback
+      transformRef.current = callback
     },
     setDefaults(fieldOrFields?: keyof TForm | Record<keyof TForm, string>, maybeValue?: string) {
       if (typeof fieldOrFields === 'undefined') {


### PR DESCRIPTION
I'm resubmitting these changes in a new PR since the original, which was submitted nearly a year ago, now has conflicts due to the typescript rewrite. This is a duplicate of  #1171 in response to #1131.

Please, please, please, let's get this fixed. `useForm` is just simply broken without the ability to reliably transform data before submitting.