### PR TITLE
Change PageProps values from 'unknown' to 'any'.

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,7 +25,7 @@ export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete'
 export type RequestPayload = Record<string, FormDataConvertible> | FormData
 
 export interface PageProps {
-  [key: string]: unknown
+  [key: string]: any
 }
 
 export interface Page<SharedProps extends PageProps = PageProps> {


### PR DESCRIPTION
As it is not currently possible to extend and override the PageProps interface with our own implementation, unless you explicitly write the keys for items you expect in your page props, i.e.
```ts
export interface PageProps {
  user: any
  profile: any
  someOtherKey: any
  jetstream: any
}
```
then using TypeScript in Laravel Jetstream projects (which use Inertia and Vue) can be a real hassle, as your code is polluted with "variable ... is of type unknown".

By setting PageProps values to `[key: string]: any`, this can allow for an easier incremental adoption of TypeScript in projects using Inertia.