### PR TITLE
fix: double location visit bug on hard redirect

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -167,9 +167,6 @@ export class Router {
       const locationVisit: LocationVisit = { preserveScroll }
       window.sessionStorage.setItem('inertiaLocationVisit', JSON.stringify(locationVisit))
       window.location.href = url.href
-      if (urlWithoutHash(window.location).href === urlWithoutHash(url).href) {
-        window.location.reload()
-      }
     } catch (error) {
       return false
     }


### PR DESCRIPTION
### TL;DR

Form state lost when response redirect to the same location. (in case of 409)

### Detail

This PR fixes a bug when redirecting 303 to the same location and frontend version is outdated, Inertial will trigger two instead of one backend visits. One of the visit will be auto cancelled by browser, however the request will typically have been sent to backend and that will typically waste the re-flashed flash data and the `preserveState` data, causing form state to be lost.

The core of the problem is that we did something like this in the code: 
```
window.location.href = url
if (...) {
  window.location.reload()
}
```

If the condition matches, this code snippet will trigger two page loads and the first page load will be cancelled by browser. I believe the conditional reload logic [was initially introduced to fix a bug](https://github.com/inertiajs/inertia/commit/9a3b3bc6ae1d8f145f0a111528320448df5bfeab). However, I failed to re-produce the old bug no matter how I try. `window.location.href = url` will always trigger page load unless the url is `#`. Therefore I figure we can revert the old bug fix, which happens to cause a new bug.