### PR TITLE
Fix form helper types for `setDefaults()` method (React) and `defaults()` method (Vue)

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -19,8 +19,8 @@ export interface InertiaFormProps<TForm extends Record<string, unknown>> {
   setData: setDataByObject<TForm> & setDataByMethod<TForm> & setDataByKeyValuePair<TForm>
   transform: (callback: (data: TForm) => TForm) => void
   setDefaults(): void
-  setDefaults(field: keyof TForm, value: string): void
-  setDefaults(fields: Record<keyof TForm, string>): void
+  setDefaults(field: keyof TForm, value: typeof TForm): void
+  setDefaults(fields: TForm): void
   reset: (...fields: (keyof TForm)[]) => void
   clearErrors: (...fields: (keyof TForm)[]) => void
   setError(field: keyof TForm, value: string): void

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -1,4 +1,4 @@
-import { Method, Progress, router, VisitOptions } from '@inertiajs/core'
+import { FormDataConvertible, Method, Progress, router, VisitOptions } from '@inertiajs/core'
 import isEqual from 'lodash.isequal'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import useRemember from './useRemember'
@@ -19,8 +19,8 @@ export interface InertiaFormProps<TForm extends Record<string, unknown>> {
   setData: setDataByObject<TForm> & setDataByMethod<TForm> & setDataByKeyValuePair<TForm>
   transform: (callback: (data: TForm) => TForm) => void
   setDefaults(): void
-  setDefaults(field: keyof TForm, value: typeof TForm): void
-  setDefaults(fields: TForm): void
+  setDefaults(field: keyof TForm, value: FormDataConvertible): void
+  setDefaults(fields: Partial<TForm>): void
   reset: (...fields: (keyof TForm)[]) => void
   clearErrors: (...fields: (keyof TForm)[]) => void
   setError(field: keyof TForm, value: string): void
@@ -186,7 +186,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
     transform(callback) {
       transform = callback
     },
-    setDefaults(fieldOrFields?: keyof TForm | Record<keyof TForm, string>, maybeValue?: string) {
+    setDefaults(fieldOrFields?: keyof TForm | Partial<TForm>, maybeValue?: FormDataConvertible) {
       if (typeof fieldOrFields === 'undefined') {
         setDefaults(() => data)
       } else {

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -1,4 +1,4 @@
-import { Method, Progress, router, VisitOptions } from '@inertiajs/core'
+import { FormDataConvertible, Method, Progress, router, VisitOptions } from '@inertiajs/core'
 import cloneDeep from 'lodash.clonedeep'
 import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
@@ -14,8 +14,8 @@ interface InertiaFormProps<TForm> {
   data(): TForm
   transform(callback: (data: TForm) => object): this
   defaults(): this
-  defaults(field: keyof TForm, value: typeof TForm): this
-  defaults(fields: TForm): this
+  defaults(field: keyof TForm, value: FormDataConvertible): this
+  defaults(fields: Partial<TForm>): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -14,8 +14,8 @@ interface InertiaFormProps<TForm> {
   data(): TForm
   transform(callback: (data: TForm) => object): this
   defaults(): this
-  defaults(field: keyof TForm, value: string): this
-  defaults(fields: Record<keyof TForm, string>): this
+  defaults(field: keyof TForm, value: typeof TForm): this
+  defaults(fields: TForm): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -3,7 +3,7 @@ import cloneDeep from 'lodash.clonedeep'
 import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
 
-export interface InertiaFormProps<TForm extends Record<string, unknown>> {
+interface InertiaFormProps<TForm extends Record<string, unknown>> {
   isDirty: boolean
   errors: Partial<Record<keyof TForm, string>>
   hasErrors: boolean

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -3,7 +3,7 @@ import cloneDeep from 'lodash.clonedeep'
 import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
 
-interface InertiaFormProps<TForm extends Record<string, unknown>> {
+export interface InertiaFormProps<TForm extends Record<string, unknown>> {
   isDirty: boolean
   errors: Partial<Record<keyof TForm, string>>
   hasErrors: boolean
@@ -14,8 +14,8 @@ interface InertiaFormProps<TForm extends Record<string, unknown>> {
   data(): TForm
   transform(callback: (data: TForm) => object): this
   defaults(): this
-  defaults(field: keyof TForm, value: string): this
-  defaults(fields: Record<keyof TForm, string>): this
+  defaults(field: keyof TForm, value: typeof TForm): this
+  defaults(fields: TForm>): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -1,4 +1,4 @@
-import { Method, Progress, router, VisitOptions } from '@inertiajs/core'
+import { FormDataConvertible, Method, Progress, router, VisitOptions } from '@inertiajs/core'
 import cloneDeep from 'lodash.clonedeep'
 import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
@@ -14,8 +14,8 @@ export interface InertiaFormProps<TForm extends Record<string, unknown>> {
   data(): TForm
   transform(callback: (data: TForm) => object): this
   defaults(): this
-  defaults(field: keyof TForm, value: typeof TForm): this
-  defaults(fields: TForm): this
+  defaults(field: keyof TForm, value: FormDataConvertible): this
+  defaults(fields: Partial<TForm>): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
@@ -70,7 +70,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
 
       return this
     },
-    defaults(fieldOrFields?: keyof TForm | Record<keyof TForm, string>, maybeValue?: string) {
+    defaults(fieldOrFields?: keyof TForm | Partial<TForm>, maybeValue?: FormDataConvertible) {
       if (typeof data === 'function') {
         throw new Error('You cannot call `defaults()` when using a function to define your form data.')
       }

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -15,7 +15,7 @@ export interface InertiaFormProps<TForm extends Record<string, unknown>> {
   transform(callback: (data: TForm) => object): this
   defaults(): this
   defaults(field: keyof TForm, value: typeof TForm): this
-  defaults(fields: TForm>): this
+  defaults(fields: TForm): this
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this


### PR DESCRIPTION
Allows types than strings, based on the type passed in by the implementer.
fixes #1502 

Successfully tested locally in my project.