### PR TITLE
Update link to use props to retrieve event callbacks not attrs

### DIFF
--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -14,6 +14,7 @@ export interface InertiaLinkProps {
   only?: string[]
   onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
   onBefore?: () => void
+  onError?: () => void
   onStart?: () => void
   onProgress?: (progress: Progress) => void
   onFinish?: () => void
@@ -63,6 +64,30 @@ const Link: InertiaLink = defineComponent({
       type: Object,
       default: () => ({}),
     },
+    onCancelToken: {
+      default: () => (() => {}),
+    },
+    onBefore: {
+      default: () => (() => {}),
+    },
+    onError: {
+      default: () => (() => {}),
+    },
+    onStart: {
+      default: () => (() => {}),
+    },
+    onProgress: {
+      default: () => (() => {}),
+    },
+    onFinish: {
+      default: () => (() => {}),
+    },
+    onCancel: {
+      default: () => (() => {}),
+    },
+    onSuccess: {
+      default: () => (() => {}),
+    },
     queryStringArrayFormat: {
       type: String as PropType<'brackets' | 'indices'>,
       default: 'brackets',
@@ -97,22 +122,14 @@ const Link: InertiaLink = defineComponent({
                 preserveState: props.preserveState ?? method !== 'get',
                 only: props.only,
                 headers: props.headers,
-                // @ts-expect-error
-                onCancelToken: attrs.onCancelToken || (() => ({})),
-                // @ts-expect-error
-                onBefore: attrs.onBefore || (() => ({})),
-                // @ts-expect-error
-                onStart: attrs.onStart || (() => ({})),
-                // @ts-expect-error
-                onProgress: attrs.onProgress || (() => ({})),
-                // @ts-expect-error
-                onFinish: attrs.onFinish || (() => ({})),
-                // @ts-expect-error
-                onCancel: attrs.onCancel || (() => ({})),
-                // @ts-expect-error
-                onSuccess: attrs.onSuccess || (() => ({})),
-                // @ts-expect-error
-                onError: attrs.onError || (() => ({})),
+                onCancelToken: props.onCancelToken,
+                onBefore: props.onBefore,
+                onStart: props.onStart,
+                onProgress: props.onProgress,
+                onFinish: props.onFinish,
+                onCancel: props.onCancel,
+                onSuccess: props.onSuccess,
+                onError: props.onError,
               })
             }
           },


### PR DESCRIPTION
When using Vue Attrs over the component props we lose the capability to define the prop as camelcase or kebab-case. In most cases, this is fine. If you are using Eslint, one of the rules from the vuejs core team that is recommended/strongly-recommended is using [kebab-case for component props in the template](https://eslint.vuejs.org/rules/attribute-hyphenation.html). By using the attrs to retrieve this data the end user cannot conform to eslint rules defined in their project. The following PR updates this functionality to use the props to retrieve the callbacks. The defaults for the props have been updated to match the intended definitions specified in the router class. This update removes the need to use the `// @ts-expect-error` comments in the render function. 