### PR TITLE
Change Vue3 Head fragment detection method

### DIFF
--- a/packages/vue3/src/head.ts
+++ b/packages/vue3/src/head.ts
@@ -87,7 +87,7 @@ const Head: InertiaHead = defineComponent({
     renderNodes(nodes) {
       return this.addTitleElement(
         nodes
-          .flatMap((node) => (node.type.toString() === 'Symbol(Fragment)' ? node.children : node))
+          .flatMap((node) => (node.type.toString().startsWith('Symbol') ? node.children : node))
           .map((node) => this.renderTag(node))
           .filter((node) => node),
       )


### PR DESCRIPTION
In development builds, a `v-for` array is received by the `renderNodes` function as type "Symbol(Fragment)" which is correctly detected. However, in production builds, this same array is received as "Symbol()". This results in the `v-for` array of Head elements being discarded.