### PR TITLE
Add `displayName` to `Link` component in React adapter

### DIFF
--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -137,5 +137,6 @@ const Link: InertiaLink = forwardRef<unknown, InertiaLinkProps>(
     )
   },
 )
+Link.displayName = 'InertiaLink'
 
 export default Link


### PR DESCRIPTION
Right now the Inertia Link component doesn't have a displayName set, this doesn't cause any functional issues, but the displayName is often used by devtools to help make things a bit nicer.

The most recent example I've found of this causing issues is in Storybook - 
https://github.com/storybookjs/storybook/issues/20920#issuecomment-1499679321

If I use e.g. the Inertia Link component then it's showing as `<[Object object] href="/">This is a link</[Object object]>`.
While it could be argued that this is a storybook issue, other devtools also use displayName so it's an easy win for Inertia with no downsides.

We merged #351 for similar reasons.