### PR TITLE
Add initialization callback to form helper in Vue adapters

### DIFF
--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -40,7 +40,7 @@ export default function useForm<TForm>(data: TForm | (() => TForm)): InertiaForm
 export default function useForm<TForm>(rememberKey: string, data: TForm | (() => TForm)): InertiaForm<TForm>
 export default function useForm<TForm>(...args): InertiaForm<TForm> {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
-  const data = (typeof args[0] !== 'string' ? args[0] : args[1]) || {}
+  const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const restored = rememberKey ? (router.restore(rememberKey) as { data: any; errors: any }) : null
   let defaults = typeof data === 'object' ? cloneDeep(data) : cloneDeep(data())
   let cancelToken = null

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -61,6 +61,8 @@ export default function useForm<TForm>(...args): InertiaForm<TForm> {
       Object.keys(this.data()).forEach((key) => delete this[key])
       defaults = cloneDeep(data)
       Object.keys(data).forEach((key) => Vue.set(this, key, data[key]))
+
+      return this
     },
     data() {
       return Object.keys(defaults).reduce((carry, key) => {

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -11,6 +11,7 @@ interface InertiaFormProps<TForm> {
   progress: Progress | null
   wasSuccessful: boolean
   recentlySuccessful: boolean
+  init(data: TForm): this
   data(): TForm
   transform(callback: (data: TForm) => object): this
   defaults(): this
@@ -56,8 +57,13 @@ export default function useForm<TForm>(...args): InertiaForm<TForm> {
     progress: null,
     wasSuccessful: false,
     recentlySuccessful: false,
+    init(data) {
+      Object.keys(this.data()).forEach((key) => delete this[key])
+      defaults = cloneDeep(data)
+      Object.keys(data).forEach((key) => Vue.set(this, key, data[key]))
+    },
     data() {
-      return Object.keys(data).reduce((carry, key) => {
+      return Object.keys(defaults).reduce((carry, key) => {
         carry[key] = this[key]
         return carry
       }, {})

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -41,7 +41,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
   maybeData?: TForm | (() => TForm),
 ): InertiaForm<TForm> {
   const rememberKey = typeof rememberKeyOrData === 'string' ? rememberKeyOrData : null
-  const data = typeof rememberKeyOrData !== 'string' ? rememberKeyOrData : maybeData
+  const data = typeof rememberKeyOrData === 'string' ? maybeData : rememberKeyOrData
   const restored = rememberKey
     ? (router.restore(rememberKey) as { data: TForm; errors: Record<keyof TForm, string> })
     : null

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -11,6 +11,7 @@ interface InertiaFormProps<TForm extends Record<string, unknown>> {
   progress: Progress | null
   wasSuccessful: boolean
   recentlySuccessful: boolean
+  init(data: TForm): this
   data(): TForm
   transform(callback: (data: TForm) => object): this
   defaults(): this
@@ -41,7 +42,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
   maybeData?: TForm,
 ): InertiaForm<TForm> {
   const rememberKey = typeof rememberKeyOrData === 'string' ? rememberKeyOrData : null
-  const data = typeof rememberKeyOrData === 'object' ? rememberKeyOrData : maybeData
+  const data = typeof rememberKeyOrData === 'object' ? rememberKeyOrData : maybeData || {}
   const restored = rememberKey
     ? (router.restore(rememberKey) as { data: TForm; errors: Record<keyof TForm, string> })
     : null
@@ -59,8 +60,13 @@ export default function useForm<TForm extends Record<string, unknown>>(
     progress: null,
     wasSuccessful: false,
     recentlySuccessful: false,
+    init(data) {
+      Object.keys(this.data()).forEach((key) => delete this[key])
+      defaults = cloneDeep(data)
+      Object.keys(data).forEach((key) => (this[key] = data[key]))
+    },
     data() {
-      return (Object.keys(data) as Array<keyof TForm>).reduce((carry, key) => {
+      return (Object.keys(defaults) as Array<keyof TForm>).reduce((carry, key) => {
         // @ts-expect-error
         carry[key] = this[key]
         return carry

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -32,17 +32,17 @@ interface InertiaFormProps<TForm extends Record<string, unknown>> {
 
 export type InertiaForm<TForm extends Record<string, unknown>> = TForm & InertiaFormProps<TForm>
 
-export default function useForm<TForm extends Record<string, unknown>>(data: TForm): InertiaForm<TForm>
+export default function useForm<TForm extends Record<string, unknown>>(data?: TForm): InertiaForm<TForm>
 export default function useForm<TForm extends Record<string, unknown>>(
   rememberKey: string,
   data: TForm,
 ): InertiaForm<TForm>
 export default function useForm<TForm extends Record<string, unknown>>(
-  rememberKeyOrData: string | TForm,
+  rememberKeyOrData?: string | TForm,
   maybeData?: TForm,
 ): InertiaForm<TForm> {
   const rememberKey = typeof rememberKeyOrData === 'string' ? rememberKeyOrData : null
-  const data = typeof rememberKeyOrData === 'object' ? rememberKeyOrData : maybeData || {}
+  const data = (typeof rememberKeyOrData === 'object' ? rememberKeyOrData : maybeData) || ({} as TForm)
   const restored = rememberKey
     ? (router.restore(rememberKey) as { data: TForm; errors: Record<keyof TForm, string> })
     : null

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -64,6 +64,8 @@ export default function useForm<TForm extends Record<string, unknown>>(
       Object.keys(this.data()).forEach((key) => delete this[key])
       defaults = cloneDeep(data)
       Object.keys(data).forEach((key) => (this[key] = data[key]))
+
+      return this
     },
     data() {
       return (Object.keys(defaults) as Array<keyof TForm>).reduce((carry, key) => {


### PR DESCRIPTION
Right now there is no easy way to reinitialize a form using the form helper without providing all the data a second time. This creates unnecessary boilerplate in situations where a simple `form.reset()` isn't enough because you want to update the values based on props that may have changed. For example:

**Before (option 1):**

```js
// MyDialog.vue

const props = defineProps({
  company_id: Number,
})

const open = ref(false)
const form = useForm({
  first_name: '',
  last_name: '',
  email: '',
  role: 'User',
  company_id: props.company_id,
})

function open() {
  form.first_name = ''
  form.last_name = ''
  form.email = ''
  form.role = 'User'
  form.company_id = props.company_id
  open.value = true
}
```

**Before (option 2):**

```js
// MyDialog.vue

const props = defineProps({
  company_id: Number,
})

const open = ref(false)
const form = useForm(getFormData())

function getFormData() {
   return {
    first_name: '',
    last_name: '',
    email: '',
    role: 'User',
    company_id: props.company_id,
  }
}

function open() {
  Object.assign(form, getFormData())
  open.value = true
}
```

This PR solves this problem by adding an new optional initialization callback to the form helper. This function is automatically called when resetting the form, ensuring that the latest component state (props) is used.

```js
// MyDialog.vue

const props = defineProps({
  company_id: Number,
})

const open = ref(false)

const form = useForm(() => ({
  first_name: '',
  last_name: '',
  email: '',
  role: 'User',
  company_id: props.company_id,
}))

function open() {
  form.reset()
  open.value = true
}
```