### PR TITLE
Fix `usePage()` reactivity in Vue 2 adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3229,10 +3229,10 @@
       "devDependencies": {
         "esbuild": "^0.16.13",
         "typescript": "^4.9.4",
-        "vue": "^2.6.0"
+        "vue": "^2.7.0"
       },
       "peerDependencies": {
-        "vue": "^2.6.0"
+        "vue": "^2.7.0"
       }
     },
     "packages/vue3": {
@@ -3886,7 +3886,7 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.isequal": "^4.5.0",
         "typescript": "^4.9.4",
-        "vue": "^2.6.0"
+        "vue": "^2.7.0"
       }
     },
     "@inertiajs/vue2-playground": {

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -52,10 +52,10 @@
   "devDependencies": {
     "esbuild": "^0.16.13",
     "typescript": "^4.9.4",
-    "vue": "^2.6.0"
+    "vue": "^2.7.0"
   },
   "peerDependencies": {
-    "vue": "^2.6.0"
+    "vue": "^2.7.0"
   },
   "dependencies": {
     "@inertiajs/core": "1.0.4",

--- a/packages/vue2/src/app.ts
+++ b/packages/vue2/src/app.ts
@@ -1,5 +1,5 @@
 import { createHeadManager, Page, router } from '@inertiajs/core'
-import { Component, PluginObject } from 'vue'
+import { Component, computed, PluginObject, reactive } from 'vue'
 import { ComponentOptions } from 'vue/types/umd'
 import remember from './remember'
 import { VuePageHandlerArgs } from './types'
@@ -124,5 +124,10 @@ export const plugin: PluginObject<any> = {
 }
 
 export function usePage() {
-  return app.page
+  return reactive({
+    props: computed(() => app.page.props),
+    url: computed(() => app.page.url),
+    component: computed(() => app.page.component),
+    version: computed(() => app.page.version),
+  })
 }

--- a/playgrounds/vue2/resources/js/Components/Layout.vue
+++ b/playgrounds/vue2/resources/js/Components/Layout.vue
@@ -2,7 +2,9 @@
 import { Link, usePage } from '@inertiajs/vue2'
 import { computed } from 'vue'
 
-const appName = computed(() => usePage().props.appName)
+const page = usePage()
+
+const appName = computed(() => page.props.appName)
 </script>
 
 <template>


### PR DESCRIPTION
Right now the `usePage()` hook in the Vue 2 adapter isn't actually reactive. The following doesn't work:

```html
<script setup>
import { usePage } from '@inertiajs/vue2'
import { computed } from 'vue'

const page = usePage()

const appName = computed(() => page.props.appName)
</script>
```

This PR updates the Vue 2 adapter to use the same technique used in the Vue 3 adapter to solve this (see #1469).

The only issue here is that this requires Vue 2.7 features to fix this — the `computed()` and `reactive()` methods. Meaning anyone who is still using Vue 2.6 will need to also upgrade to Vue 2.7 when updating to the next release of Inertia. Given that this is the only way to solve this problem, I think that's a reasonable tradeoff.