### PR TITLE
Fix `usePage()` null object error in Vue 3 adapter

### DIFF
--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -128,11 +128,11 @@ export const plugin: Plugin = {
 
 export function usePage<SharedProps extends PageProps>(): Page<SharedProps> {
   return reactive({
-    props: computed(() => page.value.props),
-    url: computed(() => page.value.url),
-    component: computed(() => page.value.component),
-    version: computed(() => page.value.version),
-    scrollRegions: computed(() => page.value.scrollRegions),
-    rememberedState: computed(() => page.value.rememberedState),
+    props: computed(() => page.value?.props),
+    url: computed(() => page.value?.url),
+    component: computed(() => page.value?.component),
+    version: computed(() => page.value?.version),
+    scrollRegions: computed(() => page.value?.scrollRegions),
+    rememberedState: computed(() => page.value?.rememberedState),
   })
 }


### PR DESCRIPTION
follow-up fix for #1469, as proposed by @reinink 

I have tested this with a local build and all is working as expected again.