### PR TITLE
Add beforeLeave hook on router

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -269,6 +269,7 @@ export class Router {
       onProgress = () => {},
       onFinish = () => {},
       onCancel = () => {},
+      onBeforeLeave = () => {},
       onSuccess = () => {},
       onError = () => {},
       queryStringArrayFormat = 'brackets',
@@ -322,6 +323,7 @@ export class Router {
       onProgress,
       onFinish,
       onCancel,
+      onBeforeLeave,
       onSuccess,
       onError,
       queryStringArrayFormat,
@@ -367,7 +369,7 @@ export class Router {
         }
       },
     })
-      .then((response) => {
+      .then(async (response) => {
         if (!this.isInertiaResponse(response)) {
           return Promise.reject({ response })
         }
@@ -387,6 +389,7 @@ export class Router {
           responseUrl.hash = requestUrl.hash
           pageResponse.url = responseUrl.href
         }
+        await onBeforeLeave()
         return this.setPage(pageResponse, { visitId, replace, preserveScroll, preserveState })
       })
       .then(() => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -175,6 +175,7 @@ export type VisitOptions = Partial<
     onCancel: GlobalEventCallback<'cancel'>
     onSuccess: GlobalEventCallback<'success'>
     onError: GlobalEventCallback<'error'>
+    onBeforeLeave: VoidFunction,
   }
 >
 

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -101,6 +101,11 @@ export default function useForm<TForm extends Record<string, unknown>>(
             return options.onProgress(event)
           }
         },
+        onBeforeLeave: () => {
+          if (options.onBeforeLeave) {
+            return options.onBeforeLeave()
+          }
+        },
         onSuccess: (page) => {
           if (isMounted.current) {
             setProcessing(false)

--- a/packages/svelte/src/useForm.js
+++ b/packages/svelte/src/useForm.js
@@ -119,6 +119,11 @@ function useForm(...args) {
             return options.onProgress(event)
           }
         },
+        onBeforeLeave: () => {
+          if (options.onBeforeLeave) {
+            return options.onBeforeLeave()
+          }
+        },
         onSuccess: async (page) => {
           this.setStore('processing', false)
           this.setStore('progress', null)

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -151,6 +151,11 @@ export default function useForm<TForm>(...args): InertiaForm<TForm> {
             return options.onProgress(event)
           }
         },
+        onBeforeLeave: () => {
+          if (options.onBeforeLeave) {
+            return options.onBeforeLeave()
+          }
+        },
         onSuccess: async (page) => {
           this.processing = false
           this.progress = null

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -158,6 +158,11 @@ export default function useForm<TForm extends Record<string, unknown>>(
             return options.onProgress(event)
           }
         },
+        onBeforeLeave: () => {
+          if (options.onBeforeLeave) {
+            return options.onBeforeLeave()
+          }
+        },
         onSuccess: async (page) => {
           this.processing = false
           this.progress = null


### PR DESCRIPTION
in some case we want doing a async work before inertia changed page

for example :
i have a form in modal, i want after form submited and result is success, before inertia navigate me to another page, hide my modal dialog

with this pr i can doing it by passing `onBeforeLeave` to `VisitOptions`

thanks