### PR TITLE
Save data to remembered as a valid watch source

### DIFF
--- a/packages/vue3/src/useRemember.ts
+++ b/packages/vue3/src/useRemember.ts
@@ -13,7 +13,7 @@ export default function useRemember<T extends object>(
   const restored = router.restore(key)
   const type = isReactive(data) ? reactive : ref
   const hasCallbacks = typeof data.__remember === 'function' && typeof data.__restore === 'function'
-  const remembered = restored === undefined ? data : type(hasCallbacks ? data.__restore(restored) : restored)
+  const remembered = restored === undefined ? type(data) : type(hasCallbacks ? data.__restore(restored) : restored)
 
   watch(
     remembered,

--- a/packages/vue3/src/useRemember.ts
+++ b/packages/vue3/src/useRemember.ts
@@ -13,7 +13,7 @@ export default function useRemember<T extends object>(
   const restored = router.restore(key)
   const type = isReactive(data) ? reactive : ref
   const hasCallbacks = typeof data.__remember === 'function' && typeof data.__restore === 'function'
-  const remembered = restored === undefined ? type(data) : type(hasCallbacks ? data.__restore(restored) : restored)
+  const remembered = type(restored === undefined ? data : hasCallbacks ? data.__restore(restored) : restored)
 
   watch(
     remembered,


### PR DESCRIPTION
Calling `useRemember` with a new object was being passed to `remembered` as a bare object, and therefore not a valid source for the Vue `watch` function. This converts it to either a ref or reactive as appropriate.

Fixes #1483