### PR TITLE
Update useForm to correctly update/read values in Svelte store

### DIFF
--- a/packages/svelte/src/useForm.js
+++ b/packages/svelte/src/useForm.js
@@ -22,7 +22,8 @@ function useForm(...args) {
     processing: false,
     setStore(key, value) {
       store.update((store) => {
-        return Object.assign({}, store, typeof key === 'string' ? { [key]: value } : key)
+        const _value = typeof value === 'function' ? value(store) : value
+        return Object.assign({}, store, typeof key === 'string' ? { [key]: _value } : key)
       })
     },
     data() {
@@ -57,30 +58,29 @@ function useForm(...args) {
             .reduce((carry, key) => {
               carry[key] = defaults[key]
               return carry
-            }, {}),
+            }, {})
         )
       }
 
       return this
     },
     setError(key, value) {
-      this.setStore('errors', {
-        ...this.errors,
+      this.setStore('errors', (store) => ({
+        ...store.errors,
         ...(value ? { [key]: value } : key),
-      })
+      }))
 
       return this
     },
     clearErrors(...fields) {
-      this.setStore(
-        'errors',
-        Object.keys(this.errors).reduce(
+      this.setStore('errors', (store) =>
+        Object.keys(store.errors).reduce(
           (carry, field) => ({
             ...carry,
-            ...(fields.length > 0 && !fields.includes(field) ? { [field]: this.errors[field] } : {}),
+            ...(fields.length > 0 && !fields.includes(field) ? { [field]: store.errors[field] } : {}),
           }),
-          {},
-        ),
+          {}
+        )
       )
 
       return this


### PR DESCRIPTION
The Svelte version of the useForm helper is incorrectly reading values from the Svelte store by using `this`.

On line 68 of the `setError` function is directly referencing `this.errors` variable to get a list of the current errors to add back into the store along with any new errors. This is not the correct way to get current values from a Svelte store. You need to subscribe to the store or use the store's update function which passes in the stores current values to the callback. In this case when you call `clearErrors` and then immediately `setError` the internal variable `this.errors` still contains the old errors that were cleared in the `clearErrors` function. The store hasn't updated them yet.

With this PR I updated the `setStore` function to allow the `value` parameter to be a callback (in addition to string and object) that passes in the current store values. This allows the `setError` and `clearErrors` function to have access to the current store values by using the callback.

This should also fix https://github.com/inertiajs/inertia/issues/1521