### PR TITLE
added history event

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -42,3 +42,7 @@ export const fireStartEvent: GlobalEventTrigger<'start'> = (visit) => {
 export const fireSuccessEvent: GlobalEventTrigger<'success'> = (page) => {
   return fireEvent('success', { detail: { page } })
 }
+
+export const fireHistoryEvent: GlobalEventTrigger<'history'> = (page) => {
+  return fireEvent('history', { cancelable: true, detail: { page }})
+}

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -5,6 +5,7 @@ import {
   fireErrorEvent,
   fireExceptionEvent,
   fireFinishEvent,
+  fireHistoryEvent,
   fireInvalidEvent,
   fireNavigateEvent,
   fireProgressEvent,
@@ -156,6 +157,11 @@ export class Router {
 
   protected handleBackForwardVisit(page: Page): void {
     window.history.state.version = page.version
+
+    if (!fireHistoryEvent(page)) {
+      return
+    }
+
     this.setPage(window.history.state, { preserveScroll: true, preserveState: true }).then(() => {
       this.restoreScrollPositions()
       fireNavigateEvent(page)
@@ -480,6 +486,11 @@ export class Router {
   protected handlePopstateEvent(event: PopStateEvent): void {
     if (event.state !== null) {
       const page = event.state
+
+      if (!fireHistoryEvent(page)) {
+        return
+      }
+
       const visitId = this.createVisitId()
       Promise.resolve(this.resolveComponent(page.component)).then((component) => {
         if (visitId === this.visitId) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -145,6 +145,13 @@ export type GlobalEventsMap = {
     }
     result: boolean | void
   }
+  history: {
+    parameters: [History['state'] | Page]
+    details: {
+      page: Page
+    }
+    result: boolean | void
+  }
 }
 
 export type GlobalEventNames = keyof GlobalEventsMap
@@ -206,5 +213,6 @@ declare global {
     'inertia:exception': GlobalEvent<'exception'>
     'inertia:finish': GlobalEvent<'finish'>
     'inertia:navigate': GlobalEvent<'navigate'>
+    'inertia:history': GlobalEvent<'history'>
   }
 }


### PR DESCRIPTION
dieser PR fügt ein history event ein.
Dieses Event wird jedesmal ausgeführt bevor die seite aus der window.history geladen wird. Das Event kann gestoppt werden um den Komponenten tausch zu verhindern.

I need this or something similar as we have an Inertia.js Vue Router hybrid site. Otherwise there is no way to prevent Inertia from taking over the page change on certain pages. 