### PR TITLE
Preserve Default Meta in Inertia.js Core Package

### DIFF
--- a/packages/core/src/head.ts
+++ b/packages/core/src/head.ts
@@ -41,7 +41,6 @@ const Renderer = {
     targetElements.forEach((targetElement) => {
       const index = this.findMatchingElementIndex(targetElement as Element, sourceElements)
       if (index === -1) {
-        targetElement?.parentNode?.removeChild(targetElement)
         return
       }
 


### PR DESCRIPTION
I have made a simple update to the Inertia.js core package that addresses the issue of default meta deletion when the inertia attribute is added to a meta tag but not explicitly passed to the ```Head``` component.

In the current system, if the inertia attribute is present on a meta tag but not passed to the ```Head``` component, the default meta is deleted from the head section. This behavior has caused inconvenience for certain use cases.

To overcome this issue, I have removed the line ```targetElement?.parentNode?.removeChild(targetElement)``` from the core package's 'head.ts``` file . This change ensures that the default meta remains intact even when the meta not passed to the ```Head``` component.
 
I believe that this modification will greatly enhance the usability and flexibility of the Inertia.js core package. It resolves the problem of unintended meta deletion and ensures a more consistent and intuitive experience.

Thank you for considering this pull request. I am excited to contribute to the Inertia.js project and look forward to your feedback and suggestions.