### PR TITLE
[1.x] Fix useForm re-renders by memoizing functions in React

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -58,7 +58,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
   const [progress, setProgress] = useState(null)
   const [wasSuccessful, setWasSuccessful] = useState(false)
   const [recentlySuccessful, setRecentlySuccessful] = useState(false)
-  let transform = (data) => data
+  const transform = useRef((data) => data)
 
   useEffect(() => {
     isMounted.current = true
@@ -157,9 +157,9 @@ export default function useForm<TForm extends Record<string, unknown>>(
       }
 
       if (method === 'delete') {
-        router.delete(url, { ..._options, data: transform(data) })
+        router.delete(url, { ..._options, data: transform.current(data) })
       } else {
-        router[method](url, transform(data), _options)
+        router[method](url, transform.current(data), _options)
       }
     },
     [data, setErrors],
@@ -262,7 +262,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
   }, [])
 
   const transformFunction = useCallback((callback) => {
-    transform = callback
+    transform.current = callback
   }, [])
 
   return {

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -168,14 +168,14 @@ export default function useForm<TForm extends Record<string, unknown>>(
   const setDataFunction = useCallback(
     (keyOrData: keyof TForm | Function | TForm, maybeValue?: TForm[keyof TForm]) => {
       if (typeof keyOrData === 'string') {
-        setData({ ...data, [keyOrData]: maybeValue })
+        setData((data) => ({ ...data, [keyOrData]: maybeValue }))
       } else if (typeof keyOrData === 'function') {
         setData((data) => keyOrData(data))
       } else {
         setData(keyOrData as TForm)
       }
     },
-    [data, setData],
+    [setData],
   )
 
   const setDefaultsFunction = useCallback(
@@ -197,7 +197,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
       if (fields.length === 0) {
         setData(defaults)
       } else {
-        setData(
+        setData((data) =>
           (Object.keys(defaults) as Array<keyof TForm>)
             .filter((key) => fields.includes(key))
             .reduce(
@@ -210,7 +210,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
         )
       }
     },
-    [data, setData, defaults],
+    [setData, defaults],
   )
 
   const setError = useCallback(


### PR DESCRIPTION
When using the `useForm()` in a React component that has some heavy pure components(components using `React.memo`) as children and passing some methods returned by `useForm()` like `setData`, `clearErrors`, etc to them, on every re-render, these methods returned by `useForm()` are getting **new references** so new props are passed to these `React.memo()`ed children and they will be re-rendered unnecessarily. 
This pull request fixes this issue by using `useCallback` for those methods in the `useForm` hook.