### PR TITLE
[vue3]: Prevented double execution of resolveComponent callback

### DIFF
--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -31,7 +31,16 @@ export default async function createInertiaApp({
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
   const initialPage = page || JSON.parse(el.dataset.page)
-  const resolveComponent = (name) => Promise.resolve(resolve(name)).then((module) => module.default || module)
+  const resolvedComponentCache = {
+    name: null,
+    component: null
+  }
+  const resolveComponent = (name) => {
+    if (resolvedComponentCache.name == name) return resolvedComponentCache.component
+    let promise = Promise.resolve(resolve(name)).then((module) => module.default || module)
+    Object.assign(resolvedComponentCache, { name, component: promise })
+    return promise
+  }
 
   let head = []
 


### PR DESCRIPTION
Fixes #1595

During the initial createInertiaApp call, the `resolveComponent` callback is executed twice. Once in `createInertiaApp.ts` (`const vueApp = await resolveComponent(initialPage.component)`) and then again inside `router.ts` when `setPage` is called.

Added a small cache object that stores the resolved component for if/when the same named component is requested again.