### PR TITLE
fixes for svelte's useForm helper

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@inertiajs/core": "1.0.9",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/svelte/src/useForm.js
+++ b/packages/svelte/src/useForm.js
@@ -7,7 +7,7 @@ function useForm(...args) {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const restored = rememberKey ? router.restore(rememberKey) : null
-  let defaults = cloneDeep(data);
+  let defaults = cloneDeep(data)
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = (data) => data
@@ -49,14 +49,15 @@ function useForm(...args) {
       return this
     },
     reset(...fields) {
+      let clonedDefaults = cloneDeep(defaults)
       if (fields.length === 0) {
-        this.setStore(defaults)
+        this.setStore(clonedDefaults)
       } else {
         this.setStore(
-          Object.keys(defaults)
+          Object.keys(clonedDefaults)
             .filter((key) => fields.includes(key))
             .reduce((carry, key) => {
-              carry[key] = defaults[key]
+              carry[key] = clonedDefaults[key]
               return carry
             }, {}),
         )

--- a/packages/svelte/src/useForm.js
+++ b/packages/svelte/src/useForm.js
@@ -125,7 +125,6 @@ function useForm(...args) {
           this.setStore('processing', false)
           this.setStore('progress', null)
           this.clearErrors()
-          this.defaults()
           this.setStore('wasSuccessful', true)
           this.setStore('recentlySuccessful', true)
           recentlySuccessfulTimeoutId = setTimeout(() => this.setStore('recentlySuccessful', false), 2000)

--- a/packages/svelte/src/useForm.js
+++ b/packages/svelte/src/useForm.js
@@ -125,6 +125,7 @@ function useForm(...args) {
           this.setStore('processing', false)
           this.setStore('progress', null)
           this.clearErrors()
+          this.defaults()
           this.setStore('wasSuccessful', true)
           this.setStore('recentlySuccessful', true)
           recentlySuccessfulTimeoutId = setTimeout(() => this.setStore('recentlySuccessful', false), 2000)

--- a/packages/svelte/src/useForm.js
+++ b/packages/svelte/src/useForm.js
@@ -1,12 +1,13 @@
 import { router } from '@inertiajs/core'
 import isEqual from 'lodash.isequal'
+import cloneDeep from 'lodash.clonedeep'
 import { writable } from 'svelte/store'
 
 function useForm(...args) {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const restored = rememberKey ? router.restore(rememberKey) : null
-  let defaults = data
+  let defaults = cloneDeep(data);
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = (data) => data
@@ -22,7 +23,7 @@ function useForm(...args) {
     processing: false,
     setStore(key, value) {
       store.update((store) => {
-        return Object.assign({}, store, typeof key === 'string' ? { [key]: value } : key)
+        return Object.assign(store, typeof key === 'string' ? { [key]: value } : key)
       })
     },
     data() {
@@ -38,12 +39,12 @@ function useForm(...args) {
     },
     defaults(key, value) {
       if (typeof key === 'undefined') {
-        defaults = Object.assign(defaults, this.data())
+        defaults = Object.assign(defaults, cloneDeep(this.data()))
 
         return this
       }
 
-      defaults = Object.assign(defaults, value ? { [key]: value } : key)
+      defaults = Object.assign(defaults, cloneDeep(value ? { [key]: value } : key))
 
       return this
     },


### PR DESCRIPTION
This fixes two issues in useForm helper that I found.

- Form fields with objects as values (arrays/objects) has broken reactivity. This is because input `data` is shallow copied to `defaults`. Updating nested objects in form updates `defaults` object as well. Since the current form data is compared to `defaults`, no changes are detected.
- Broken `setStore`. Svelte's stores replaces store value with anything it receives from `update`'s callback function. In this case `setStore` creates completely new object instance every time it's called by returning `Object.assign({}, store, ...)`. Later when form submit fails, `this.clearErrors().setError(errors)` is called on object instance that request was made from which is NOT the object currently stored in form store hence nothing is cleared.

This should fix form error issue in #1521 #1276


Edit:

Added two more fixes:

- reset function also shallow copies but this time defaults to data. This again breaks nested array/object reactivity.
~~- updating defaults to current data after successful request. It's debatable but IMO form defaults should be updated because previous form state is irrelevant after successful submit.~~


I see that Vue adapters work very similarly to the changes I made.

