### PR TITLE
Add ability to handle deferred props

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -34,6 +34,10 @@ export interface Page<SharedProps extends PageProps = PageProps> {
     SharedProps & {
       errors: Errors & ErrorBag
     }
+  deferProps?: (keyof (PageProps &
+    SharedProps & {
+      errors: Errors & ErrorBag
+    }))[]
   url: string
   version: string | null
 


### PR DESCRIPTION
This works in tandem with https://github.com/inertiajs/inertia-laravel/pull/531. This is the client-side implementation of this feature. These deferred properties will only ever be loaded automatically on page loads/navigations. Otherwise, they behave just the same as Lazy props.

See the previously mentioned PR for more details.