### PR TITLE
Update `useForm` types to accept interfaces

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -7,7 +7,11 @@ type setDataByObject<TForm> = (data: TForm) => void
 type setDataByMethod<TForm> = (data: (previousData: TForm) => TForm) => void
 type setDataByKeyValuePair<TForm> = <K extends keyof TForm>(key: K, value: TForm[K]) => void
 
-export interface InertiaFormProps<TForm extends Record<string, unknown>> {
+type ValidPropsType<T> = T extends {}
+  ? { [K in keyof T]: K extends string ? (T[K] extends FormDataConvertible ? T[K] : never) : never }
+  : never
+
+export interface InertiaFormProps<TForm> {
   data: TForm
   isDirty: boolean
   errors: Partial<Record<keyof TForm, string>>
@@ -33,14 +37,14 @@ export interface InertiaFormProps<TForm extends Record<string, unknown>> {
   delete: (url: string, options?: VisitOptions) => void
   cancel: () => void
 }
-export default function useForm<TForm extends Record<string, unknown>>(initialValues?: TForm): InertiaFormProps<TForm>
-export default function useForm<TForm extends Record<string, unknown>>(
+export default function useForm<TForm>(initialValues?: ValidPropsType<TForm>): InertiaFormProps<TForm>
+export default function useForm<TForm>(
   rememberKey: string,
-  initialValues?: TForm,
+  initialValues?: ValidPropsType<TForm>,
 ): InertiaFormProps<TForm>
-export default function useForm<TForm extends Record<string, unknown>>(
-  rememberKeyOrInitialValues?: string | TForm,
-  maybeInitialValues?: TForm,
+export default function useForm<TForm>(
+  rememberKeyOrInitialValues?: string | ValidPropsType<TForm>,
+  maybeInitialValues?: ValidPropsType<TForm>,
 ): InertiaFormProps<TForm> {
   const isMounted = useRef(null)
   const rememberKey = typeof rememberKeyOrInitialValues === 'string' ? rememberKeyOrInitialValues : null
@@ -171,6 +175,8 @@ export default function useForm<TForm extends Record<string, unknown>>(
       if (typeof keyOrData === 'string') {
         setData({ ...data, [keyOrData]: maybeValue })
       } else if (typeof keyOrData === 'function') {
+        // TODO: Make types more happy without making developers more sad
+        // @ts-expect-error: No constituent of type
         setData((data) => keyOrData(data))
       } else {
         setData(keyOrData as TForm)

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -3,6 +3,10 @@ import cloneDeep from 'lodash.clonedeep'
 import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
 
+type ValidPropsType<T> = T extends {}
+  ? { [K in keyof T]: K extends string ? (T[K] extends FormDataConvertible ? T[K] : never) : never }
+  : never
+
 interface InertiaFormProps<TForm> {
   isDirty: boolean
   errors: Record<keyof TForm, string>
@@ -36,8 +40,11 @@ export interface InertiaFormTrait {
   form<TForm>(rememberKey: string, data: TForm): InertiaForm<TForm>
 }
 
-export default function useForm<TForm>(data: TForm | (() => TForm)): InertiaForm<TForm>
-export default function useForm<TForm>(rememberKey: string, data: TForm | (() => TForm)): InertiaForm<TForm>
+export default function useForm<TForm>(data: ValidPropsType<TForm> | (() => ValidPropsType<TForm>)): InertiaForm<TForm>
+export default function useForm<TForm>(
+  rememberKey: string,
+  data: ValidPropsType<TForm> | (() => ValidPropsType<TForm>),
+): InertiaForm<TForm>
 export default function useForm<TForm>(...args): InertiaForm<TForm> {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -3,7 +3,11 @@ import cloneDeep from 'lodash.clonedeep'
 import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
 
-interface InertiaFormProps<TForm extends Record<string, unknown>> {
+type ValidPropsType<T> = T extends {}
+  ? { [K in keyof T]: K extends string ? (T[K] extends FormDataConvertible ? T[K] : never) : never }
+  : never
+
+interface InertiaFormProps<TForm> {
   isDirty: boolean
   errors: Partial<Record<keyof TForm, string>>
   hasErrors: boolean
@@ -29,16 +33,16 @@ interface InertiaFormProps<TForm extends Record<string, unknown>> {
   cancel(): void
 }
 
-export type InertiaForm<TForm extends Record<string, unknown>> = TForm & InertiaFormProps<TForm>
+export type InertiaForm<TForm> = TForm & InertiaFormProps<TForm>
 
-export default function useForm<TForm extends Record<string, unknown>>(data: TForm | (() => TForm)): InertiaForm<TForm>
-export default function useForm<TForm extends Record<string, unknown>>(
+export default function useForm<TForm>(data: ValidPropsType<TForm> | (() => ValidPropsType<TForm>)): InertiaForm<TForm>
+export default function useForm<TForm>(
   rememberKey: string,
-  data: TForm | (() => TForm),
+  data: ValidPropsType<TForm> | (() => ValidPropsType<TForm>),
 ): InertiaForm<TForm>
-export default function useForm<TForm extends Record<string, unknown>>(
-  rememberKeyOrData: string | TForm | (() => TForm),
-  maybeData?: TForm | (() => TForm),
+export default function useForm<TForm>(
+  rememberKeyOrData: string | ValidPropsType<TForm> | (() => ValidPropsType<TForm>),
+  maybeData?: ValidPropsType<TForm> | (() => ValidPropsType<TForm>),
 ): InertiaForm<TForm> {
   const rememberKey = typeof rememberKeyOrData === 'string' ? rememberKeyOrData : null
   const data = typeof rememberKeyOrData === 'string' ? maybeData : rememberKeyOrData


### PR DESCRIPTION
Previously a bare interface type that does not extend `Record<string, unknown>` was not accepted. This isn't ideal so this PR makes changes such that we are able to accept arbitrary interface types but still get validation when using `useForm()`. Since we still want to do some validation on the types we use a conditional type in parameter position to validate that the data being passed through is correct. This isn’t the most ideal solution because the errors highlight the entire object instead of individual keys but it is an improvement over the status quo.

Fixes #1624
Closes #1626