### PR TITLE
Build playgrounds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,7 @@ jobs:
           npm install
           cd packages/core && npm run build
           cd ../${{ matrix.adapter }} && npm run build
+
+      - name: Build Playground
+        run: |
+          cd playgrounds/${{ matrix.adapter }} && npm run build


### PR DESCRIPTION
This PR adds playground builds to the CI process to ensure no easily caught regressions.