### PR TITLE
Update `useForm` to accept interfaces

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -6,8 +6,9 @@ import useRemember from './useRemember'
 type setDataByObject<TForm> = (data: TForm) => void
 type setDataByMethod<TForm> = (data: (previousData: TForm) => TForm) => void
 type setDataByKeyValuePair<TForm> = <K extends keyof TForm>(key: K, value: TForm[K]) => void
+type FormDataType = object;
 
-export interface InertiaFormProps<TForm extends Record<string, unknown>> {
+export interface InertiaFormProps<TForm extends FormDataType> {
   data: TForm
   isDirty: boolean
   errors: Partial<Record<keyof TForm, string>>
@@ -33,12 +34,12 @@ export interface InertiaFormProps<TForm extends Record<string, unknown>> {
   delete: (url: string, options?: VisitOptions) => void
   cancel: () => void
 }
-export default function useForm<TForm extends Record<string, unknown>>(initialValues?: TForm): InertiaFormProps<TForm>
-export default function useForm<TForm extends Record<string, unknown>>(
+export default function useForm<TForm extends FormDataType>(initialValues?: TForm): InertiaFormProps<TForm>
+export default function useForm<TForm extends FormDataType>(
   rememberKey: string,
   initialValues?: TForm,
 ): InertiaFormProps<TForm>
-export default function useForm<TForm extends Record<string, unknown>>(
+export default function useForm<TForm extends FormDataType>(
   rememberKeyOrInitialValues?: string | TForm,
   maybeInitialValues?: TForm,
 ): InertiaFormProps<TForm> {

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -3,7 +3,9 @@ import cloneDeep from 'lodash.clonedeep'
 import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
 
-interface InertiaFormProps<TForm> {
+type FormDataType = object;
+
+interface InertiaFormProps<TForm extends FormDataType> {
   isDirty: boolean
   errors: Record<keyof TForm, string>
   hasErrors: boolean
@@ -29,16 +31,16 @@ interface InertiaFormProps<TForm> {
   cancel(): void
 }
 
-export type InertiaForm<TForm> = TForm & InertiaFormProps<TForm>
+export type InertiaForm<TForm extends FormDataType> = TForm & InertiaFormProps<TForm>
 
 export interface InertiaFormTrait {
-  form<TForm>(data: TForm): InertiaForm<TForm>
-  form<TForm>(rememberKey: string, data: TForm): InertiaForm<TForm>
+  form<TForm extends FormDataType>(data: TForm): InertiaForm<TForm>
+  form<TForm extends FormDataType>(rememberKey: string, data: TForm): InertiaForm<TForm>
 }
 
-export default function useForm<TForm>(data: TForm | (() => TForm)): InertiaForm<TForm>
-export default function useForm<TForm>(rememberKey: string, data: TForm | (() => TForm)): InertiaForm<TForm>
-export default function useForm<TForm>(...args): InertiaForm<TForm> {
+export default function useForm<TForm extends FormDataType>(data: TForm | (() => TForm)): InertiaForm<TForm>
+export default function useForm<TForm extends FormDataType>(rememberKey: string, data: TForm | (() => TForm)): InertiaForm<TForm>
+export default function useForm<TForm extends FormDataType>(...args): InertiaForm<TForm> {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const restored = rememberKey ? (router.restore(rememberKey) as { data: any; errors: any }) : null

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -3,7 +3,9 @@ import cloneDeep from 'lodash.clonedeep'
 import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
 
-interface InertiaFormProps<TForm extends Record<string, unknown>> {
+type FormDataType = object;
+
+interface InertiaFormProps<TForm extends FormDataType> {
   isDirty: boolean
   errors: Partial<Record<keyof TForm, string>>
   hasErrors: boolean
@@ -29,14 +31,14 @@ interface InertiaFormProps<TForm extends Record<string, unknown>> {
   cancel(): void
 }
 
-export type InertiaForm<TForm extends Record<string, unknown>> = TForm & InertiaFormProps<TForm>
+export type InertiaForm<TForm extends FormDataType> = TForm & InertiaFormProps<TForm>
 
-export default function useForm<TForm extends Record<string, unknown>>(data: TForm | (() => TForm)): InertiaForm<TForm>
-export default function useForm<TForm extends Record<string, unknown>>(
+export default function useForm<TForm extends FormDataType>(data: TForm | (() => TForm)): InertiaForm<TForm>
+export default function useForm<TForm extends FormDataType>(
   rememberKey: string,
   data: TForm | (() => TForm),
 ): InertiaForm<TForm>
-export default function useForm<TForm extends Record<string, unknown>>(
+export default function useForm<TForm extends FormDataType>(
   rememberKeyOrData: string | TForm | (() => TForm),
   maybeData?: TForm | (() => TForm),
 ): InertiaForm<TForm> {


### PR DESCRIPTION
A differing attempt to fix #1624. Tested Vue2, Vue3 and React in the included playgrounds, worked fine (after setting the language to TS in the tested Vue2 page). `FormDataType` exists so if someone wants to make a more restrictive type, it's easier for refactors.