### PR TITLE
Remove empty payload from GET requests

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -342,7 +342,7 @@ export class Router {
     Axios({
       method,
       url: urlWithoutHash(url).href,
-      data: method === 'get' ? {} : data,
+      data: method === 'get' ? null : data,
       params: method === 'get' ? data : {},
       signal: this.activeVisit.cancelToken.signal,
       headers: {

--- a/packages/vue2/tests/cypress/integration/links.test.js
+++ b/packages/vue2/tests/cypress/integration/links.test.js
@@ -166,8 +166,6 @@ describe('Links', () => {
 
           cy.wait('@spy').then(({ request, response }) => {
             expect(request.url).to.eq(Cypress.config().baseUrl + '/dump/get?foo=get')
-            expect(request.headers).to.contain.key('content-type')
-            expect(request.headers['content-type']).to.contain('application/json')
             expect(request.method).to.eq('GET')
             expect(response.body.props.form).to.be.empty
             expect(response.body.props.files).to.be.undefined

--- a/packages/vue2/tests/cypress/integration/manual-visits.test.js
+++ b/packages/vue2/tests/cypress/integration/manual-visits.test.js
@@ -193,8 +193,6 @@ describe('Manual Visits', () => {
 
         cy.wait('@spy').then(({ request, response }) => {
           expect(request.url).to.eq(Cypress.config().baseUrl + '/dump/get?foo=visit')
-          expect(request.headers).to.contain.key('content-type')
-          expect(request.headers['content-type']).to.contain('application/json')
           expect(request.method).to.eq('GET')
           expect(response.body.props.form).to.be.empty
           expect(response.body.props.files).to.be.undefined
@@ -207,8 +205,6 @@ describe('Manual Visits', () => {
 
           cy.wait('@spy').then(({ request, response }) => {
             expect(request.url).to.eq(Cypress.config().baseUrl + '/dump/get?bar=get')
-            expect(request.headers).to.contain.key('content-type')
-            expect(request.headers['content-type']).to.contain('application/json')
             expect(request.method).to.eq('GET')
             expect(response.body.props.form).to.be.empty
             expect(response.body.props.files).to.be.undefined


### PR DESCRIPTION
Currently all Inertia GET requests have `Content-Type: application/json` header applied because empty object is passed as a payload. Axios sees an object and sets content type to application/json even though request body is empty.

This is an issue because Laravel interprets these requests differently than regular GET request. See [here](https://github.com/laravel/framework/blob/b8557e4a708a1bd2bc8229bd53feecfa2ac1c6fb/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php#L16)

One example where this is a problem - for example I have GET route and I want to add or update some query parameters in current request using `request()->merge(['foo' => 'bar'])`

When running `request()->query()` I expect to get `foo` parameter back since it is a GET request. Instead I get nothing. This is because `merge` runs on json input source instead of query. See [here](https://github.com/laravel/framework/blob/b8557e4a708a1bd2bc8229bd53feecfa2ac1c6fb/src/Illuminate/Http/Request.php#L349) and [here](https://github.com/laravel/framework/blob/b8557e4a708a1bd2bc8229bd53feecfa2ac1c6fb/src/Illuminate/Http/Request.php#L421) 

Setting data to `null` is enough for Axios to ignore payload.