### PR TITLE
Fix `Link` type in React

### DIFF
--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -37,7 +37,7 @@ export type InertiaLinkProps = BaseInertiaLinkProps &
   Omit<React.HTMLAttributes<HTMLElement>, keyof BaseInertiaLinkProps> &
   Omit<React.AllHTMLAttributes<HTMLElement>, keyof BaseInertiaLinkProps>
 
-type InertiaLink = React.FunctionComponent<InertiaLinkProps>
+type InertiaLink = ReturnType<typeof forwardRef<unknown, InertiaLinkProps>>
 
 const Link: InertiaLink = forwardRef<unknown, InertiaLinkProps>(
   (

--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -37,9 +37,7 @@ export type InertiaLinkProps = BaseInertiaLinkProps &
   Omit<React.HTMLAttributes<HTMLElement>, keyof BaseInertiaLinkProps> &
   Omit<React.AllHTMLAttributes<HTMLElement>, keyof BaseInertiaLinkProps>
 
-type InertiaLink = ReturnType<typeof forwardRef<unknown, InertiaLinkProps>>
-
-const Link: InertiaLink = forwardRef<unknown, InertiaLinkProps>(
+const Link = forwardRef<unknown, InertiaLinkProps>(
   (
     {
       children,


### PR DESCRIPTION
this fixes #1511 

it's a more explicit version of @Gregory-Gerard recommended solution
