### PR TITLE
Fix type of `onClick` for Link component in React

### DIFF
--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -17,7 +17,7 @@ interface BaseInertiaLinkProps {
   href: string
   method?: Method
   headers?: Record<string, string>
-  onClick?: (event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>) => void
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
   preserveScroll?: PreserveStateOption
   preserveState?: PreserveStateOption
   replace?: boolean


### PR DESCRIPTION
An `onClick` in React — or event in the browser — never receives keyboard events. Even for a button that is “clicked” using enter or spacebar the browser creates a corresponding pointer event for the action that is passed into `onClick`.