### PR TITLE
Fix type of `onClick` for Link component in Vue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ For changes prior to v1.0.0, see the [legacy releases](https://legacy.inertiajs.
 
 ## [Unreleased](https://github.com/inertiajs/inertia/compare/v1.0.11...HEAD)
 
-- Nothing!
+- Fix type of `onClick` for `Link` component in React and Vue ([#1699](https://github.com/inertiajs/inertia/pull/1699), [#1701](https://github.com/inertiajs/inertia/pull/1701))
 
 ## [v1.0.11](https://github.com/inertiajs/inertia/compare/v1.0.10...v1.0.11)
 

--- a/packages/vue2/src/link.ts
+++ b/packages/vue2/src/link.ts
@@ -15,7 +15,7 @@ export interface InertiaLinkProps {
   href: string
   method?: Method
   headers?: Record<string, string>
-  onClick?: (event: MouseEvent | KeyboardEvent) => void
+  onClick?: (event: MouseEvent) => void
   preserveScroll?: PreserveStateOption
   preserveState?: PreserveStateOption
   replace?: boolean

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -7,7 +7,7 @@ export interface InertiaLinkProps {
   href: string
   method?: Method
   headers?: object
-  onClick?: (event: MouseEvent | KeyboardEvent) => void
+  onClick?: (event: MouseEvent) => void
   preserveScroll?: boolean | ((props: PageProps) => boolean)
   preserveState?: boolean | ((props: PageProps) => boolean) | null
   replace?: boolean


### PR DESCRIPTION
Same fix as #1699, except for Vue.

An `onClick` in Vue — or event in the browser — never receives keyboard events. Even for a button that is “clicked” using enter or spacebar the browser creates a corresponding pointer event for the action that is passed into `onClick`.