### PR TITLE
[1.x] Return early when using `router.on()` during SSR

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -580,7 +580,7 @@ export class Router {
       }
     }) as EventListener
 
-    if (typeof document === 'undefined') {
+    if (isServer) {
       return () => {};
     }
 

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -574,7 +574,7 @@ export class Router {
     callback: (event: GlobalEvent<TEventName>) => GlobalEventResult<TEventName>,
   ): VoidFunction {
     if (isServer) {
-      return () => {};
+      return () => {}
     }
 
     const listener = ((event: GlobalEvent<TEventName>) => {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -573,16 +573,16 @@ export class Router {
     type: TEventName,
     callback: (event: GlobalEvent<TEventName>) => GlobalEventResult<TEventName>,
   ): VoidFunction {
+    if (isServer) {
+      return () => {};
+    }
+
     const listener = ((event: GlobalEvent<TEventName>) => {
       const response = callback(event)
       if (event.cancelable && !event.defaultPrevented && response === false) {
         event.preventDefault()
       }
     }) as EventListener
-
-    if (isServer) {
-      return () => {};
-    }
 
     document.addEventListener(`inertia:${type}`, listener)
     return () => document.removeEventListener(`inertia:${type}`, listener)

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -580,6 +580,10 @@ export class Router {
       }
     }) as EventListener
 
+    if (typeof document === 'undefined') {
+      return () => {};
+    }
+
     document.addEventListener(`inertia:${type}`, listener)
     return () => document.removeEventListener(`inertia:${type}`, listener)
   }


### PR DESCRIPTION
When using `router.on()` it is always executed, this means the following won't work during SSR:
```html
<script setup>
import { router } from '@inertiajs/vue3'

router.on('start', (event) => {
  console.log(`Starting a visit to ${event.detail.visit.url}`)
})
</script>
```

Instead, we'd need to wrap this in a `onMounted` hook, or check if the document/window exists;
```html
<script setup>
import { router } from '@inertiajs/vue3'
import { onMounted } from 'vue'

onMounted(() => {
  router.on('start', (event) => {
    console.log(`Starting a visit to ${event.detail.visit.url}`)
  })
})
</script>
```

But since `router.on()` is already just a wrapper for `document.addEventListener()` I'd expect the wrapper to take care of that for you.

A simple fix I've made here is to simply check if we're in ssr with the `isServer` constant, if it is we return an empty void function