### PR TITLE
Memoize `transform` to fix long standing `useForm` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ For changes prior to v1.0.0, see the [legacy releases](https://legacy.inertiajs.
 
 ### Fixed
 
-- Add explicit children to `InertiaHeadProps` ([#1448](https://github.com/inertiajs/inertia/pull/1448))
-- Export `InertiaLinkProps` type ([#1450](https://github.com/inertiajs/inertia/pull/1450))
-- Improve React `usePage` generic type ([#1451](https://github.com/inertiajs/inertia/pull/1451))
+- Added explicit children to `InertiaHeadProps` ([#1448](https://github.com/inertiajs/inertia/pull/1448))
+- Exported `InertiaLinkProps` type ([#1450](https://github.com/inertiajs/inertia/pull/1450))
+- Improved React `usePage` generic type ([#1451](https://github.com/inertiajs/inertia/pull/1451))
 
 ## [v1.0.1](https://github.com/inertiajs/inertia/compare/v1.0.0...v1.0.1)
 

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -58,7 +58,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
   const [progress, setProgress] = useState(null)
   const [wasSuccessful, setWasSuccessful] = useState(false)
   const [recentlySuccessful, setRecentlySuccessful] = useState(false)
-  let transform = (data) => data
+  const transformRef = useRef<(data: TForm) => Record<string, any>>(data => data)
 
   useEffect(() => {
     isMounted.current = true
@@ -157,9 +157,9 @@ export default function useForm<TForm extends Record<string, unknown>>(
       }
 
       if (method === 'delete') {
-        router.delete(url, { ..._options, data: transform(data) })
+        router.delete(url, { ..._options, data: transformRef.current(data) })
       } else {
-        router[method](url, transform(data), _options)
+        router[method](url, transformRef.current(data), _options)
       }
     },
     [data, setErrors],
@@ -184,7 +184,7 @@ export default function useForm<TForm extends Record<string, unknown>>(
     wasSuccessful,
     recentlySuccessful,
     transform(callback) {
-      transform = callback
+      transformRef.current = callback
     },
     setDefaults(fieldOrFields?: keyof TForm | Record<keyof TForm, string>, maybeValue?: string) {
       if (typeof fieldOrFields === 'undefined') {


### PR DESCRIPTION
I'm opening another PR to fix this bug (#1171, #1131, #1491, #1631)

In the React `useForm` package, the `transform` function is set as a local variable in the component. This means that if the page triggers _any_ re-render, the `transform` variable is re-initialized to the placeholder function (`(data) => data`). For this reason, it's more likely than not that the transform method does nothing, rendering [the docs](https://inertiajs.com/forms) inaccurate.

The previous PRs were closed without being read. I think the whole React community here would really appreciate this bug finally being fixed.