### PR TITLE
[1.x] Fix doubling hash in React StrictMode

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,33 +1,33 @@
-import { AxiosResponse, default as Axios } from 'axios'
+import { default as Axios, AxiosResponse } from 'axios'
 import debounce from './debounce'
 import {
-  fireBeforeEvent,
-  fireErrorEvent,
-  fireExceptionEvent,
-  fireFinishEvent,
-  fireInvalidEvent,
-  fireNavigateEvent,
-  fireProgressEvent,
-  fireStartEvent,
-  fireSuccessEvent,
+    fireBeforeEvent,
+    fireErrorEvent,
+    fireExceptionEvent,
+    fireFinishEvent,
+    fireInvalidEvent,
+    fireNavigateEvent,
+    fireProgressEvent,
+    fireStartEvent,
+    fireSuccessEvent,
 } from './events'
 import { hasFiles } from './files'
 import { objectToFormData } from './formData'
 import modal from './modal'
 import {
-  ActiveVisit,
-  GlobalEvent,
-  GlobalEventNames,
-  GlobalEventResult,
-  LocationVisit,
-  Page,
-  PageHandler,
-  PageResolver,
-  PendingVisit,
-  PreserveStateOption,
-  RequestPayload,
-  VisitId,
-  VisitOptions,
+    ActiveVisit,
+    GlobalEvent,
+    GlobalEventNames,
+    GlobalEventResult,
+    LocationVisit,
+    Page,
+    PageHandler,
+    PageResolver,
+    PendingVisit,
+    PreserveStateOption,
+    RequestPayload,
+    VisitId,
+    VisitOptions,
 } from './types'
 import { hrefToUrl, mergeDataIntoQueryString, urlWithoutHash } from './url'
 
@@ -84,7 +84,7 @@ export class Router {
   protected handleInitialPageVisit(page: Page): void {
     const hash = window.location.hash
     if (!this.page.url.includes(hash)) {
-      this.page.url += window.location.hash
+      this.page.url += hash
     }
     this.setPage(page, { preserveState: true }).then(() => fireNavigateEvent(page))
   }

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -82,8 +82,8 @@ export class Router {
   }
 
   protected handleInitialPageVisit(page: Page): void {
-    const hash = window.location.hash;
-    if(!this.page.url.includes(hash)) {
+    const hash = window.location.hash
+    if (!this.page.url.includes(hash)) {
       this.page.url += window.location.hash
     }
     this.setPage(page, { preserveState: true }).then(() => fireNavigateEvent(page))

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -82,7 +82,10 @@ export class Router {
   }
 
   protected handleInitialPageVisit(page: Page): void {
-    this.page.url += window.location.hash
+    const hash = window.location.hash;
+    if(!this.page.url.includes(hash)) {
+      this.page.url += window.location.hash
+    }
     this.setPage(page, { preserveState: true }).then(() => fireNavigateEvent(page))
   }
 


### PR DESCRIPTION
Hello!

We are having the following problem in our application.

We are using `<React.StrictMode>` in the application, this causes the application to redirect twice in dev mode.
This forces us to double the previous hash during development because it calls the same router logic twice.
For example it makes `exanple.com/#hi` become `exanple.com/#hi#hi` after the update

This fix would prevent that from happening. If so, would you have handled this differently? 

Thank you very much for Inertia! It's a cool project 😉 