### PR TITLE
Revalidating isDirty when using the defaults() function.

### DIFF
--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -86,6 +86,7 @@ export default function useForm<TForm extends FormDataType>(
           typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields,
         )
       }
+      form.isDirty = !isEqual(form.data(), defaults)
 
       return this
     },


### PR DESCRIPTION
When the form.defaults() function is used, it doesn't update the form.isDirty(), as it is revalidated by a watcher, which is only triggered after a change in the form. I mistakenly called the same validation trigger used in the watcher to revalidate the isDirty() within the defaults() function. This was an error because isDirty() returns false if a field is cleared and then rewritten with the same value after using defaults().