### PR TITLE
Fix Svelte 4 slot rendering issues

### DIFF
--- a/packages/svelte/src/Render.svelte
+++ b/packages/svelte/src/Render.svelte
@@ -14,12 +14,23 @@
   export let component
   export let props = {}
   export let children = []
+
+  let prevComponent;
+  let key;
+  $: {
+    if (prevComponent !== component) {
+      key = Date.now();
+      prevComponent = component;
+    }
+  }
 </script>
 
 {#if $store.component}
-  <svelte:component this={component} {...props}>
-    {#each children as child, index (component && component.length === index ? $store.key : null)}
-      <svelte:self {...child} />
-    {/each}
-  </svelte:component>
+  {#key key}
+    <svelte:component this={component} {...props}>
+      {#each children as child, index (component && component.length === index ? $store.key : null)}
+        <svelte:self {...child} />
+      {/each}
+    </svelte:component>
+  {/key}
 {/if}

--- a/packages/svelte/src/Render.svelte
+++ b/packages/svelte/src/Render.svelte
@@ -15,12 +15,12 @@
   export let props = {}
   export let children = []
 
-  let prevComponent;
-  let key;
+  let prevComponent
+  let key
   $: {
     if (prevComponent !== component) {
-      key = Date.now();
-      prevComponent = component;
+      key = Date.now()
+      prevComponent = component
     }
   }
 </script>


### PR DESCRIPTION
Fix #1733 
Fix #1621

# Overview

When routing between layouts, Svelte ([v4.1.0 and above](https://github.com/inertiajs/inertia/issues/1621#issuecomment-1775805874)) will not slot in the pages correctly. 

This PR implements additional logic with a key block to guarantee accurate page rendering while maintaining the persistent layouts feature.

# Notes

- I found a PR that includes this fix: https://github.com/inertiajs/inertia/pull/1705
- This issue may be related: https://github.com/inertiajs/inertia/issues/1670