### PR TITLE
Address history back button security issue (full page loads)

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -155,8 +155,21 @@ export class Router {
   }
 
   protected handleBackForwardVisit(page: Page): void {
-    window.history.state.version = page.version
-    this.setPage(window.history.state, { preserveScroll: true, preserveState: true }).then(() => {
+    let currentState
+
+    /* This ensures we give precedence to a fresh state.
+    'page' here holds the props from the latest backend request.
+    This prevents user A logging out and user B seeing sensitive data
+    from user A by going back in the history (shared computer)
+    */
+    if (page.props) {
+      currentState = page
+    } else {
+      window.history.state.version = page.version
+      currentState = window.history.state
+    }
+
+    this.setPage(currentState, { preserveScroll: true, preserveState: true }).then(() => {
       this.restoreScrollPositions()
       fireNavigateEvent(page)
     })


### PR DESCRIPTION
_**Disclaimer:** I'm open to ideas on how to address this in a better way here. This isn't the same as the `popstate` custom handler people have proposed in other issues/PRs._ 

### Summary of the problem

From a security standpoint, there are two situations where Inertia restores `props` from its cache (i.e. `window.history.state`) that are concerning at the moment:

1. **During client-side navigation (e.g. after clicking on an `InertiaLink` component) a user goes back in the browser's history**
  - This relies on the `popstate` API to restore the app's state, has been discussed in a few issues in this project, and it's not what this PR is about. Still warrants attention though.

2. **After full page loads a user goes back in the browser's history**

  - This is what this PR is about

👨‍💻 This is the code affecting behavior related to number 2 from above: https://github.com/inertiajs/inertia/blob/master/packages/core/src/router.ts#L157-L163
- `page` here represents fresh Inertia props. When a backend request is performed, and Inertia props are provided via the rendered HTML, this is what `page` here includes
- `window.history.state` on the other hand represents stale props. This is the state of the Inertia props prior to what `page` contains. 

The issue is that the code is always giving preference to those stale props. Because Inertia props are the bread and butter of Inertia, they often contain sensitive information from the users, information which is cleared when they log out, but because Inertia pulls those from its cache (without any sort of configuration around this behaviour, or without checking if `page`'s props may be fresher) sensitive information may be leaked to third-parties in Inertia apps. 

### Reproducing this problem

_from an Inertia app_
1. User A is logged in and at the path `/foobar`
4. User A signs out and this causes a full `/foobar` page load 
5. User A leaves the shared computer
6. User B goes back in the browser's history
7. User B can see all sensitive information from User A 
