### PR TITLE
Fix: in setPage if no component return empty promise

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -449,6 +449,10 @@ export class Router {
       preserveState?: PreserveStateOption
     } = {},
   ): Promise<void> {
+    if (!page.component) {
+      return Promise.resolve()
+    }
+
     return Promise.resolve(this.resolveComponent(page.component)).then((component) => {
       if (visitId === this.visitId) {
         page.scrollRegions = page.scrollRegions || []


### PR DESCRIPTION
### This PR:
- [x] Resolves #1766

In certain scenarios when the [user is moving back and forth with the browser page data is lost](https://github.com/inertiajs/inertia/blob/master/packages/core/src/router.ts#L159) and [`setPage`](https://github.com/inertiajs/inertia/blob/master/packages/core/src/router.ts#L453) tries to resolve an empty component, resulting in an undefined error being seen. Multiple Interia users have reported this issue and we are experiencing it in our project also (see attached image). [Error is thrown from `laravel-vite-plugin` Intertia helper `resolvePageComponent`](https://github.com/laravel/vite-plugin/blob/1.x/src/inertia-helpers/index.ts#L12), but in general, this shouldn't happen if there is no page. 

`page` object should be typed more strictly, but that is larger effort. 

Also, when debugging I've also noticed that `visitId` is always an empty object, so the [if statement in `then`](https://github.com/inertiajs/inertia/blob/master/packages/core/src/router.ts#L453) always gets executed because `{} === {}`. I've never seen that `visitId` had any meaningful value. 

![image](https://github.com/inertiajs/inertia/assets/1560102/c3e47ab6-bbf8-4096-846c-370090141bb9)
