### PR TITLE
feat: tiny alternatives for `lodash.isequal` and `lodash.clonedeep` -> `just`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2146,6 +2146,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/just-clone": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
+      "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA=="
+    },
+    "node_modules/just-compare": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/just-compare/-/just-compare-2.3.0.tgz",
+      "integrity": "sha512-6shoR7HDT+fzfL3gBahx1jZG3hWLrhPAf+l7nCwahDdT9XDtosB9kIF0ZrzUp5QY8dJWfQVr5rnsPqsbvflDzg=="
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -2217,16 +2227,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
       "dev": true
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -3989,7 +3989,7 @@
       "license": "MIT",
       "dependencies": {
         "@inertiajs/core": "1.0.14",
-        "lodash.isequal": "^4.5.0"
+        "just-compare": "^2.3.0"
       },
       "devDependencies": {
         "@types/react": "^16.9.1",
@@ -4021,8 +4021,8 @@
       "license": "MIT",
       "dependencies": {
         "@inertiajs/core": "1.0.14",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
+        "just-clone": "^6.2.0",
+        "just-compare": "^2.3.0"
       },
       "peerDependencies": {
         "svelte": "^3.20.0 || ^4.0.0"
@@ -4034,8 +4034,8 @@
       "license": "MIT",
       "dependencies": {
         "@inertiajs/core": "1.0.14",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
+        "just-clone": "^6.2.0",
+        "just-compare": "^2.3.0"
       },
       "devDependencies": {
         "esbuild": "^0.16.13",
@@ -4065,8 +4065,8 @@
       "license": "MIT",
       "dependencies": {
         "@inertiajs/core": "1.0.14",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
+        "just-clone": "^6.2.0",
+        "just-compare": "^2.3.0"
       },
       "devDependencies": {
         "esbuild": "^0.16.13",
@@ -4695,7 +4695,7 @@
         "@types/react": "^16.9.1",
         "@types/react-dom": "^16.9.17",
         "esbuild": "^0.16.13",
-        "lodash.isequal": "^4.5.0",
+        "just-compare": "^2.3.0",
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "typescript": "^4.9.4"
       },
@@ -4739,8 +4739,8 @@
       "version": "file:packages/svelte",
       "requires": {
         "@inertiajs/core": "1.0.14",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
+        "just-clone": "^6.2.0",
+        "just-compare": "^2.3.0"
       }
     },
     "@inertiajs/svelte-playground": {
@@ -4763,8 +4763,8 @@
       "requires": {
         "@inertiajs/core": "1.0.14",
         "esbuild": "^0.16.13",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0",
+        "just-clone": "^6.2.0",
+        "just-compare": "^2.3.0",
         "typescript": "^4.9.4",
         "vue": "^2.7.0"
       },
@@ -4799,8 +4799,8 @@
       "requires": {
         "@inertiajs/core": "1.0.14",
         "esbuild": "^0.16.13",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0",
+        "just-clone": "^6.2.0",
+        "just-compare": "^2.3.0",
         "typescript": "^4.9.4",
         "vue": "^3.0.0"
       },
@@ -5972,6 +5972,16 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
+    "just-clone": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
+      "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA=="
+    },
+    "just-compare": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/just-compare/-/just-compare-2.3.0.tgz",
+      "integrity": "sha512-6shoR7HDT+fzfL3gBahx1jZG3hWLrhPAf+l7nCwahDdT9XDtosB9kIF0ZrzUp5QY8dJWfQVr5rnsPqsbvflDzg=="
+    },
     "kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -6025,16 +6035,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
       "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.template": {
       "version": "4.5.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,6 +60,6 @@
   },
   "dependencies": {
     "@inertiajs/core": "1.0.14",
-    "lodash.isequal": "^4.5.0"
+    "just-compare": "^2.3.0"
   }
 }

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -1,5 +1,5 @@
 import { FormDataConvertible, Method, Progress, router, VisitOptions } from '@inertiajs/core'
-import isEqual from 'lodash.isequal'
+import compare from 'just-compare'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import useRemember from './useRemember'
 
@@ -177,7 +177,7 @@ export default function useForm<TForm extends FormDataType>(
         setData(keyOrData as TForm)
       }
     },
-    isDirty: !isEqual(data, defaults),
+    isDirty: !compare(data, defaults),
     errors,
     hasErrors,
     processing,

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@inertiajs/core": "1.0.14",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.isequal": "^4.5.0"
+    "just-clone": "^6.2.0",
+    "just-compare": "^2.3.0"
   }
 }

--- a/packages/svelte/src/useForm.js
+++ b/packages/svelte/src/useForm.js
@@ -1,13 +1,13 @@
 import { router } from '@inertiajs/core'
-import isEqual from 'lodash.isequal'
-import cloneDeep from 'lodash.clonedeep'
+import compare from 'just-compare'
+import clone from 'just-clone'
 import { writable } from 'svelte/store'
 
 function useForm(...args) {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const restored = rememberKey ? router.restore(rememberKey) : null
-  let defaults = cloneDeep(data)
+  let defaults = clone(data)
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = (data) => data
@@ -39,17 +39,17 @@ function useForm(...args) {
     },
     defaults(key, value) {
       if (typeof key === 'undefined') {
-        defaults = Object.assign(defaults, cloneDeep(this.data()))
+        defaults = Object.assign(defaults, clone(this.data()))
 
         return this
       }
 
-      defaults = Object.assign(defaults, cloneDeep(value ? { [key]: value } : key))
+      defaults = Object.assign(defaults, clone(value ? { [key]: value } : key))
 
       return this
     },
     reset(...fields) {
-      let clonedDefaults = cloneDeep(defaults)
+      let clonedDefaults = clone(defaults)
       if (fields.length === 0) {
         this.setStore(clonedDefaults)
       } else {
@@ -190,7 +190,7 @@ function useForm(...args) {
   })
 
   store.subscribe((form) => {
-    if (form.isDirty === isEqual(form.data(), defaults)) {
+    if (form.isDirty === compare(form.data(), defaults)) {
       form.setStore('isDirty', !form.isDirty)
     }
 

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@inertiajs/core": "1.0.14",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.isequal": "^4.5.0"
+    "just-clone": "^6.2.0",
+    "just-compare": "^2.3.0"
   }
 }

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -1,6 +1,6 @@
 import { FormDataConvertible, Method, Progress, router, VisitOptions } from '@inertiajs/core'
-import cloneDeep from 'lodash.clonedeep'
-import isEqual from 'lodash.isequal'
+import clone from 'just-clone'
+import compare from 'just-compare'
 import { reactive, watch } from 'vue'
 
 type FormDataType = object;
@@ -44,13 +44,13 @@ export default function useForm<TForm extends FormDataType>(...args): InertiaFor
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const restored = rememberKey ? (router.restore(rememberKey) as { data: any; errors: any }) : null
-  let defaults = typeof data === 'object' ? cloneDeep(data) : cloneDeep(data())
+  let defaults = typeof data === 'object' ? clone(data) : clone(data())
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = (data) => data
 
   const form = reactive({
-    ...(restored ? restored.data : cloneDeep(defaults)),
+    ...(restored ? restored.data : clone(defaults)),
     isDirty: false,
     errors: restored ? restored.errors : {},
     hasErrors: false,
@@ -77,14 +77,14 @@ export default function useForm<TForm extends FormDataType>(...args): InertiaFor
       if (typeof key === 'undefined') {
         defaults = this.data()
       } else {
-        defaults = Object.assign({}, cloneDeep(defaults), value ? { [key]: value } : key)
+        defaults = Object.assign({}, clone(defaults), value ? { [key]: value } : key)
       }
 
       return this
     },
     reset(...fields) {
-      const resolvedData = typeof data === 'object' ? cloneDeep(defaults) : cloneDeep(data())
-      const clonedData = cloneDeep(resolvedData)
+      const resolvedData = typeof data === 'object' ? clone(defaults) : clone(data())
+      const clonedData = clone(resolvedData)
       if (fields.length === 0) {
         defaults = clonedData
         Object.assign(this, resolvedData)
@@ -162,7 +162,7 @@ export default function useForm<TForm extends FormDataType>(...args): InertiaFor
           recentlySuccessfulTimeoutId = setTimeout(() => (this.recentlySuccessful = false), 2000)
 
           const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
-          defaults = cloneDeep(this.data())
+          defaults = clone(this.data())
           this.isDirty = false
           return onSuccess
         },
@@ -233,9 +233,9 @@ export default function useForm<TForm extends FormDataType>(...args): InertiaFor
   watch(
     form,
     (newValue) => {
-      form.isDirty = !isEqual(form.data(), defaults)
+      form.isDirty = !compare(form.data(), defaults)
       if (rememberKey) {
-        router.remember(cloneDeep(newValue.__remember()), rememberKey)
+        router.remember(clone(newValue.__remember()), rememberKey)
       }
     },
     { immediate: true, deep: true },

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@inertiajs/core": "1.0.14",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.isequal": "^4.5.0"
+    "just-clone": "^6.2.0",
+    "just-compare": "^2.3.0"
   }
 }

--- a/packages/vue3/src/remember.ts
+++ b/packages/vue3/src/remember.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import cloneDeep from 'lodash.clonedeep'
+import clone from 'just-clone'
 import { ComponentOptions } from 'vue'
 
 const remember: ComponentOptions = {
@@ -52,7 +52,7 @@ const remember: ComponentOptions = {
             rememberable.reduce(
               (data, key) => ({
                 ...data,
-                [key]: cloneDeep(hasCallbacks(key) ? this[key].__remember() : this[key]),
+                [key]: clone(hasCallbacks(key) ? this[key].__remember() : this[key]),
               }),
               {},
             ),

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -1,6 +1,6 @@
 import { FormDataConvertible, Method, Progress, router, VisitOptions } from '@inertiajs/core'
-import cloneDeep from 'lodash.clonedeep'
-import isEqual from 'lodash.isequal'
+import clone from 'just-clone'
+import compare from 'just-compare'
 import { reactive, watch } from 'vue'
 
 type FormDataType = object;
@@ -47,13 +47,13 @@ export default function useForm<TForm extends FormDataType>(
   const restored = rememberKey
     ? (router.restore(rememberKey) as { data: TForm; errors: Record<keyof TForm, string> })
     : null
-  let defaults = typeof data === 'object' ? cloneDeep(data) : cloneDeep(data())
+  let defaults = typeof data === 'object' ? clone(data) : clone(data())
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = (data) => data
 
   const form = reactive({
-    ...(restored ? restored.data : cloneDeep(defaults)),
+    ...(restored ? restored.data : clone(defaults)),
     isDirty: false,
     errors: restored ? restored.errors : {},
     hasErrors: false,
@@ -82,7 +82,7 @@ export default function useForm<TForm extends FormDataType>(
       } else {
         defaults = Object.assign(
           {},
-          cloneDeep(defaults),
+          clone(defaults),
           typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields,
         )
       }
@@ -90,8 +90,8 @@ export default function useForm<TForm extends FormDataType>(
       return this
     },
     reset(...fields) {
-      const resolvedData = typeof data === 'object' ? cloneDeep(defaults) : cloneDeep(data())
-      const clonedData = cloneDeep(resolvedData)
+      const resolvedData = typeof data === 'object' ? clone(defaults) : clone(data())
+      const clonedData = clone(resolvedData)
       if (fields.length === 0) {
         defaults = clonedData
         Object.assign(this, resolvedData)
@@ -169,7 +169,7 @@ export default function useForm<TForm extends FormDataType>(
           recentlySuccessfulTimeoutId = setTimeout(() => (this.recentlySuccessful = false), 2000)
 
           const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
-          defaults = cloneDeep(this.data())
+          defaults = clone(this.data())
           this.isDirty = false
           return onSuccess
         },
@@ -240,9 +240,9 @@ export default function useForm<TForm extends FormDataType>(
   watch(
     form,
     (newValue) => {
-      form.isDirty = !isEqual(form.data(), defaults)
+      form.isDirty = !compare(form.data(), defaults)
       if (rememberKey) {
-        router.remember(cloneDeep(newValue.__remember()), rememberKey)
+        router.remember(clone(newValue.__remember()), rememberKey)
       }
     },
     { immediate: true, deep: true },

--- a/packages/vue3/src/useRemember.ts
+++ b/packages/vue3/src/useRemember.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import cloneDeep from 'lodash.clonedeep'
+import clone from 'just-clone'
 import { isReactive, reactive, ref, Ref, watch } from 'vue'
 
 export default function useRemember<T extends object>(
@@ -18,7 +18,7 @@ export default function useRemember<T extends object>(
   watch(
     remembered,
     (newValue) => {
-      router.remember(cloneDeep(hasCallbacks ? data.__remember() : newValue), key)
+      router.remember(clone(hasCallbacks ? data.__remember() : newValue), key)
     },
     { immediate: true, deep: true },
   )


### PR DESCRIPTION
Hi @reinink 

The purpose of this PR is to reduce the size of `inertiajs`.

If we check the size of [@inertiajs/inertia-vue3](https://bundlephobia.com/package/@inertiajs/inertia-vue3@0.6.0)

**75%**  - belongs to `lodash.isequal` (**3.8kB** min + gzip) and `lodash.clonedeep` (**3.3kB** min + gzip)

![image](https://github.com/inertiajs/inertia/assets/3294939/04631249-91a0-4b9a-83c9-c3ef0670782e)

In this **PR**:

`lodash.isequal` is replaced by [just-compare](https://github.com/angus-c/just?tab=readme-ov-file#just-compare) (**419B** min + gzip)
`lodash.clonedeep` is replaced by [just-clone](https://github.com/angus-c/just?tab=readme-ov-file#just-clone) (**410B** min + gzip)


**Note**: I have a custom build of `inertia/vue3` with these 2 libraries and didn't had any issues so far.

**Differences with Lodash**:
`lodash.clonedeep` - `Lodash` can merge circular references, `just-clone` only merges plain objects, regular arrays, functions and primitives `Lodash` merges additional non-plain object types, `Lodash` treats sparse arrays as dense