### PR TITLE
[1.x] Fix a bug with [scroll-region] elements not restoring correct scroll positions in react adapter

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -136,7 +136,9 @@ export class Router {
 
   protected restoreScrollPositions(): void {
     if (this.page.scrollRegions) {
-      this.scrollRegions().forEach((region: Element, index: number) => {
+      // Similar to the above, we're using setTimeout to fix a bug in the React adapter where
+      // the rendering isn't fast enough, causing incorrect scroll positions in [scroll-region] elements.
+      setTimeout(() => this.scrollRegions().forEach((region: Element, index: number) => {
         const scrollPosition = this.page.scrollRegions[index]
         if (!scrollPosition) {
           return
@@ -146,7 +148,7 @@ export class Router {
           region.scrollTop = scrollPosition.top
           region.scrollLeft = scrollPosition.left
         }
-      })
+      }))
     }
   }
 


### PR DESCRIPTION
Hi, I'm using react and I run into a bug where I have a [scroll-region] element and after navigating back, the scroll position is not restored, even though the page has saved the positions correctly.

This happens because in the `restoreScrollPositions` method `this.scrollRegions()` returns an empty array. It thinks that there aren't any [scroll-region] elements, because the document body hasn't been updated yet. Even though there actually is an element. Simply wrapping the whole thing in `setTimeout` fixes it and positions are restored correctly. 