### PR TITLE
[1.x] Fix a flash of scrolling-to-top on page changes by using `useLayoutEffect`

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -120,22 +120,22 @@ export class Router {
     })
   }
 
-  public resetScrollPositions(): void {
-      window.scrollTo(0, 0)
-      this.scrollRegions().forEach((region) => {
-        if (typeof region.scrollTo === 'function') {
-          region.scrollTo(0, 0)
-        } else {
-          region.scrollTop = 0
-          region.scrollLeft = 0
-        }
-      })
-      this.saveScrollPositions()
-      if (window.location.hash) {
-        // We're using a setTimeout() here as a workaround for a bug in the React adapter where the
-        // rendering isn't completing fast enough, causing the anchor link to not be scrolled to.
-        setTimeout(() => document.getElementById(window.location.hash.slice(1))?.scrollIntoView())
+  protected resetScrollPositions(): void {
+    window.scrollTo(0, 0)
+    this.scrollRegions().forEach((region) => {
+      if (typeof region.scrollTo === 'function') {
+        region.scrollTo(0, 0)
+      } else {
+        region.scrollTop = 0
+        region.scrollLeft = 0
       }
+    })
+    this.saveScrollPositions()
+    if (window.location.hash) {
+      // We're using a setTimeout() here as a workaround for a bug in the React adapter where the
+      // rendering isn't completing fast enough, causing the anchor link to not be scrolled to.
+      setTimeout(() => document.getElementById(window.location.hash.slice(1))?.scrollIntoView())
+    }
   }
 
   protected resetScrollPositionsIfNotHandledExternally(): void {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -120,7 +120,7 @@ export class Router {
     })
   }
 
-  protected resetScrollPositions(): void {
+  public resetScrollPositions(): void {
     window.scrollTo(0, 0)
     this.scrollRegions().forEach((region) => {
       if (typeof region.scrollTo === 'function') {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -506,7 +506,7 @@ export class Router {
       const url = hrefToUrl(this.page.url)
       url.hash = window.location.hash
       this.replaceState({ ...this.page, url: url.href })
-      this.resetScrollPositionsIfNotHandledExternally()
+      this.resetScrollPositions()
     }
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,10 +49,12 @@ export type PageHandler = ({
   component,
   page,
   preserveState,
+  preserveScroll,
 }: {
   component: Component
   page: Page
   preserveState: PreserveStateOption
+  preserveScroll: PreserveStateOption
 }) => Promise<unknown>
 
 export type PreserveStateOption = boolean | string | ((page: Page) => boolean)

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -1,5 +1,5 @@
 import { createHeadManager, router } from '@inertiajs/core'
-import { createElement, useEffect, useMemo, useState } from 'react'
+import { createElement, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import HeadContext from './HeadContext'
 import PageContext from './PageContext'
 
@@ -15,6 +15,7 @@ export default function App({
     component: initialComponent || null,
     page: initialPage,
     key: null,
+    preserveScroll: false,
   })
 
   const headManager = useMemo(() => {
@@ -25,17 +26,25 @@ export default function App({
     )
   }, [])
 
+  useLayoutEffect(() => {
+    if (!current.preserveScroll) {
+      router.resetScrollPositions()
+    }
+  }, [current])
+
   useEffect(() => {
     router.init({
       initialPage,
       resolveComponent,
-      swapComponent: async ({ component, page, preserveState }) => {
+      swapComponent: async ({ component, page, preserveState, preserveScroll }) => {
         setCurrent((current) => ({
           component,
           page,
           key: preserveState ? current.key : Date.now(),
+          preserveScroll: !!preserveScroll,
         }))
       },
+      handleScrollResetExternally: true,
     })
 
     router.on('navigate', () => headManager.forceUpdate())

--- a/playgrounds/react/resources/js/Components/Layout.tsx
+++ b/playgrounds/react/resources/js/Components/Layout.tsx
@@ -5,7 +5,7 @@ export default function Layout({ children }) {
 
   return (
     <>
-      <nav className="flex items-center space-x-6 bg-slate-800 px-10 py-6 text-white">
+      <nav className="sticky top-0 flex w-full items-center space-x-6 bg-slate-800 px-10 py-6 text-white">
         <div className="rounded-lg bg-slate-700 px-4 py-1">{appName}</div>
         <Link href="/" className="hover:underline">
           Home

--- a/playgrounds/react/resources/js/Components/Layout.tsx
+++ b/playgrounds/react/resources/js/Components/Layout.tsx
@@ -5,7 +5,7 @@ export default function Layout({ children }) {
 
   return (
     <>
-      <nav className="sticky top-0 flex w-full items-center space-x-6 bg-slate-800 px-10 py-6 text-white">
+      <nav className="sticky top-0 flex items-center space-x-6 bg-slate-800 px-10 py-6 text-white">
         <div className="rounded-lg bg-slate-700 px-4 py-1">{appName}</div>
         <Link href="/" className="hover:underline">
           Home


### PR DESCRIPTION
This is my (attempted) fix for https://github.com/inertiajs/inertia/issues/1802. I outlined the issue in detail there but tl;dr:

- Inertia/React creates a race condition when changing pages, where resetting the scroll position to (0,0) often happens an instant before the page component itself changes to the next page
- This creates a flash of unexpected content when you'll scrolled down a page and click a `<Link>`.

A huge caveat to all of this is that I'm brand new to Inertia as a user, let alone looking at this codebase, so please take anything I suggest with a grain of salt. 

Based on how [Remix/React-router handle this successfully](https://github.com/remix-run/react-router/blob/5d475a2af140fee92a8a49f0e40d683087aa2b78/packages/react-router-dom/index.tsx#L1842) with a `useLayoutEffect`, I've slightly adapted a few things:

1. each framework package (react/vue/etc) can now specific in it's `router.init` whether it will handle resetting scroll position itself (vs letting the router core decide when to do it)
2. the `swapComponent` callback within `router.init` now passes a new argument, `preserveScroll`, similar to how it passes `preserveState`. This and (1) mean React has the information needed to manage scroll resetting in it's own render lifecycle
3. `router.resetScrollPositions()` is now public
4. Existing calls to `router.resetScrollPositions()` adjacent to the `swapComponent` call have been replaced with `router.resetScrollPositionsIfNotHandledExternally()` -- which just does nothing if the `handleScrollResetsExternally` flag is set by the framework package. Other calls to `router.resetScrollPositions()` weren't changed as they don't interact with the `swapComponent` function and don't seem to suffer the same issue


I've also updated the React playground with a `sticky` header so that the fix can be validated there as well.

Testing so far:
1. Tested the fix in the playground ✅
2. Linked the rebuild inertia into my own app, and the more aggressive flashes are gone ✅
3. Ensured that `preserveScroll` still works on `Link` and `Router` calls ✅