### PR TITLE
Fix svelte 4 warning for ARIA role

### DIFF
--- a/packages/svelte/src/Link.svelte
+++ b/packages/svelte/src/Link.svelte
@@ -12,6 +12,8 @@
   export let only = []
   export let headers = {}
   export let queryStringArrayFormat = 'brackets'
+  export let role = 'link'
+  export let tabIndex = 0
 
   beforeUpdate(() => {
     if (as === 'a' && method.toLowerCase() !== 'get') {
@@ -36,6 +38,7 @@
     queryStringArrayFormat,
   }}
   {...as === 'a' ? { href } : {}}
+  {...(as !== 'a' && as !== 'button' ? { role, tabIndex } : { tabIndex })}
   {...$$restProps}
   on:focus
   on:blur


### PR DESCRIPTION
#1627

If as is neither `'a'` nor `'button'`, it spreads the `{ role, tabindex }` object.
if role is `'button'`, it won't be included as an attribute on the element, ensuring that the correct role is applied based on the element type specified by the as variable.