### PR TITLE
Allow progress bar to be disabled per request

### DIFF
--- a/packages/core/src/progress.ts
+++ b/packages/core/src/progress.ts
@@ -9,8 +9,10 @@ function addEventListeners(delay: number): void {
   document.addEventListener('inertia:finish', finish)
 }
 
-function start(delay: number): void {
-  timeout = setTimeout(() => NProgress.start(), delay)
+function start(delay: number, event: GlobalEvent<'start'>): void {
+  if (event.detail.visit.showProgress) {
+    timeout = setTimeout(() => NProgress.start(), delay)
+  }
 }
 
 function progress(event: GlobalEvent<'progress'>) {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -272,6 +272,7 @@ export class Router {
       onSuccess = () => {},
       onError = () => {},
       queryStringArrayFormat = 'brackets',
+      showProgress = true,
     }: VisitOptions = {},
   ): void {
     let url = typeof href === 'string' ? hrefToUrl(href) : href
@@ -298,6 +299,7 @@ export class Router {
       errorBag,
       forceFormData,
       queryStringArrayFormat,
+      showProgress,
       cancelled: false,
       completed: false,
       interrupted: false,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -74,6 +74,7 @@ export type Visit = {
   errorBag: string | null
   forceFormData: boolean
   queryStringArrayFormat: 'indices' | 'brackets'
+  showProgress: boolean
 }
 
 export type GlobalEventsMap = {


### PR DESCRIPTION
Very simple change to allow users to disable the progress bar on a per request basis.

Seems like demand is fairly high from https://github.com/inertiajs/inertia/discussions/124, and I've had the use case multiple times at work too.

Example use case, for a specific form submission (in our case, last step in our signup) we wanted to show a dedicated loading page and want to disable the top loading bar for that request only.
We've had other examples like reloading some props from a websocket event trigger etc..