### PR TITLE
Fix accessibility warning in Svelte `Link` component

### DIFF
--- a/packages/svelte/src/Link.svelte
+++ b/packages/svelte/src/Link.svelte
@@ -22,6 +22,7 @@
   })
 </script>
 
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <svelte:element
   this={as}
   use:inertia={{


### PR DESCRIPTION
Resolves #1627
Resolves #1635
Resolves #1835

Right now the Svelte adapter is throwing an ARIA warning during build:

```
Link.svelte:27:0 A11y: <svelte:element> with click, dblclick, mousedown, mousemove, mouseout, mouseover, mouseup handlers must have an ARIA role
```

While a couple possible solutions have been shared (#1635, #1835), I am pretty sure that this is actually a false positive and a good use case for a `svelte-ignore` comment, so that's what I've implemented here.