### PR TITLE
[React] Use updater function in `setData` in `useForm` hook

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -170,7 +170,7 @@ export default function useForm<TForm extends FormDataType>(
     data,
     setData(keyOrData: keyof TForm | Function | TForm, maybeValue?: TForm[keyof TForm]) {
       if (typeof keyOrData === 'string') {
-        setData({ ...data, [keyOrData]: maybeValue })
+        setData((data) => ({ ...data, [keyOrData]: maybeValue }))
       } else if (typeof keyOrData === 'function') {
         setData((data) => keyOrData(data))
       } else {


### PR DESCRIPTION
This is a proposal for changing the ergonomics of the key-value variant for the `setData` hook in React.

### Current behaviour

Using this simple form as an example:

```ts
const form = useForm({
    name: 'Alice',
    lastname: 'Doe',
})
```

It is expected that sequential calls to `setData` will update the form data accordingly. However, subsequent calls overwrite the changes made by the previous calls.

```ts
form.setData('name', 'Bob') // { name: 'Bob', lastname: 'Doe'}
form.setData('lastname', 'Smith') // { name: 'Alice', lastname: 'Smith'}
```

### Desired behaviour

Sequential `setData` calls use an updater function to batch the changes from multiple calls.

```ts
form.setData('name', 'Bob') // { name: 'Bob', lastname: 'Doe'}
form.setData('lastname', 'Smith') // { name: 'Bob', lastname: 'Smith'}
```

---

This can be achieved using [updater functions](https://react.dev/reference/react/useState#updating-state-based-on-the-previous-state) for the [set functions](https://react.dev/reference/react/useState#setstate) in React. From [React documentation](https://react.dev/reference/react/useState#updating-state-based-on-the-previous-state):

> **Is using an updater always preferred?**
>
> In most cases, there is no difference between these two approaches.
>
> However, if you do multiple updates within the same event, updaters can be helpful.
>
> If you prefer consistency over slightly more verbose syntax, it’s reasonable to always write an updater if the state you’re setting is calculated from the previous state.


It is worth noting that this only affects the key-value variant of the `setData` function, and if anyone is impacted by this change, they can switch to the object variant of the `setData` function.