### PR TITLE
feat: Add `preserveUrl` option.

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -163,9 +163,9 @@ export class Router {
     })
   }
 
-  protected locationVisit(url: URL, preserveScroll: LocationVisit['preserveScroll']): boolean | void {
+  protected locationVisit(url: URL, preserveScroll: LocationVisit['preserveScroll'], preserveUrl: LocationVisit['preserveUrl']): boolean | void {
     try {
-      const locationVisit: LocationVisit = { preserveScroll }
+      const locationVisit: LocationVisit = { preserveScroll, preserveUrl }
       window.sessionStorage.setItem('inertiaLocationVisit', JSON.stringify(locationVisit))
       window.location.href = url.href
       if (urlWithoutHash(window.location).href === urlWithoutHash(url).href) {
@@ -190,7 +190,11 @@ export class Router {
     page.url += window.location.hash
     page.rememberedState = window.history.state?.rememberedState ?? {}
     page.scrollRegions = window.history.state?.scrollRegions ?? []
-    this.setPage(page, { preserveScroll: locationVisit.preserveScroll, preserveState: true }).then(() => {
+    this.setPage(page, {
+      preserveScroll: locationVisit.preserveScroll,
+      preserveUrl: locationVisit.preserveUrl,
+      preserveState: true,
+    }).then(() => {
       if (locationVisit.preserveScroll) {
         this.restoreScrollPositions()
       }
@@ -260,6 +264,7 @@ export class Router {
       replace = false,
       preserveScroll = false,
       preserveState = false,
+      preserveUrl = false,
       only = [],
       except = [],
       headers = {},
@@ -295,6 +300,7 @@ export class Router {
       replace,
       preserveScroll,
       preserveState,
+      preserveUrl,
       only,
       except,
       headers,
@@ -394,6 +400,7 @@ export class Router {
         }
         preserveScroll = this.resolvePreserveOption(preserveScroll, pageResponse) as boolean
         preserveState = this.resolvePreserveOption(preserveState, pageResponse)
+        preserveUrl = this.resolvePreserveOption(preserveUrl, pageResponse) as boolean
         if (preserveState && window.history.state?.rememberedState && pageResponse.component === this.page.component) {
           pageResponse.rememberedState = window.history.state.rememberedState
         }
@@ -424,7 +431,7 @@ export class Router {
           if (requestUrl.hash && !locationUrl.hash && urlWithoutHash(requestUrl).href === locationUrl.href) {
             locationUrl.hash = requestUrl.hash
           }
-          this.locationVisit(locationUrl, preserveScroll === true)
+          this.locationVisit(locationUrl, preserveScroll === true, preserveUrl === true)
         } else if (error.response) {
           if (fireInvalidEvent(error.response)) {
             modal.show(error.response.data)
@@ -458,11 +465,13 @@ export class Router {
       replace = false,
       preserveScroll = false,
       preserveState = false,
+      preserveUrl = false,
     }: {
       visitId?: VisitId
       replace?: boolean
       preserveScroll?: PreserveStateOption
       preserveState?: PreserveStateOption
+      preserveUrl?: PreserveStateOption
     } = {},
   ): Promise<void> {
     return Promise.resolve(this.resolveComponent(page.component)).then((component) => {
@@ -470,7 +479,13 @@ export class Router {
         page.scrollRegions = page.scrollRegions || []
         page.rememberedState = page.rememberedState || {}
         replace = replace || hrefToUrl(page.url).href === window.location.href
+
+        if (preserveUrl) {
+          page.url = window.location.href
+        }
+
         replace ? this.replaceState(page) : this.pushState(page)
+
         this.swapComponent({ component, page, preserveState }).then(() => {
           if (!preserveScroll) {
             this.resetScrollPositions()

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,6 +61,7 @@ export type Progress = AxiosProgressEvent
 
 export type LocationVisit = {
   preserveScroll: boolean
+  preserveUrl: boolean
 }
 
 export type Visit = {
@@ -69,6 +70,7 @@ export type Visit = {
   replace: boolean
   preserveScroll: PreserveStateOption
   preserveState: PreserveStateOption
+  preserveUrl: PreserveStateOption
   only: Array<string>
   except: Array<string>
   headers: Record<string, string>

--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -20,6 +20,7 @@ interface BaseInertiaLinkProps {
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
   preserveScroll?: PreserveStateOption
   preserveState?: PreserveStateOption
+  preserveUrl?: PreserveStateOption
   replace?: boolean
   only?: string[]
   except?: string[]
@@ -48,6 +49,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
       method = 'get',
       preserveScroll = false,
       preserveState = null,
+      preserveUrl = false,
       replace = false,
       only = [],
       except = [],
@@ -78,6 +80,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
             method,
             preserveScroll,
             preserveState: preserveState ?? method !== 'get',
+            preserveUrl,
             replace,
             only,
             except,
@@ -99,6 +102,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
         method,
         preserveScroll,
         preserveState,
+        preserveUrl,
         replace,
         only,
         except,

--- a/packages/vue2/src/link.ts
+++ b/packages/vue2/src/link.ts
@@ -18,6 +18,7 @@ export interface InertiaLinkProps {
   onClick?: (event: MouseEvent) => void
   preserveScroll?: PreserveStateOption
   preserveState?: PreserveStateOption
+  preserveUrl?: PreserveStateOption
   replace?: boolean
   only?: string[]
   except?: string[]
@@ -62,6 +63,10 @@ const Link: InertiaLink = {
     preserveState: {
       type: Boolean,
       default: null,
+    },
+    preserveUrl: {
+      type: Boolean,
+      default: false,
     },
     only: {
       type: Array,
@@ -131,6 +136,7 @@ const Link: InertiaLink = {
                 replace: props.replace,
                 preserveScroll: props.preserveScroll,
                 preserveState: props.preserveState ?? method !== 'get',
+                preserveUrl: props.preserveUrl,
                 only: props.only,
                 except: props.except,
                 headers: props.headers,

--- a/packages/vue2/tests/app/Pages/Visits/PreserveUrl.vue
+++ b/packages/vue2/tests/app/Pages/Visits/PreserveUrl.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <span @click="preserve" class="preserve">Preserve Url</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    preserve() {
+      this.$inertia.get('/visits/preserve-url?page=2', {}, {
+        preserveUrl: true,
+      })
+    },
+  }
+}
+</script>

--- a/packages/vue2/tests/app/server.js
+++ b/packages/vue2/tests/app/server.js
@@ -97,6 +97,9 @@ app.get('/visits/headers/version', (req, res) =>
   inertia.render(req, res, { component: 'Visits/Headers', version: 'example-version-header' }),
 )
 
+app.all('/visits/preserve-url', (req, res) =>
+  inertia.render(req, res, { component: 'Visits/PreserveUrl' }))
+
 app.post('/remember/form-helper/default', (req, res) =>
   inertia.render(req, res, {
     component: 'Remember/FormHelper/Default',

--- a/packages/vue2/tests/cypress/integration/manual-visits.test.js
+++ b/packages/vue2/tests/cypress/integration/manual-visits.test.js
@@ -1209,6 +1209,15 @@ describe('Manual Visits', () => {
     })
   })
 
+  describe('Preserve url', () => {
+    it('does preserves the url if the perserveUrl flag is passed', () => {
+      cy.visit('/visits/preserve-url')
+
+      cy.get('.preserve').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-url')
+    });
+  })
+
   describe('URL fragment navigation (& automatic scrolling)', () => {
     /** @see https://github.com/inertiajs/inertia/pull/257 */
 

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -10,6 +10,7 @@ export interface InertiaLinkProps {
   onClick?: (event: MouseEvent) => void
   preserveScroll?: boolean | ((props: PageProps) => boolean)
   preserveState?: boolean | ((props: PageProps) => boolean) | null
+  preserveUrl?: boolean | ((props: PageProps) => boolean)
   replace?: boolean
   only?: string[]
   except?: string[]
@@ -56,6 +57,10 @@ const Link: InertiaLink = defineComponent({
       type: Boolean,
       default: null,
     },
+    preserveUrl: {
+      type: Boolean,
+      default: false,
+    },
     only: {
       type: Array<string>,
       default: () => [],
@@ -100,6 +105,7 @@ const Link: InertiaLink = defineComponent({
                 replace: props.replace,
                 preserveScroll: props.preserveScroll,
                 preserveState: props.preserveState ?? method !== 'get',
+                preserveUrl: props.preserveUrl,
                 only: props.only,
                 except: props.except,
                 headers: props.headers,


### PR DESCRIPTION
This PR adds an option to preserve the current url. 

This is specially useful when there is an **infinite scroll pagination**.

## Before

To the infinite scrolls using Inertia we had to do something similar to this:

```js
const allPosts = ref(props.posts.data);
const nextPageUrl = ref(props.posts.next_page_url || null);
const loading = ref(false);

const load = () => {
    if (nextPageUrl.value === null) {
        return;
    }

    loading.value = true;
    axios.get(nextPageUrl.value, {
        headers: {
            'X-Inertia': true,
            'X-Inertia-Partial-Component': 'Posts/Index',
            'X-Inertia-Partial-Data': 'posts',
            'X-Requested-With': 'XMLHttpRequest',
            'X-Inertia-Version': usePage().version,
        },
    }).then(({ data }) => {
        nextPageUrl.value = data.props.posts.next_page_url;
        allPosts.value.push(...data.props.posts.data);
        loading.value = false;
    }).catch(() => {
        loading.value = false;
        router.get(nextPageUrl.value);
    })
}

let observer;

onMounted(() => {
    observer = new IntersectionObserver(
        entries => entries.forEach(entry => entry.isIntersecting && load()),
    );

    observer.observe(document.querySelector('footer'));
});
```

## After

This this addiction, we can take advantage of the `preserveUrl` option, and pass it on the `router.get` method, like this:

```js
const allPosts = ref(props.posts.data);

const load = () => {
    if (props.posts.next_page_url === null) {
        return;
    }

    router.get(props.posts.next_page_url, {}, {
        preserveState: true,
        preserveScroll: true,
        preserveUrl: true,
        only: ['posts'],
        onSuccess: () => allPosts.value.push(...props.posts.data)
    })
}

onMounted(() => {
    observer = new IntersectionObserver(
        entries => entries.forEach(entry => entry.isIntersecting && load()),
    );

    observer.observe(document.querySelector('footer'));
});
```

Without the `preserveUrl` it adds the `?page=2` to the url and if the user refreshes the page it will just show the `page=2` content instead of both pages.

Let me know what you guys think about this feature.

Thanks,
Francisco.