### PR TITLE
Migrate Vue 2 EOL integration tests to Vue 3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        adapter: ['vue2']
+        adapter: ['vue3']
         browser: ['chrome']
 
     steps:
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 16.15
+          node-version: 20
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -27,13 +27,13 @@ jobs:
           path: |
             ~/.cache
             node_modules
-            packages/vue2/tests/node_modules
+            packages/vue3/tests/node_modules
 
       - name: Build Inertia
         run: |
           npm install
           cd packages/core && npm run build
-          cd ../vue2 && npm run build
+          cd ../vue3 && npm run build
 
       - name: Local-link @inertiajs/core
         run: cd packages/core && npm link

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.DS_Store
 node_modules

--- a/packages/vue3/.npmignore
+++ b/packages/vue3/.npmignore
@@ -1,0 +1,4 @@
+tests
+package-lock.json
+yarn.lock
+.gitignore

--- a/packages/vue3/tests/.eslintrc.js
+++ b/packages/vue3/tests/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  env: {
+    browser: true,
+    es6: true,
+  },
+  extends: ['plugin:cypress/recommended'],
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+  rules: {
+    indent: ['error', 2],
+    quotes: ['warn', 'single'],
+    semi: ['warn', 'never'],
+    'comma-dangle': ['warn', 'always-multiline'],
+    'cypress/no-unnecessary-waiting': 'off',
+  },
+}

--- a/packages/vue3/tests/.gitignore
+++ b/packages/vue3/tests/.gitignore
@@ -1,0 +1,4 @@
+cypress/videos
+cypress/screenshots
+app/dist
+node_modules

--- a/packages/vue3/tests/app/Layouts/NestedLayout.vue
+++ b/packages/vue3/tests/app/Layouts/NestedLayout.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <span>Nested Layout</span>
+    <span>{{ createdAt }}</span>
+    <div>
+      <slot />
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    createdAt: null,
+  }),
+  created() {
+    this.createdAt = Date.now()
+    window._inertia_nested_layout_props = this.$.vnode.props
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Layouts/SiteLayout.vue
+++ b/packages/vue3/tests/app/Layouts/SiteLayout.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <span>Site Layout</span>
+    <span>{{ createdAt }}</span>
+    <div>
+      <slot />
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    createdAt: null,
+  }),
+  created() {
+    this.createdAt = Date.now()
+    window._inertia_site_layout_props = this.$.vnode.props
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Layouts/WithScrollRegion.vue
+++ b/packages/vue3/tests/app/Layouts/WithScrollRegion.vue
@@ -1,0 +1,36 @@
+<template>
+  <div style="width: 200vw">
+    <span class="layout-text">With scroll regions</span>
+    <div class="document-position">Document scroll position is {{ documentScrollLeft }} & {{ documentScrollTop }}</div>
+    <div style="height: 200vh">
+      <span class="slot-position">Slot scroll position is {{ slotScrollLeft }} & {{ slotScrollTop }}</span>
+      <div scroll-region id="slot" style="height: 100px; width: 500px; overflow: scroll" @scroll="handleScrollEvent">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    documentScrollTop: 0,
+    documentScrollLeft: 0,
+    slotScrollTop: 0,
+    slotScrollLeft: 0,
+  }),
+  created() {
+    document.addEventListener('scroll', this.handleScrollEvent)
+  },
+  beforeDestroy() {
+    document.removeEventListener('scroll', this.handleScrollEvent)
+  },
+  methods: {
+    handleScrollEvent() {
+      this.documentScrollTop = document.documentElement.scrollTop
+      this.documentScrollLeft = document.documentElement.scrollLeft
+      this.slotScrollTop = document.getElementById('slot').scrollTop
+      this.slotScrollLeft = document.getElementById('slot').scrollLeft
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Layouts/WithoutScrollRegion.vue
+++ b/packages/vue3/tests/app/Layouts/WithoutScrollRegion.vue
@@ -1,0 +1,36 @@
+<template>
+  <div style="width: 200vw">
+    <span class="layout-text">Without scroll regions</span>
+    <div class="document-position">Document scroll position is {{ documentScrollLeft }} & {{ documentScrollTop }}</div>
+    <div style="height: 200vh">
+      <span class="slot-position">Slot scroll position is {{ slotScrollLeft }} & {{ slotScrollTop }}</span>
+      <div id="slot" style="height: 100px; width: 500px; overflow: scroll" @scroll="handleScrollEvent">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    documentScrollTop: 0,
+    documentScrollLeft: 0,
+    slotScrollTop: 0,
+    slotScrollLeft: 0,
+  }),
+  created() {
+    document.addEventListener('scroll', this.handleScrollEvent)
+  },
+  beforeDestroy() {
+    document.removeEventListener('scroll', this.handleScrollEvent)
+  },
+  methods: {
+    handleScrollEvent() {
+      this.documentScrollTop = document.documentElement.scrollTop
+      this.documentScrollLeft = document.documentElement.scrollLeft
+      this.slotScrollTop = document.getElementById('slot').scrollTop
+      this.slotScrollLeft = document.getElementById('slot').scrollLeft
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Dump.vue
+++ b/packages/vue3/tests/app/Pages/Dump.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <div class="text">This is Inertia page component containing a data dump of the request</div>
+    <hr />
+    <pre class="dump">{{ dump }}</pre>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    headers: Object,
+    method: String,
+    form: Object,
+    files: Array,
+    query: Object,
+  },
+  computed: {
+    dump() {
+      return {
+        headers: this.headers,
+        method: this.method,
+        form: this.form,
+        files: this.files ? this.files : {},
+        query: this.query,
+        $page: this.$page,
+      }
+    },
+  },
+  created() {
+    window._inertia_request_dump = this.dump
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/ErrorModal.vue
+++ b/packages/vue3/tests/app/Pages/ErrorModal.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <span @click="invalidVisit" class="invalid-visit">Invalid Visit</span>
+    <span @click="invalidVisitJson" class="invalid-visit-json">Invalid Visit (JSON response)</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    invalidVisit() {
+      this.$inertia.post('/non-inertia')
+    },
+    invalidVisitJson() {
+      this.$inertia.post('/json')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Events.vue
+++ b/packages/vue3/tests/app/Pages/Events.vue
@@ -1,0 +1,578 @@
+<template>
+  <div>
+    <!-- Listeners -->
+    <span @click="withoutEventListeners" class="without-listeners">Basic Visit</span>
+    <span @click="removeInertiaListener" class="remove-inertia-listener">Remove Inertia Listener</span>
+
+    <!-- Events: Before -->
+    <span @click="beforeVisit" class="before">Before Event</span>
+    <span @click="beforeVisitPreventLocal" class="before-prevent-local">Before Event</span>
+    <inertia-link
+      :href="$page.url"
+      method="post"
+      @before="(visit) => alert('linkOnBefore', visit)"
+      @start="() => alert('linkOnStart')"
+      class="link-before"
+      >Before Event Link</inertia-link
+    >
+    <inertia-link
+      :href="$page.url"
+      method="post"
+      @before="(visit) => tap(false, alert('linkOnBefore'))"
+      @start="() => alert('This listener should not have been called.')"
+      class="link-before-prevent-local"
+      >Before Event Link</inertia-link
+    >
+    <span @click="beforeVisitPreventGlobalInertia" class="before-prevent-global-inertia"
+      >Before Event - Prevent globally using Inertia Event Listener</span
+    >
+    <span @click="beforeVisitPreventGlobalNative" class="before-prevent-global-native"
+      >Before Event - Prevent globally using Native Event Listeners</span
+    >
+
+    <!-- Events: CancelToken -->
+    <span @click="cancelTokenVisit" class="canceltoken">Cancel Token Event</span>
+    <inertia-link
+      :href="$page.url"
+      method="post"
+      @cancelToken="(event) => alert('linkOnCancelToken', event)"
+      class="link-canceltoken"
+      >Cancel Token Event Link</inertia-link
+    >
+
+    <!-- Events: Cancel -->
+    <span @click="cancelVisit" class="cancel">Cancel Event</span>
+    <inertia-link
+      :href="$page.url"
+      method="post"
+      @cancelToken="(token) => token.cancel()"
+      @cancel="(event) => alert('linkOnCancel', event)"
+      class="link-cancel"
+      >Cancel Event Link</inertia-link
+    >
+
+    <!-- Events: Start -->
+    <span @click="startVisit" class="start">Start Event</span>
+    <inertia-link :href="$page.url" method="post" @start="(event) => alert('linkOnStart', event)" class="link-start"
+      >Start Event Link</inertia-link
+    >
+
+    <!-- Events: Progress -->
+    <span @click="progressVisit" class="progress">Progress Event</span>
+    <span @click="progressNoFilesVisit" class="progress-no-files">Missing Progress Event (no files)</span>
+    <inertia-link
+      :href="$page.url"
+      method="post"
+      :data="payloadWithFile"
+      @progress="(event) => alert('linkOnProgress', event)"
+      class="link-progress"
+      >Progress Event Link</inertia-link
+    >
+    <inertia-link
+      :href="$page.url"
+      method="post"
+      @before="() => alert('linkProgressNoFilesOnBefore')"
+      @progress="(event) => alert('linkOnProgress', event)"
+      class="link-progress-no-files"
+      >Progress Event Link (no files)</inertia-link
+    >
+
+    <!-- Events: Error -->
+    <span @click="errorVisit" class="error">Error Event</span>
+    <span @click="errorPromiseVisit" class="error-promise">Error Event (delaying onFinish w/ Promise)</span>
+    <inertia-link
+      href="/events/errors"
+      method="post"
+      @error="(errors) => alert('linkOnError', errors)"
+      @success="() => alert('This listener should not have been called')"
+      class="link-error"
+      >Error Event Link</inertia-link
+    >
+    <inertia-link
+      href="/events/errors"
+      method="post"
+      @error="() => callbackSuccessErrorPromise('linkOnError')"
+      @success="() => alert('This listener should not have been called')"
+      @finish="() => alert('linkOnFinish')"
+      class="link-error-promise"
+      >Error Event Link (delaying onFinish w/ Promise)</inertia-link
+    >
+
+    <!-- Events: Success -->
+    <span @click="successVisit" class="success">Success Event</span>
+    <span @click="successPromiseVisit" class="success-promise">Success Event (delaying onFinish w/ Promise)</span>
+    <inertia-link
+      :href="$page.url"
+      method="post"
+      @error="() => alert('This listener should not have been called')"
+      @success="(event) => alert('linkOnSuccess', event)"
+      class="link-success"
+      >Success Event Link</inertia-link
+    >
+    <inertia-link
+      :href="$page.url"
+      method="post"
+      @error="() => alert('This listener should not have been called')"
+      @success="() => callbackSuccessErrorPromise('linkOnSuccess')"
+      @finish="() => alert('linkOnFinish')"
+      class="link-success-promise"
+      >Success Event Link (delaying onFinish w/ Promise)</inertia-link
+    >
+
+    <!-- Events: Invalid -->
+    <span @click="invalidVisit" class="invalid">Finish Event</span>
+
+    <!-- Events: Exception -->
+    <span @click="exceptionVisit" class="exception">Exception Event</span>
+
+    <!-- Events: Finish -->
+    <span @click="finishVisit" class="finish">Finish Event</span>
+    <inertia-link :href="$page.url" method="post" @finish="(event) => alert('linkOnFinish', event)" class="link-finish"
+      >Finish Event Link</inertia-link
+    >
+
+    <!-- Events: Navigate -->
+    <span @click="navigateVisit" class="navigate">Navigate Event</span>
+
+    <!-- Lifecycles -->
+    <span @click="lifecycleSuccess" class="lifecycle-success">Lifecycle Success</span>
+    <span @click="lifecycleError" class="lifecycle-error">Lifecycle Error</span>
+    <span @click="lifecycleCancel" class="lifecycle-cancel">Lifecycle Cancel</span>
+    <span @click="lifecycleCancelAfterFinish" class="lifecycle-cancel-after-finish"
+      >Lifecycle Cancel - After Finish</span
+    >
+  </div>
+</template>
+<script>
+import { router } from '@inertiajs/vue3'
+
+export default {
+  data: () => ({
+    payloadWithFile: {
+      file: new File(['foobar'], 'example.bin'),
+    },
+  }),
+  methods: {
+    alert(...args) {
+      args.forEach((arg) => alert(arg))
+    },
+    withoutEventListeners() {
+      this.$inertia.post(this.$page.url, {})
+    },
+    removeInertiaListener() {
+      const removeEventListener = router.on('before', () => alert('Inertia.on(before)'))
+
+      alert('Removing Inertia.on Listener')
+      removeEventListener()
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onBefore: () => alert('onBefore'),
+          onStart: () => alert('onStart'),
+        },
+      )
+    },
+    beforeVisit() {
+      router.on('before', (event) => {
+        alert('Inertia.on(before)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:before', (event) => {
+        alert('addEventListener(inertia:before)')
+        alert(event)
+      })
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onBefore: (event) => {
+            alert('onBefore')
+            alert(event)
+          },
+          onStart: () => alert('onStart'),
+        },
+      )
+    },
+    beforeVisitPreventLocal() {
+      document.addEventListener('inertia:before', () => alert('addEventListener(inertia:before)'))
+      router.on('before', () => alert('Inertia.on(before)'))
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onBefore: () => {
+            alert('onBefore')
+            return false
+          },
+          onStart: () => alert('This listener should not have been called.'),
+        },
+      )
+    },
+    beforeVisitPreventGlobalInertia() {
+      document.addEventListener('inertia:before', () => alert('addEventListener(inertia:before)'))
+      router.on('before', (visit) => {
+        alert('Inertia.on(before)')
+        return false
+      })
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onBefore: () => alert('onBefore'),
+          onStart: () => alert('This listener should not have been called.'),
+        },
+      )
+    },
+    beforeVisitPreventGlobalNative() {
+      router.on('before', () => alert('Inertia.on(before)'))
+      document.addEventListener('inertia:before', (event) => {
+        alert('addEventListener(inertia:before)')
+        event.preventDefault()
+      })
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onBefore: () => alert('onBefore'),
+          onStart: () => alert('This listener should not have been called.'),
+        },
+      )
+    },
+    cancelTokenVisit() {
+      router.on('cancelToken', () => alert('This listener should not have been called.'))
+      document.addEventListener('inertia:cancelToken', () => alert('This listener should not have been called.'))
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onCancelToken: (event) => {
+            alert('onCancelToken')
+            alert(event)
+          },
+        },
+      )
+    },
+    startVisit() {
+      router.on('start', (event) => {
+        alert('Inertia.on(start)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:start', (event) => {
+        alert('addEventListener(inertia:start)')
+        alert(event)
+      })
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onStart: (event) => {
+            alert('onStart')
+            alert(event)
+          },
+        },
+      )
+    },
+    progressVisit() {
+      router.on('progress', (event) => {
+        alert('Inertia.on(progress)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:progress', (event) => {
+        alert('addEventListener(inertia:progress)')
+        alert(event)
+      })
+
+      this.$inertia.post(this.$page.url, this.payloadWithFile, {
+        onProgress: (event) => {
+          alert('onProgress')
+          alert(event)
+        },
+      })
+    },
+    progressNoFilesVisit() {
+      router.on('progress', (event) => {
+        alert('Inertia.on(progress)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:progress', (event) => {
+        alert('addEventListener(inertia:progress)')
+        alert(event)
+      })
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onBefore: () => alert('progressNoFilesOnBefore'),
+          onProgress: (event) => {
+            alert('onProgress')
+            alert(event)
+          },
+        },
+      )
+    },
+    cancelVisit() {
+      router.on('cancel', (event) => {
+        alert('Inertia.on(cancel)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:cancel', (event) => {
+        alert('addEventListener(inertia:cancel)')
+        alert(event)
+      })
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onCancelToken: (token) => token.cancel(),
+          onCancel: (event) => {
+            alert('onCancel')
+            alert(event)
+          },
+        },
+      )
+    },
+    errorVisit() {
+      router.on('error', (event) => {
+        alert('Inertia.on(error)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:error', (event) => {
+        alert('addEventListener(inertia:error)')
+        alert(event)
+      })
+
+      this.$inertia.post(
+        '/events/errors',
+        {},
+        {
+          onError: (errors) => {
+            alert('onError')
+            alert(errors)
+          },
+        },
+      )
+    },
+    errorPromiseVisit() {
+      this.$inertia.post(
+        '/events/errors',
+        {},
+        {
+          onError: () => this.callbackSuccessErrorPromise('onError'),
+          onSuccess: () => alert('This listener should not have been called'),
+          onFinish: () => alert('onFinish'),
+        },
+      )
+    },
+    successVisit() {
+      router.on('success', (event) => {
+        alert('Inertia.on(success)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:success', (event) => {
+        alert('addEventListener(inertia:success)')
+        alert(event)
+      })
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onError: () => alert('This listener should not have been called'),
+          onSuccess: (page) => {
+            alert('onSuccess')
+            alert(page)
+          },
+        },
+      )
+    },
+    successPromiseVisit() {
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onSuccess: () => this.callbackSuccessErrorPromise('onSuccess'),
+          onError: () => alert('This listener should not have been called'),
+          onFinish: () => alert('onFinish'),
+        },
+      )
+    },
+    finishVisit() {
+      router.on('finish', (event) => {
+        alert('Inertia.on(finish)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:finish', (event) => {
+        alert('addEventListener(inertia:finish)')
+        alert(event)
+      })
+
+      this.$inertia.post(
+        this.$page.url,
+        {},
+        {
+          onFinish: (event) => {
+            alert('onFinish')
+            alert(event)
+          },
+        },
+      )
+    },
+    invalidVisit() {
+      router.on('invalid', (event) => {
+        alert('Inertia.on(invalid)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:invalid', (event) => {
+        alert('addEventListener(inertia:invalid)')
+        alert(event)
+      })
+
+      this.$inertia.post(
+        '/non-inertia',
+        {},
+        {
+          onInvalid: () => alert('This listener should not have been called.'),
+        },
+      )
+    },
+    exceptionVisit() {
+      router.on('exception', (event) => {
+        alert('Inertia.on(exception)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:exception', (event) => {
+        alert('addEventListener(inertia:exception)')
+        alert(event)
+      })
+
+      try {
+        this.$inertia.post(
+          '/disconnect',
+          {},
+          {
+            onException: () => alert('This listener should not have been called.'),
+          },
+        )
+      } catch (error) {
+      }
+    },
+    navigateVisit() {
+      router.on('navigate', (event) => {
+        alert('Inertia.on(navigate)')
+        alert(event)
+      })
+
+      document.addEventListener('inertia:navigate', (event) => {
+        alert('addEventListener(inertia:navigate)')
+        alert(event)
+      })
+
+      this.$inertia.get(
+        '/',
+        {},
+        {
+          onNavigate: () => alert('This listener should not have been called.'),
+        },
+      )
+    },
+    registerAllListeners() {
+      router.on('before', () => alert('Inertia.on(before)'))
+      router.on('cancelToken', () => alert('Inertia.on(cancelToken)'))
+      router.on('cancel', () => alert('Inertia.on(cancel)'))
+      router.on('start', () => alert('Inertia.on(start)'))
+      router.on('progress', () => alert('Inertia.on(progress)'))
+      router.on('error', () => alert('Inertia.on(error)'))
+      router.on('success', () => alert('Inertia.on(success)'))
+      router.on('invalid', () => alert('Inertia.on(invalid)'))
+      router.on('exception', () => alert('Inertia.on(exception)'))
+      router.on('finish', () => alert('Inertia.on(finish)'))
+      router.on('navigate', () => alert('Inertia.on(navigate)'))
+      document.addEventListener('inertia:before', () => alert('addEventListener(inertia:before)'))
+      document.addEventListener('inertia:cancelToken', () => alert('addEventListener(inertia:cancelToken)'))
+      document.addEventListener('inertia:cancel', () => alert('addEventListener(inertia:cancel)'))
+      document.addEventListener('inertia:start', () => alert('addEventListener(inertia:start)'))
+      document.addEventListener('inertia:progress', () => alert('addEventListener(inertia:progress)'))
+      document.addEventListener('inertia:error', () => alert('addEventListener(inertia:error)'))
+      document.addEventListener('inertia:success', () => alert('addEventListener(inertia:success)'))
+      document.addEventListener('inertia:invalid', () => alert('addEventListener(inertia:invalid)'))
+      document.addEventListener('inertia:exception', () => alert('addEventListener(inertia:exception)'))
+      document.addEventListener('inertia:finish', () => alert('addEventListener(inertia:finish)'))
+      document.addEventListener('inertia:navigate', () => alert('addEventListener(inertia:navigate)'))
+
+      return {
+        onBefore: () => alert('onBefore'),
+        onCancelToken: () => alert('onCancelToken'),
+        onCancel: () => alert('onCancel'),
+        onStart: () => alert('onStart'),
+        onProgress: () => alert('onProgress'),
+        onError: () => alert('onError'),
+        onSuccess: () => alert('onSuccess'),
+        onInvalid: () => alert('onInvalid'), // Does not exist.
+        onException: () => alert('onException'), // Does not exist.
+        onFinish: () => alert('onFinish'),
+        onNavigate: () => alert('onNavigate'), // Does not exist.
+      }
+    },
+    lifecycleSuccess() {
+      this.$inertia.post(this.$page.url, this.payloadWithFile, this.registerAllListeners())
+    },
+    lifecycleError() {
+      this.$inertia.post('/events/errors', this.payloadWithFile, this.registerAllListeners())
+    },
+    lifecycleCancel() {
+      this.$inertia.post('/sleep', this.payloadWithFile, {
+        ...this.registerAllListeners(),
+        onCancelToken: (token) => {
+          alert('onCancelToken')
+
+          setTimeout(() => {
+            alert('CANCELLING!')
+            token.cancel()
+          }, 10)
+        },
+      })
+    },
+    lifecycleCancelAfterFinish() {
+      let cancelToken = null
+
+      this.$inertia.post(this.$page.url, this.payloadWithFile, {
+        ...this.registerAllListeners(),
+        onCancelToken: (token) => {
+          alert('onCancelToken')
+          cancelToken = token
+        },
+        onFinish: () => {
+          alert('onFinish')
+          alert('CANCELLING!')
+          cancelToken.cancel()
+        },
+      })
+    },
+    callbackSuccessErrorPromise(eventName) {
+      alert(eventName)
+      setTimeout(() => alert('onFinish should have been fired by now if Promise functionality did not work'), 5)
+      return new Promise((resolve) => setTimeout(resolve, 20))
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/FormHelper/Data.vue
+++ b/packages/vue3/tests/app/Pages/FormHelper/Data.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="name" v-model="form.name" />
+    </label>
+    <span class="name_error" v-if="form.errors.name">{{ form.errors.name }}</span>
+    <label>
+      Handle
+      <input type="text" id="handle" name="handle" v-model="form.handle" />
+    </label>
+    <span class="handle_error" v-if="form.errors.handle">{{ form.errors.handle }}</span>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="form.remember" />
+    </label>
+    <span class="remember_error" v-if="form.errors.remember">{{ form.errors.remember }}</span>
+
+    <span @click="submit" class="submit">Submit form</span>
+
+    <span @click="resetAll" class="reset">Reset all data</span>
+    <span @click="resetOne" class="reset-one">Reset one field</span>
+
+    <span @click="reassign" class="reassign">Reassign current as defaults</span>
+    <span @click="reassignObject" class="reassign-object">Reassign default values</span>
+    <span @click="reassignSingle" class="reassign-single">Reassign single default</span>
+
+    <span class="errors-status">Form has {{ form.hasErrors ? '' : 'no ' }}errors</span>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      form: this.$inertia.form({
+        name: 'foo',
+        handle: 'example',
+        remember: false,
+      }),
+    }
+  },
+  methods: {
+    submit() {
+      this.form.post(this.$page.url)
+    },
+    resetAll() {
+      this.form.reset()
+    },
+    resetOne() {
+      this.form.reset('handle')
+    },
+    reassign() {
+      this.form.defaults()
+    },
+    reassignObject() {
+      this.form.defaults({
+        handle: 'updated handle',
+        remember: true,
+      })
+    },
+    reassignSingle() {
+      this.form.defaults('name', 'single value')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/FormHelper/Errors.vue
+++ b/packages/vue3/tests/app/Pages/FormHelper/Errors.vue
@@ -1,0 +1,61 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="name" v-model="form.name" />
+    </label>
+    <span class="name_error" v-if="form.errors.name">{{ form.errors.name }}</span>
+    <label>
+      Handle
+      <input type="text" id="handle" name="handle" v-model="form.handle" />
+    </label>
+    <span class="handle_error" v-if="form.errors.handle">{{ form.errors.handle }}</span>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="form.remember" />
+    </label>
+    <span class="remember_error" v-if="form.errors.remember">{{ form.errors.remember }}</span>
+
+    <span @click="submit" class="submit">Submit form</span>
+
+    <span @click="clearErrors" class="clear">Clear all errors</span>
+    <span @click="clearError" class="clear-one">Clear one error</span>
+    <span @click="setErrors" class="set">Set errors</span>
+    <span @click="setError" class="set-one">Set one error</span>
+
+    <span class="errors-status">Form has {{ form.hasErrors ? '' : 'no ' }}errors</span>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      form: this.$inertia.form({
+        name: 'foo',
+        handle: 'example',
+        remember: false,
+      }),
+    }
+  },
+  methods: {
+    submit() {
+      this.form.post('/form-helper/errors')
+    },
+    clearErrors() {
+      this.form.clearErrors()
+    },
+    clearError() {
+      this.form.clearErrors('handle')
+    },
+    setErrors() {
+      this.form.setError({
+        name: 'Manually set Name error',
+        handle: 'Manually set Handle error',
+      })
+    },
+    setError() {
+      this.form.setError('handle', 'Manually set Handle error')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/FormHelper/Events.vue
+++ b/packages/vue3/tests/app/Pages/FormHelper/Events.vue
@@ -1,0 +1,364 @@
+<template>
+  <div>
+    <span @click="submit" class="submit">Submit form</span>
+
+    <span @click="successfulRequest" class="successful-request">Successful request</span>
+    <span @click="cancelledVisit" class="cancel">Cancellable Visit</span>
+
+    <span @click="onBeforeVisit" class="before">onBefore</span>
+    <span @click="onBeforeVisitCancelled" class="before-cancel">onBefore cancellation</span>
+    <span @click="onStartVisit" class="start">onStart</span>
+    <span @click="onProgressVisit" class="progress">onProgress</span>
+
+    <span @click="onSuccessVisit" class="success">onSuccess</span>
+    <span @click="onSuccessProgress" class="success-progress">onSuccess progress property</span>
+    <span @click="onSuccessProcessing" class="success-processing">onSuccess resets processing</span>
+    <span @click="onSuccessResetErrors" class="success-reset-errors">onSuccess resets errors</span>
+    <span @click="onSuccessPromiseVisit" class="success-promise">onSuccess promise</span>
+
+    <span @click="onErrorVisit" class="error">onError</span>
+    <span @click="onErrorProgress" class="error-progress">onError progress property</span>
+    <span @click="onErrorProcessing" class="error-processing">onError resets processing</span>
+    <span @click="errorsSetOnError" class="errors-set-on-error">Errors set on error</span>
+    <span @click="onErrorPromiseVisit" class="error-promise">onError promise</span>
+
+    <span @click="progressNoFiles" class="no-progress">progress no files</span>
+
+    <span class="success-status">Form was {{ form.wasSuccessful ? '' : 'not ' }}successful</span>
+    <span class="recently-status">Form was {{ form.recentlySuccessful ? '' : 'not ' }}recently successful</span>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      wasSubmittedPreviously: false,
+      form: this.$inertia.form({
+        name: 'foo',
+        remember: false,
+      }),
+    }
+  },
+  methods: {
+    callbacks(overrides = {}) {
+      const defaults = {
+        onBefore: () => alert('onBefore'),
+        onCancelToken: () => alert('onCancelToken'),
+        onStart: () => alert('onStart'),
+        onProgress: () => alert('onProgress'),
+        onFinish: () => alert('onFinish'),
+        onCancel: () => alert('onCancel'),
+        onSuccess: () => alert('onSuccess'),
+        onError: () => alert('onError'),
+      }
+
+      return {
+        ...defaults,
+        ...overrides,
+      }
+    },
+    submit() {
+      this.form.post(this.$page.url)
+    },
+    successfulRequest() {
+      this.form.post(this.$page.url, {
+        ...this.callbacks(),
+      })
+    },
+    onSuccessResetErrors() {
+      this.form.post('/form-helper/events/errors', {
+        onBefore: () => {
+          alert('onBefore')
+          alert(this.form.hasErrors)
+        },
+        onError: () => {
+          alert('onError')
+          alert(this.form.hasErrors)
+
+          this.form.post('/form-helper/events', {
+            onStart: () => {
+              alert('onStart')
+              alert(this.form.hasErrors)
+              alert(this.form.errors)
+            },
+            onSuccess: () => {
+              alert('onSuccess')
+              alert(this.form.hasErrors)
+              alert(this.form.errors)
+            },
+          })
+        },
+      })
+    },
+    errorsSetOnError() {
+      this.form.post('/form-helper/events/errors', {
+        ...this.callbacks({
+          onStart: () => {
+            alert('onStart')
+            alert(this.form.errors)
+          },
+          onError: () => {
+            alert('onError')
+            alert(this.form.errors)
+          },
+        }),
+      })
+    },
+    onBeforeVisit() {
+      this.form.post('/sleep', {
+        ...this.callbacks({
+          onBefore: (visit) => {
+            alert('onBefore')
+            alert(visit)
+          },
+        }),
+      })
+    },
+    onBeforeVisitCancelled() {
+      this.form.post('/sleep', {
+        ...this.callbacks({
+          onBefore: (visit) => {
+            alert('onBefore')
+            return false
+          },
+        }),
+      })
+    },
+    onStartVisit() {
+      this.form.post('/form-helper/events', {
+        ...this.callbacks({
+          onStart: (visit) => {
+            alert('onStart')
+            alert(visit)
+          },
+        }),
+      })
+    },
+    onProgressVisit() {
+      this.form
+        .transform((data) => ({
+          ...data,
+          file: new File(['foobar'], 'example.bin'),
+        }))
+        .post('/dump/post', {
+          ...this.callbacks({
+            onProgress: (event) => {
+              alert('onProgress')
+              alert(event)
+            },
+          }),
+        })
+    },
+    cancelledVisit() {
+      this.form.post('/sleep', {
+        ...this.callbacks({
+          onCancelToken: (token) => {
+            alert('onCancelToken')
+
+            setTimeout(() => {
+              alert('CANCELLING!')
+              token.cancel()
+            }, 10)
+          },
+        }),
+      })
+    },
+    onSuccessVisit() {
+      this.form.post('/dump/post', {
+        ...this.callbacks({
+          onSuccess: (page) => {
+            alert('onSuccess')
+            alert(page)
+          },
+        }),
+      })
+    },
+    onSuccessPromiseVisit() {
+      this.form.post('/dump/post', {
+        ...this.callbacks({
+          onSuccess: (page) => {
+            alert('onSuccess')
+
+            setTimeout(() => alert('onFinish should have been fired by now if Promise functionality did not work'), 5)
+            return new Promise((resolve) => setTimeout(resolve, 20))
+          },
+        }),
+      })
+    },
+    onErrorVisit() {
+      this.form.post('/form-helper/events/errors', {
+        ...this.callbacks({
+          onError: (errors) => {
+            alert('onError')
+            alert(errors)
+          },
+        }),
+      })
+    },
+    onErrorPromiseVisit() {
+      this.form.post('/form-helper/events/errors', {
+        ...this.callbacks({
+          onError: (errors) => {
+            alert('onError')
+
+            setTimeout(() => alert('onFinish should have been fired by now if Promise functionality did not work'), 5)
+            return new Promise((resolve) => setTimeout(resolve, 20))
+          },
+        }),
+      })
+    },
+    onSuccessProcessing() {
+      this.form.post(this.$page.url, {
+        ...this.callbacks({
+          onBefore: () => {
+            alert('onBefore')
+            alert(this.form.processing)
+          },
+          onCancelToken: () => {
+            alert('onCancelToken')
+            alert(this.form.processing)
+          },
+          onStart: () => {
+            alert('onStart')
+            alert(this.form.processing)
+          },
+          onSuccess: () => {
+            alert('onSuccess')
+            alert(this.form.processing)
+          },
+          onFinish: () => {
+            alert('onFinish')
+            alert(this.form.processing)
+          },
+        }),
+      })
+    },
+    onErrorProcessing() {
+      this.form.post('/form-helper/events/errors', {
+        ...this.callbacks({
+          onBefore: () => {
+            alert('onBefore')
+            alert(this.form.processing)
+          },
+          onCancelToken: () => {
+            alert('onCancelToken')
+            alert(this.form.processing)
+          },
+          onStart: () => {
+            alert('onStart')
+            alert(this.form.processing)
+          },
+          onError: () => {
+            alert('onError')
+            alert(this.form.processing)
+          },
+          onFinish: () => {
+            alert('onFinish')
+            alert(this.form.processing)
+          },
+        }),
+      })
+    },
+    onSuccessProgress() {
+      this.form
+        .transform((data) => ({
+          ...data,
+          file: new File(['foobar'], 'example.bin'),
+        }))
+        .post(this.$page.url, {
+          ...this.callbacks({
+            onBefore: () => {
+              alert('onBefore')
+              alert(this.form.progress)
+            },
+            onCancelToken: () => {
+              alert('onCancelToken')
+              alert(this.form.progress)
+            },
+            onStart: () => {
+              alert('onStart')
+              alert(this.form.progress)
+            },
+            onProgress: () => {
+              alert('onProgress')
+              alert(this.form.progress)
+            },
+            onSuccess: () => {
+              alert('onSuccess')
+              alert(this.form.progress)
+            },
+            onFinish: () => {
+              alert('onFinish')
+              alert(this.form.progress)
+            },
+          }),
+        })
+    },
+    onErrorProgress() {
+      this.form
+        .transform((data) => ({
+          ...data,
+          file: new File(['foobar'], 'example.bin'),
+        }))
+        .post('/form-helper/events/errors', {
+          ...this.callbacks({
+            onBefore: () => {
+              alert('onBefore')
+              alert(this.form.progress)
+            },
+            onCancelToken: () => {
+              alert('onCancelToken')
+              alert(this.form.progress)
+            },
+            onStart: () => {
+              alert('onStart')
+              alert(this.form.progress)
+            },
+            onProgress: () => {
+              alert('onProgress')
+              alert(this.form.progress)
+            },
+            onError: () => {
+              alert('onError')
+              alert(this.form.progress)
+            },
+            onFinish: () => {
+              alert('onFinish')
+              alert(this.form.progress)
+            },
+          }),
+        })
+    },
+    progressNoFiles() {
+      this.form.post(this.$page.url, {
+        ...this.callbacks({
+          onBefore: () => {
+            alert('onBefore')
+            alert(this.form.progress)
+          },
+          onCancelToken: () => {
+            alert('onCancelToken')
+            alert(this.form.progress)
+          },
+          onStart: () => {
+            alert('onStart')
+            alert(this.form.progress)
+          },
+          onProgress: () => {
+            alert('onProgress')
+            alert(this.form.progress)
+          },
+          onSuccess: () => {
+            alert('onSuccess')
+            alert(this.form.progress)
+          },
+          onFinish: () => {
+            alert('onFinish')
+            alert(this.form.progress)
+          },
+        }),
+      })
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/FormHelper/Methods.vue
+++ b/packages/vue3/tests/app/Pages/FormHelper/Methods.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="name" v-model="form.name" />
+    </label>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="form.remember" />
+    </label>
+
+    <span @click="postForm" class="post">POST form</span>
+    <span @click="putForm" class="put">PUT form</span>
+    <span @click="patchForm" class="patch">PATCH form</span>
+    <span @click="deleteForm" class="delete">DELETE form</span>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      form: this.$inertia.form({
+        name: 'foo',
+        remember: false,
+      }),
+    }
+  },
+  methods: {
+    postForm() {
+      this.form.post('/dump/post')
+    },
+    putForm() {
+      this.form.put('/dump/put')
+    },
+    patchForm() {
+      this.form.patch('/dump/patch')
+    },
+    deleteForm() {
+      this.form.delete('/dump/delete')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/FormHelper/Transform.vue
+++ b/packages/vue3/tests/app/Pages/FormHelper/Transform.vue
@@ -1,0 +1,63 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="name" v-model="form.name" />
+    </label>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="form.remember" />
+    </label>
+
+    <span @click="postForm" class="post">POST form</span>
+    <span @click="putForm" class="put">PUT form</span>
+    <span @click="patchForm" class="patch">PATCH form</span>
+    <span @click="deleteForm" class="delete">DELETE form</span>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      form: this.$inertia.form({
+        name: 'foo',
+        remember: false,
+      }),
+    }
+  },
+  methods: {
+    postForm() {
+      this.form
+        .transform((data) => ({
+          ...data,
+          name: 'bar',
+        }))
+        .post('/dump/post')
+    },
+    putForm() {
+      this.form
+        .transform((data) => ({
+          ...data,
+          name: 'baz',
+        }))
+        .put('/dump/put')
+    },
+    patchForm() {
+      this.form
+        .transform((data) => ({
+          ...data,
+          name: 'foo',
+        }))
+        .patch('/dump/patch')
+    },
+    deleteForm() {
+      this.form
+        .transform((data) => ({
+          ...data,
+          name: 'bar',
+        }))
+        .delete('/dump/delete')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Home.vue
+++ b/packages/vue3/tests/app/Pages/Home.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <span class="text">This is the Test App Entrypoint page</span>
+
+    <inertia-link href="/links/method" class="links-method">Basic inertia-links</inertia-link>
+    <inertia-link href="/links/replace" class="links-replace">'Replace' inertia-links</inertia-link>
+
+    <span @click="visitsMethod" class="visits-method">Manual basic visits</span>
+    <span @click="visitsReplace" class="visits-replace">Manual 'Replace' visits</span>
+
+    <inertia-link href="/redirect" method="post" class="links-redirect">Redirect Link</inertia-link>
+    <span @click="redirect" class="visits-redirect">Manual Redirect visit</span>
+
+    <inertia-link href="/redirect-external" method="post" class="links-redirect-external">Redirect Link</inertia-link>
+    <span @click="redirectExternal" class="visits-redirect-external">Manual External Redirect visit</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    visitsMethod() {
+      this.$inertia.visit('/visits/method')
+    },
+    visitsReplace() {
+      this.$inertia.get('/visits/replace')
+    },
+    redirect() {
+      this.$inertia.post('/redirect')
+    },
+    redirectExternal() {
+      this.$inertia.post('/redirect-external')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Links/AsWarning.vue
+++ b/packages/vue3/tests/app/Pages/Links/AsWarning.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates inertia-links with an 'as' warning</span>
+
+    <inertia-link :method="method" href="/example" class="get">{{ method }} Link</inertia-link>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    method: String,
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Links/AsWarningFalse.vue
+++ b/packages/vue3/tests/app/Pages/Links/AsWarningFalse.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates inertia-links without the 'as' warning</span>
+
+    <inertia-link :method="method" href="/example" class="get" as="button">{{ method }} button Link</inertia-link>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    method: String,
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Links/AutomaticCancellation.vue
+++ b/packages/vue3/tests/app/Pages/Links/AutomaticCancellation.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates that only one visit can be active at a time</span>
+    <inertia-link href="/sleep" class="visit" @cancel="() => alert('cancelled')" @start="() => alert('started')"
+      >Link</inertia-link
+    >
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    alert(message) {
+      return window.alert(message)
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Links/Data/AutoConverted.vue
+++ b/packages/vue3/tests/app/Pages/Links/Data/AutoConverted.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <span class="text"
+      >This is the links page that demonstrates the automatic conversion of plain objects to form-data</span
+    >
+
+    <inertia-link method="GET" href="/dump/get" :data="linkData" class="get">GET Link</inertia-link>
+    <inertia-link as="button" method="POST" href="/dump/post" :data="linkData" class="post">POST Link</inertia-link>
+    <inertia-link as="button" method="PUT" href="/dump/put" :data="linkData" class="put">PUT Link</inertia-link>
+    <inertia-link as="button" method="PATCH" href="/dump/patch" :data="linkData" class="patch">PATCH Link</inertia-link>
+    <inertia-link as="button" method="DELETE" href="/dump/delete" :data="linkData" class="delete"
+      >DELETE Link</inertia-link
+    >
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    linkData: {
+      file: new File([], 'example.jpg'),
+      foo: 'bar',
+    },
+  }),
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Links/Data/FormData.vue
+++ b/packages/vue3/tests/app/Pages/Links/Data/FormData.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates passing data through FormData objects</span>
+
+    <inertia-link method="GET" href="/dump/get" :data="linkData" class="get">GET Link</inertia-link>
+    <inertia-link as="button" method="POST" href="/dump/post" :data="linkData" class="post">POST Link</inertia-link>
+    <inertia-link as="button" method="PUT" href="/dump/put" :data="linkData" class="put">PUT Link</inertia-link>
+    <inertia-link as="button" method="PATCH" href="/dump/patch" :data="linkData" class="patch">PATCH Link</inertia-link>
+    <inertia-link as="button" method="DELETE" href="/dump/delete" :data="linkData" class="delete"
+      >DELETE Link</inertia-link
+    >
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    linkData: new FormData(),
+  }),
+  created() {
+    this.linkData.append('bar', 'baz')
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Links/Data/Object.vue
+++ b/packages/vue3/tests/app/Pages/Links/Data/Object.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates passing data through plain objects</span>
+
+    <inertia-link method="GET" href="/dump/get" :data="{ foo: 'get' }" class="get">GET Link</inertia-link>
+    <inertia-link as="button" method="POST" href="/dump/post" :data="{ bar: 'post' }" class="post"
+      >POST Link</inertia-link
+    >
+    <inertia-link as="button" method="PUT" href="/dump/put" :data="{ baz: 'put' }" class="put">PUT Link</inertia-link>
+    <inertia-link as="button" method="PATCH" href="/dump/patch" :data="{ foo: 'patch' }" class="patch"
+      >PATCH Link</inertia-link
+    >
+    <inertia-link as="button" method="DELETE" href="/dump/delete" :data="{ bar: 'delete' }" class="delete"
+      >DELETE Link</inertia-link
+    >
+
+    <inertia-link href="/dump/get" :data="{ a: ['b', 'c'] }" class="qsaf-default">QSAF Defaults</inertia-link>
+    <inertia-link href="/dump/get" :data="{ a: ['b', 'c'] }" queryStringArrayFormat="indices" class="qsaf-indices"
+      >QSAF Indices</inertia-link
+    >
+    <inertia-link href="/dump/get" :data="{ a: ['b', 'c'] }" queryStringArrayFormat="brackets" class="qsaf-brackets"
+      >QSAF Brackets</inertia-link
+    >
+  </div>
+</template>

--- a/packages/vue3/tests/app/Pages/Links/Headers.vue
+++ b/packages/vue3/tests/app/Pages/Links/Headers.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates passing custom headers</span>
+    <inertia-link href="/dump/get" class="default">Standard visit Link</inertia-link>
+
+    <inertia-link method="GET" href="/dump/get" :headers="{ foo: 'bar' }" class="custom">GET Link</inertia-link>
+    <inertia-link
+      as="button"
+      method="POST"
+      href="/dump/post"
+      :headers="{ bar: 'baz', 'X-Requested-With': 'custom' }"
+      class="overridden"
+      >POST Link</inertia-link
+    >
+  </div>
+</template>

--- a/packages/vue3/tests/app/Pages/Links/Location.vue
+++ b/packages/vue3/tests/app/Pages/Links/Location.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates location visits inertia-links</span>
+
+    <inertia-link href="/location" replace class="example">Location visit</inertia-link>
+  </div>
+</template>

--- a/packages/vue3/tests/app/Pages/Links/Method.vue
+++ b/packages/vue3/tests/app/Pages/Links/Method.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates inertia-link methods</span>
+
+    <inertia-link method="GET" href="/dump/get" class="get">GET Link</inertia-link>
+    <inertia-link as="button" method="POST" href="/dump/post" class="post">POST Link</inertia-link>
+    <inertia-link as="button" method="PUT" href="/dump/put" class="put">PUT Link</inertia-link>
+    <inertia-link as="button" method="PATCH" href="/dump/patch" class="patch">PATCH Link</inertia-link>
+    <inertia-link as="button" method="DELETE" href="/dump/delete" class="delete">DELETE Link</inertia-link>
+  </div>
+</template>

--- a/packages/vue3/tests/app/Pages/Links/PartialReloads.vue
+++ b/packages/vue3/tests/app/Pages/Links/PartialReloads.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates partial reloads</span>
+    <span class="foo-text">Foo is now {{ foo }}</span>
+    <span class="bar-text">Bar is now {{ bar }}</span>
+    <span class="baz-text">Baz is now {{ baz }}</span>
+    <pre class="headers">{{ headers }}</pre>
+
+    <inertia-link href="/links/partial-reloads" :data="{ foo }" class="all">Update All</inertia-link>
+    <inertia-link href="/links/partial-reloads" :only="['headers', 'foo', 'bar']" :data="{ foo }" class="foo-bar"
+      >'Only' foo + bar</inertia-link
+    >
+    <inertia-link href="/links/partial-reloads" :only="['headers', 'baz']" :data="{ foo }" class="baz"
+      >'Only' baz</inertia-link
+    >
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    foo: {
+      type: Number,
+      default: 0,
+    },
+    bar: Number,
+    baz: Number,
+    headers: Object,
+  },
+  created() {
+    window._inertia_props = this.$page.props
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Links/PartialReloads.vue
+++ b/packages/vue3/tests/app/Pages/Links/PartialReloads.vue
@@ -13,6 +13,12 @@
     <inertia-link href="/links/partial-reloads" :only="['headers', 'baz']" :data="{ foo }" class="baz"
       >'Only' baz</inertia-link
     >
+    <inertia-link href="/links/partial-reloads" :except="['foo', 'bar']" :data="{ foo }" class="except-foo-bar"
+      >'Except' foo + bar</inertia-link
+    >
+    <inertia-link href="/links/partial-reloads" :except="['baz']" :data="{ foo }" class="except-baz"
+      >'Except' baz</inertia-link
+    >
   </div>
 </template>
 <script>

--- a/packages/vue3/tests/app/Pages/Links/PreserveScroll.vue
+++ b/packages/vue3/tests/app/Pages/Links/PreserveScroll.vue
@@ -1,0 +1,55 @@
+<template>
+  <div style="height: 800px; width: 600px">
+    <span class="text">This is the links page that demonstrates scroll preservation with scroll regions</span>
+    <span class="foo">Foo is now {{ foo }}</span>
+
+    <inertia-link href="/links/preserve-scroll-page-two" preserve-scroll :data="{ foo: 'baz' }" class="preserve"
+      >Preserve Scroll</inertia-link
+    >
+    <inertia-link href="/links/preserve-scroll-page-two" :data="{ foo: 'bar' }" class="reset"
+      >Reset Scroll</inertia-link
+    >
+
+    <inertia-link
+      href="/links/preserve-scroll-page-two"
+      :preserve-scroll="preserveCallback"
+      :data="{ foo: 'baz' }"
+      class="preserve-callback"
+      >Preserve Scroll (Callback)</inertia-link
+    >
+    <inertia-link
+      href="/links/preserve-scroll-page-two"
+      :preserve-scroll="preserveCallbackFalse"
+      :data="{ foo: 'foo' }"
+      class="reset-callback"
+      >Reset Scroll (Callback)</inertia-link
+    >
+
+    <a href="/non-inertia" class="off-site">Off-site link</a>
+  </div>
+</template>
+<script>
+import WithScrollRegion from '@/Layouts/WithScrollRegion.vue'
+
+export default {
+  layout: WithScrollRegion,
+  props: {
+    foo: {
+      type: String,
+      default: 'default',
+    },
+  },
+  methods: {
+    preserveCallback(page) {
+      alert(page)
+
+      return true
+    },
+    preserveCallbackFalse(page) {
+      alert(page)
+
+      return false
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Links/PreserveScrollFalse.vue
+++ b/packages/vue3/tests/app/Pages/Links/PreserveScrollFalse.vue
@@ -1,0 +1,55 @@
+<template>
+  <div style="height: 800px; width: 600px">
+    <span class="text">This is the links page that demonstrates scroll preservation without scroll regions</span>
+    <span class="foo">Foo is now {{ foo }}</span>
+
+    <inertia-link href="/links/preserve-scroll-false-page-two" preserve-scroll :data="{ foo: 'baz' }" class="preserve"
+      >Preserve Scroll</inertia-link
+    >
+    <inertia-link href="/links/preserve-scroll-false-page-two" :data="{ foo: 'bar' }" class="reset"
+      >Reset Scroll</inertia-link
+    >
+
+    <inertia-link
+      href="/links/preserve-scroll-false-page-two"
+      :preserve-scroll="preserveCallback"
+      :data="{ foo: 'baz' }"
+      class="preserve-callback"
+      >Preserve Scroll (Callback)</inertia-link
+    >
+    <inertia-link
+      href="/links/preserve-scroll-false-page-two"
+      :preserve-scroll="preserveCallbackFalse"
+      :data="{ foo: 'foo' }"
+      class="reset-callback"
+      >Reset Scroll (Callback)</inertia-link
+    >
+
+    <a href="/non-inertia" class="off-site">Off-site link</a>
+  </div>
+</template>
+<script>
+import WithoutScrollRegion from '@/Layouts/WithoutScrollRegion.vue'
+
+export default {
+  layout: WithoutScrollRegion,
+  props: {
+    foo: {
+      type: String,
+      default: 'default',
+    },
+  },
+  methods: {
+    preserveCallback(page) {
+      alert(page)
+
+      return true
+    },
+    preserveCallbackFalse(page) {
+      alert(page)
+
+      return false
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Links/PreserveState.vue
+++ b/packages/vue3/tests/app/Pages/Links/PreserveState.vue
@@ -1,0 +1,61 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates preserve state on inertia-links</span>
+    <span class="foo">Foo is now {{ foo }}</span>
+    <label>
+      Example Field
+      <input type="text" name="example-field" class="field" />
+    </label>
+
+    <inertia-link href="/links/preserve-state-page-two" preserve-state :data="{ foo: 'bar' }" class="preserve"
+      >[State] Preserve: true</inertia-link
+    >
+    <inertia-link
+      href="/links/preserve-state-page-two"
+      :preserve-state="false"
+      :data="{ foo: 'baz' }"
+      class="preserve-false"
+      >[State] Preserve: false</inertia-link
+    >
+
+    <inertia-link
+      href="/links/preserve-state-page-two"
+      :preserve-state="preserveCallback"
+      :data="{ foo: 'callback-bar' }"
+      class="preserve-callback"
+      >[State] Preserve Callback: true</inertia-link
+    >
+    <inertia-link
+      href="/links/preserve-state-page-two"
+      :preserve-state="preserveCallbackFalse"
+      :data="{ foo: 'callback-baz' }"
+      class="preserve-callback-false"
+      >[State] Preserve Callback: false</inertia-link
+    >
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    foo: {
+      type: String,
+      default: 'default',
+    },
+  },
+  mounted() {
+    window._inertia_page_key = this.$.vnode.key
+  },
+  methods: {
+    preserveCallback(page) {
+      alert(page)
+
+      return true
+    },
+    preserveCallbackFalse(page) {
+      alert(page)
+
+      return false
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Links/Replace.vue
+++ b/packages/vue3/tests/app/Pages/Links/Replace.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates replace on inertia-links</span>
+
+    <inertia-link href="/dump/get" replace class="replace">[State] Replace: true</inertia-link>
+    <inertia-link href="/dump/get" :replace="false" class="replace-false">[State] Replace: false</inertia-link>
+  </div>
+</template>

--- a/packages/vue3/tests/app/Pages/Links/UrlFragments.vue
+++ b/packages/vue3/tests/app/Pages/Links/UrlFragments.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates url fragment behaviour</span>
+    <div style="width: 200vw; height: 200vh; margin-top: 50vh">
+      <!-- prettier-ignore -->
+      <div class="document-position">Document scroll position is {{ documentScrollLeft }} & {{ documentScrollTop }}</div>
+      <inertia-link href="/links/url-fragments#target" class="basic">Basic link</inertia-link>
+      <inertia-link href="#target" class="fragment">Fragment link</inertia-link>
+      <inertia-link href="/links/url-fragments#non-existent-fragment" class="non-existent-fragment"
+        >Non-existent fragment link</inertia-link
+      >
+
+      <div id="target">This is the element with id 'target'</div>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    documentScrollTop: 0,
+    documentScrollLeft: 0,
+  }),
+  created() {
+    document.addEventListener('scroll', this.handleScrollEvent)
+  },
+  beforeDestroy() {
+    document.removeEventListener('scroll', this.handleScrollEvent)
+  },
+  methods: {
+    handleScrollEvent() {
+      this.documentScrollTop = document.documentElement.scrollTop
+      this.documentScrollLeft = document.documentElement.scrollLeft
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/PersistentLayouts/RenderFunction/Nested/PageA.vue
+++ b/packages/vue3/tests/app/Pages/PersistentLayouts/RenderFunction/Nested/PageA.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <span class="text">Nested Persistent Layout - Page A</span>
+    <inertia-link href="/persistent-layouts/render-function/nested/page-b">Page B</inertia-link>
+  </div>
+</template>
+<script>
+import NestedLayout from '@/Layouts/NestedLayout.vue'
+import SiteLayout from '@/Layouts/SiteLayout.vue'
+
+export default {
+  layout: (h, page) => {
+    return h(SiteLayout, [h(NestedLayout, [page])])
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/PersistentLayouts/RenderFunction/Nested/PageB.vue
+++ b/packages/vue3/tests/app/Pages/PersistentLayouts/RenderFunction/Nested/PageB.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <span class="text">Nested Persistent Layout - Page B</span>
+    <inertia-link href="/persistent-layouts/render-function/nested/page-a">Page A</inertia-link>
+  </div>
+</template>
+<script>
+import NestedLayout from '@/Layouts/NestedLayout.vue'
+import SiteLayout from '@/Layouts/SiteLayout.vue'
+
+export default {
+  layout: (h, page) => {
+    return h(SiteLayout, [h(NestedLayout, [page])])
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/PersistentLayouts/RenderFunction/Simple/PageA.vue
+++ b/packages/vue3/tests/app/Pages/PersistentLayouts/RenderFunction/Simple/PageA.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <span class="text">Simple Persistent Layout - Page A</span>
+    <inertia-link href="/persistent-layouts/render-function/simple/page-b">Page B</inertia-link>
+  </div>
+</template>
+<script>
+import Layout from '@/Layouts/SiteLayout.vue'
+
+export default {
+  layout: (h, page) => h(Layout, [page]),
+}
+</script>

--- a/packages/vue3/tests/app/Pages/PersistentLayouts/RenderFunction/Simple/PageB.vue
+++ b/packages/vue3/tests/app/Pages/PersistentLayouts/RenderFunction/Simple/PageB.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <span class="text">Simple Persistent Layout - Page B</span>
+    <inertia-link href="/persistent-layouts/render-function/simple/page-a">Page A</inertia-link>
+  </div>
+</template>
+<script>
+import Layout from '@/Layouts/SiteLayout.vue'
+
+export default {
+  layout: (h, page) => h(Layout, [page]),
+}
+</script>

--- a/packages/vue3/tests/app/Pages/PersistentLayouts/Shorthand/Nested/PageA.vue
+++ b/packages/vue3/tests/app/Pages/PersistentLayouts/Shorthand/Nested/PageA.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <span class="text">Nested Persistent Layout - Page A</span>
+    <inertia-link href="/persistent-layouts/shorthand/nested/page-b">Page B</inertia-link>
+  </div>
+</template>
+<script>
+import NestedLayout from '@/Layouts/NestedLayout.vue'
+import SiteLayout from '@/Layouts/SiteLayout.vue'
+
+export default {
+  layout: [SiteLayout, NestedLayout],
+  created() {
+    // this.$.props for declared props
+    window._inertia_page_props = this.$.attrs
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/PersistentLayouts/Shorthand/Nested/PageB.vue
+++ b/packages/vue3/tests/app/Pages/PersistentLayouts/Shorthand/Nested/PageB.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <span class="text">Nested Persistent Layout - Page B</span>
+    <inertia-link href="/persistent-layouts/shorthand/nested/page-a">Page A</inertia-link>
+  </div>
+</template>
+<script>
+import NestedLayout from '@/Layouts/NestedLayout.vue'
+import SiteLayout from '@/Layouts/SiteLayout.vue'
+
+export default {
+  layout: [SiteLayout, NestedLayout],
+}
+</script>

--- a/packages/vue3/tests/app/Pages/PersistentLayouts/Shorthand/Simple/PageA.vue
+++ b/packages/vue3/tests/app/Pages/PersistentLayouts/Shorthand/Simple/PageA.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <span class="text">Simple Persistent Layout - Page A</span>
+    <inertia-link href="/persistent-layouts/shorthand/simple/page-b">Page B</inertia-link>
+  </div>
+</template>
+<script>
+import Layout from '@/Layouts/SiteLayout.vue'
+
+export default {
+  layout: Layout,
+  created() {
+    // this.$.props for declared props
+    window._inertia_page_props = this.$.attrs
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/PersistentLayouts/Shorthand/Simple/PageB.vue
+++ b/packages/vue3/tests/app/Pages/PersistentLayouts/Shorthand/Simple/PageB.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <span class="text">Simple Persistent Layout - Page B</span>
+    <inertia-link href="/persistent-layouts/shorthand/simple/page-a">Page A</inertia-link>
+  </div>
+</template>
+<script>
+import Layout from '@/Layouts/SiteLayout.vue'
+
+export default {
+  layout: Layout,
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Remember/Array.vue
+++ b/packages/vue3/tests/app/Pages/Remember/Array.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="full_name" v-model="name" />
+    </label>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="remember" />
+    </label>
+    <label>
+      Untracked
+      <input type="text" id="untracked" name="untracked" v-model="untracked" />
+    </label>
+
+    <inertia-link href="/dump/get" class="link">Navigate away</inertia-link>
+  </div>
+</template>
+<script>
+export default {
+  remember: ['name', 'remember'],
+  data: () => ({
+    name: '',
+    remember: false,
+    untracked: '',
+  }),
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Remember/Components/ComponentA.vue
+++ b/packages/vue3/tests/app/Pages/Remember/Components/ComponentA.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <span>This component uses a string 'key' for the remember functionality.</span>
+    <label>
+      Full Name
+      <input type="text" class="a-name" name="full_name" v-model="name" />
+    </label>
+    <label>
+      Remember Me
+      <input type="checkbox" class="a-remember" name="remember" v-model="remember" />
+    </label>
+    <label>
+      Remember Me
+      <input type="text" class="a-untracked" name="untracked" v-model="untracked" />
+    </label>
+  </div>
+</template>
+<script>
+export default {
+  remember: {
+    data: ['name', 'remember'],
+    key: 'Example/ComponentA',
+  },
+  data: () => ({
+    name: '',
+    remember: false,
+    untracked: '',
+  }),
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Remember/Components/ComponentB.vue
+++ b/packages/vue3/tests/app/Pages/Remember/Components/ComponentB.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <span>This component uses a callback-style 'key' for the remember functionality.</span>
+    <label>
+      Full Name
+      <input type="text" class="b-name" name="full_name" v-model="name" />
+    </label>
+    <label>
+      Remember Me
+      <input type="checkbox" class="b-remember" name="remember" v-model="remember" />
+    </label>
+    <label>
+      Remember Me
+      <input type="text" class="b-untracked" name="untracked" v-model="untracked" />
+    </label>
+  </div>
+</template>
+<script>
+export default {
+  remember: {
+    data: ['name', 'remember'],
+    key: () => 'Example/ComponentB',
+  },
+  data: () => ({
+    name: '',
+    remember: false,
+    untracked: '',
+  }),
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Remember/Default.vue
+++ b/packages/vue3/tests/app/Pages/Remember/Default.vue
@@ -1,0 +1,27 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="full_name" v-model="name" />
+    </label>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="remember" />
+    </label>
+    <label>
+      Untracked
+      <input type="text" id="untracked" name="untracked" v-model="untracked" />
+    </label>
+
+    <inertia-link href="/dump/get" class="link">Navigate away</inertia-link>
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    name: '',
+    remember: false,
+    untracked: '',
+  }),
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Remember/FormHelper/Default.vue
+++ b/packages/vue3/tests/app/Pages/Remember/FormHelper/Default.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="name" v-model="form.name" />
+    </label>
+    <span class="name_error" v-if="form.errors.name">{{ form.errors.name }}</span>
+    <label>
+      Handle
+      <input type="text" id="handle" name="handle" v-model="form.handle" />
+    </label>
+    <span class="handle_error" v-if="form.errors.handle">{{ form.errors.handle }}</span>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="form.remember" />
+    </label>
+    <span class="remember_error" v-if="form.errors.remember">{{ form.errors.remember }}</span>
+    <label>
+      Untracked
+      <input type="text" id="untracked" name="untracked" v-model="untracked" />
+    </label>
+
+    <span @click="submit" class="submit">Submit form</span>
+
+    <inertia-link href="/dump/get" class="link">Navigate away</inertia-link>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      untracked: '',
+      form: this.$inertia.form({
+        name: 'foo',
+        handle: 'example',
+        remember: false,
+      }),
+    }
+  },
+  methods: {
+    submit() {
+      this.form.post('/remember/form-helper/default')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Remember/FormHelper/Remember.vue
+++ b/packages/vue3/tests/app/Pages/Remember/FormHelper/Remember.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="name" v-model="form.name" />
+    </label>
+    <span class="name_error" v-if="form.errors.name">{{ form.errors.name }}</span>
+    <label>
+      Handle
+      <input type="text" id="handle" name="handle" v-model="form.handle" />
+    </label>
+    <span class="handle_error" v-if="form.errors.handle">{{ form.errors.handle }}</span>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="form.remember" />
+    </label>
+    <span class="remember_error" v-if="form.errors.remember">{{ form.errors.remember }}</span>
+    <label>
+      Untracked
+      <input type="text" id="untracked" name="untracked" v-model="untracked" />
+    </label>
+
+    <span @click="submit" class="submit">Submit form</span>
+    <span @click="reset" class="reset-one">Reset one field & error</span>
+
+    <inertia-link href="/dump/get" class="link">Navigate away</inertia-link>
+  </div>
+</template>
+<script>
+export default {
+  remember: 'form',
+  data() {
+    return {
+      untracked: '',
+      form: this.$inertia.form({
+        name: 'foo',
+        handle: 'example',
+        remember: false,
+      }),
+    }
+  },
+  methods: {
+    submit() {
+      this.form.post('/remember/form-helper/remember')
+    },
+    reset() {
+      this.form.reset('handle').clearErrors('name')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Remember/MultipleComponents.vue
+++ b/packages/vue3/tests/app/Pages/Remember/MultipleComponents.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="full_name" v-model="name" />
+    </label>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="remember" />
+    </label>
+    <label>
+      Untracked
+      <input type="text" id="untracked" name="untracked" v-model="untracked" />
+    </label>
+
+    <component-a class="component-a" />
+    <component-b class="component-b" />
+
+    <inertia-link href="/dump/get" class="link">Navigate away</inertia-link>
+    <a href="/non-inertia" class="off-site">Navigate off-site</a>
+  </div>
+</template>
+<script>
+import ComponentA from '@/Pages/Remember/Components/ComponentA.vue'
+import ComponentB from '@/Pages/Remember/Components/ComponentB.vue'
+
+export default {
+  components: {
+    ComponentA,
+    ComponentB,
+  },
+  remember: ['name', 'remember'],
+  data: () => ({
+    name: '',
+    remember: false,
+    untracked: '',
+  }),
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Remember/Object.vue
+++ b/packages/vue3/tests/app/Pages/Remember/Object.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="full_name" v-model="name" />
+    </label>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="remember" />
+    </label>
+    <label>
+      Untracked
+      <input type="text" id="untracked" name="untracked" v-model="untracked" />
+    </label>
+
+    <inertia-link href="/dump/get" class="link">Navigate away</inertia-link>
+  </div>
+</template>
+<script>
+export default {
+  remember: {
+    data: ['name', 'remember'],
+  },
+  data: () => ({
+    name: '',
+    remember: false,
+    untracked: '',
+  }),
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Remember/String.vue
+++ b/packages/vue3/tests/app/Pages/Remember/String.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <label>
+      Full Name
+      <input type="text" id="name" name="full_name" v-model="name" />
+    </label>
+    <label>
+      Remember Me
+      <input type="checkbox" id="remember" name="remember" v-model="remember" />
+    </label>
+    <label>
+      Untracked
+      <input type="text" id="untracked" name="untracked" v-model="untracked" />
+    </label>
+
+    <inertia-link href="/dump/get" class="link">Navigate away</inertia-link>
+  </div>
+</template>
+<script>
+export default {
+  remember: 'name',
+  data: () => ({
+    name: '',
+    remember: false,
+    untracked: '',
+  }),
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/AutomaticCancellation.vue
+++ b/packages/vue3/tests/app/Pages/Visits/AutomaticCancellation.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates that only one visit can be active at a time</span>
+    <span @click="visit" class="visit">Link</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    visit() {
+      this.$inertia.get(
+        '/sleep',
+        {},
+        {
+          onStart: () => alert('started'),
+          onCancel: () => alert('cancelled'),
+        },
+      )
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/Data/AutoConverted.vue
+++ b/packages/vue3/tests/app/Pages/Visits/Data/AutoConverted.vue
@@ -1,0 +1,45 @@
+<template>
+  <div>
+    <span class="text"
+      >This is the page that demonstrates automatic conversion of plain objects to form-data using manual visits</span
+    >
+
+    <span @click="visitMethod" class="visit">Visit Link</span>
+    <span @click="postMethod" class="post">POST Link</span>
+    <span @click="putMethod" class="put">PUT Link</span>
+    <span @click="patchMethod" class="patch">PATCH Link</span>
+    <span @click="deleteMethod" class="delete">DELETE Link</span>
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    formData: {
+      file: new File([], 'example.jpg'),
+      foo: 'bar',
+    },
+  }),
+  methods: {
+    visitMethod() {
+      this.$inertia.visit('/dump/post', {
+        method: 'post',
+        data: this.formData,
+      })
+    },
+    postMethod() {
+      this.$inertia.post('/dump/post', this.formData)
+    },
+    putMethod() {
+      this.$inertia.put('/dump/put', this.formData)
+    },
+    patchMethod() {
+      this.$inertia.patch('/dump/patch', this.formData)
+    },
+    deleteMethod() {
+      this.$inertia.delete('/dump/delete', {
+        data: this.formData,
+      })
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/Data/FormData.vue
+++ b/packages/vue3/tests/app/Pages/Visits/Data/FormData.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates manual visit data passing through FormData objects</span>
+
+    <span @click="visitMethod" class="visit">Visit Link</span>
+    <span @click="postMethod" class="post">POST Link</span>
+    <span @click="putMethod" class="put">PUT Link</span>
+    <span @click="patchMethod" class="patch">PATCH Link</span>
+    <span @click="deleteMethod" class="delete">DELETE Link</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    visitMethod() {
+      const formData = new FormData()
+      formData.append('foo', 'visit')
+
+      this.$inertia.visit('/dump/post', {
+        method: 'post',
+        data: formData,
+      })
+    },
+    postMethod() {
+      const formData = new FormData()
+      formData.append('baz', 'post')
+
+      this.$inertia.post('/dump/post', formData)
+    },
+    putMethod() {
+      const formData = new FormData()
+      formData.append('foo', 'put')
+
+      this.$inertia.put('/dump/put', formData)
+    },
+    patchMethod() {
+      const formData = new FormData()
+      formData.append('bar', 'patch')
+
+      this.$inertia.patch('/dump/patch', formData)
+    },
+    deleteMethod() {
+      const formData = new FormData()
+      formData.append('baz', 'delete')
+
+      this.$inertia.delete('/dump/delete', {
+        data: formData,
+      })
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/Data/Object.vue
+++ b/packages/vue3/tests/app/Pages/Visits/Data/Object.vue
@@ -1,0 +1,69 @@
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates manual visit data passing through plain objects</span>
+
+    <span @click="visitMethod" class="visit">Visit Link</span>
+    <span @click="getMethod" class="get">GET Link</span>
+    <span @click="postMethod" class="post">POST Link</span>
+    <span @click="putMethod" class="put">PUT Link</span>
+    <span @click="patchMethod" class="patch">PATCH Link</span>
+    <span @click="deleteMethod" class="delete">DELETE Link</span>
+
+    <span @click="qsafDefault" class="qsaf-default">QSAF Defaults</span>
+    <span @click="qsafIndices" class="qsaf-indices">QSAF Indices</span>
+    <span @click="qsafBrackets" class="qsaf-brackets">QSAF Brackets</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    visitMethod() {
+      this.$inertia.visit('/dump/get', {
+        data: { foo: 'visit' },
+      })
+    },
+    getMethod() {
+      this.$inertia.get('/dump/get', {
+        bar: 'get',
+      })
+    },
+    postMethod() {
+      this.$inertia.post('/dump/post', {
+        baz: 'post',
+      })
+    },
+    putMethod() {
+      this.$inertia.put('/dump/put', {
+        foo: 'put',
+      })
+    },
+    patchMethod() {
+      this.$inertia.patch('/dump/patch', {
+        bar: 'patch',
+      })
+    },
+    deleteMethod() {
+      this.$inertia.delete('/dump/delete', {
+        data: { baz: 'delete' },
+      })
+    },
+    qsafDefault() {
+      this.$inertia.visit('/dump/get', {
+        data: { a: ['b', 'c'] },
+      })
+    },
+    qsafIndices() {
+      this.$inertia.visit('/dump/get', {
+        data: { a: ['b', 'c'] },
+        queryStringArrayFormat: 'indices',
+      })
+    },
+    qsafBrackets() {
+      this.$inertia.visit('/dump/get', {
+        data: { a: ['b', 'c'] },
+        queryStringArrayFormat: 'brackets',
+      })
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/ErrorBags.vue
+++ b/packages/vue3/tests/app/Pages/Visits/ErrorBags.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates error bags using manual visits</span>
+    <span @click="defaultVisit" class="default">Default visit</span>
+    <span @click="basicVisit" class="visit">Basic visit</span>
+    <span @click="postVisit" class="get">POST visit</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    defaultVisit() {
+      this.$inertia.post('/dump/post')
+    },
+    basicVisit() {
+      this.$inertia.visit('/dump/post', {
+        method: 'post',
+        data: { foo: 'bar' },
+        errorBag: 'visitErrorBag',
+      })
+    },
+    postVisit() {
+      this.$inertia.post(
+        '/dump/post',
+        {
+          foo: 'baz',
+        },
+        {
+          errorBag: 'postErrorBag',
+        },
+      )
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/Headers.vue
+++ b/packages/vue3/tests/app/Pages/Visits/Headers.vue
@@ -1,0 +1,95 @@
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates passing custom headers through manual visits</span>
+
+    <span @click="defaultHeadersMethod" class="default">Standard visit Link</span>
+
+    <span @click="visitWithCustomHeaders" class="visit">Specific visit Link</span>
+    <span @click="getMethod" class="get">GET Link</span>
+    <span @click="postMethod" class="post">POST Link</span>
+    <span @click="putMethod" class="put">PUT Link</span>
+    <span @click="patchMethod" class="patch">PATCH Link</span>
+    <span @click="deleteMethod" class="delete">DELETE Link</span>
+
+    <span @click="overridden" class="overridden">DELETE Link</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    defaultHeadersMethod() {
+      this.$inertia.visit('/dump/get')
+    },
+    visitWithCustomHeaders() {
+      this.$inertia.visit('/dump/get', {
+        headers: {
+          foo: 'bar',
+        },
+      })
+    },
+    getMethod() {
+      this.$inertia.get(
+        '/dump/get',
+        {},
+        {
+          headers: {
+            bar: 'baz',
+          },
+        },
+      )
+    },
+    postMethod() {
+      this.$inertia.post(
+        '/dump/post',
+        {},
+        {
+          headers: {
+            baz: 'foo',
+          },
+        },
+      )
+    },
+    putMethod() {
+      this.$inertia.put(
+        '/dump/put',
+        {},
+        {
+          headers: {
+            foo: 'bar',
+          },
+        },
+      )
+    },
+    patchMethod() {
+      this.$inertia.patch(
+        '/dump/patch',
+        {},
+        {
+          headers: {
+            bar: 'baz',
+          },
+        },
+      )
+    },
+    deleteMethod() {
+      this.$inertia.delete('/dump/delete', {
+        headers: {
+          baz: 'foo',
+        },
+      })
+    },
+    overridden() {
+      this.$inertia.post(
+        '/dump/post',
+        {},
+        {
+          headers: {
+            bar: 'baz',
+            'X-Requested-With': 'custom',
+          },
+        },
+      )
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/Location.vue
+++ b/packages/vue3/tests/app/Pages/Visits/Location.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates location visits</span>
+
+    <span @click="locationVisit" class="example">Location visit</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    locationVisit() {
+      this.$inertia.get('/location')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/Method.vue
+++ b/packages/vue3/tests/app/Pages/Visits/Method.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates manual visit methods</span>
+
+    <span @click="standardVisitMethod" class="visit-get">Standard visit Link</span>
+    <span @click="specificVisitMethod" class="visit-specific">Specific visit Link</span>
+    <span @click="getMethod" class="get">GET Link</span>
+    <span @click="postMethod" class="post">POST Link</span>
+    <span @click="putMethod" class="put">PUT Link</span>
+    <span @click="patchMethod" class="patch">PATCH Link</span>
+    <span @click="deleteMethod" class="delete">DELETE Link</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    standardVisitMethod() {
+      this.$inertia.visit('/dump/get')
+    },
+    specificVisitMethod() {
+      this.$inertia.visit('/dump/patch', {
+        method: 'patch',
+      })
+    },
+    getMethod() {
+      this.$inertia.get('/dump/get')
+    },
+    postMethod() {
+      this.$inertia.post('/dump/post')
+    },
+    putMethod() {
+      this.$inertia.put('/dump/put')
+    },
+    patchMethod() {
+      this.$inertia.patch('/dump/patch')
+    },
+    deleteMethod() {
+      this.$inertia.delete('/dump/delete')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/PartialReloads.vue
+++ b/packages/vue3/tests/app/Pages/Visits/PartialReloads.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates partial reloads using manual visits</span>
+    <span class="foo-text">Foo is now {{ foo }}</span>
+    <span class="bar-text">Bar is now {{ bar }}</span>
+    <span class="baz-text">Baz is now {{ baz }}</span>
+    <pre class="headers">{{ headers }}</pre>
+
+    <span @click="partialReloadVisit" class="visit">Update All (visit)</span>
+    <span @click="partialReloadVisitFooBar" class="visit-foo-bar">'Only' foo + bar (visit)</span>
+    <span @click="partialReloadVisitBaz" class="visit-baz">'Only' baz (visit)</span>
+
+    <span @click="partialReloadGet" class="get">Update All (GET)</span>
+    <span @click="partialReloadGetFooBar" class="get-foo-bar">'Only' foo + bar (GET)</span>
+    <span @click="partialReloadGetBaz" class="get-baz">'Only' baz (GET)</span>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    foo: {
+      type: Number,
+      default: 0,
+    },
+    bar: Number,
+    baz: Number,
+    headers: Object,
+  },
+  created() {
+    window._inertia_props = this.$page.props
+  },
+  methods: {
+    partialReloadVisit() {
+      this.$inertia.visit('/visits/partial-reloads', {
+        data: { foo: this.foo },
+      })
+    },
+    partialReloadVisitFooBar() {
+      this.$inertia.visit('/visits/partial-reloads', {
+        data: { foo: this.foo },
+        only: ['headers', 'foo', 'bar'],
+      })
+    },
+    partialReloadVisitBaz() {
+      this.$inertia.visit('/visits/partial-reloads', {
+        data: { foo: this.foo },
+        only: ['headers', 'baz'],
+      })
+    },
+    partialReloadGet() {
+      this.$inertia.get('/visits/partial-reloads', {
+        foo: this.foo,
+      })
+    },
+    partialReloadGetFooBar() {
+      this.$inertia.get(
+        '/visits/partial-reloads',
+        {
+          foo: this.foo,
+        },
+        {
+          only: ['headers', 'foo', 'bar'],
+        },
+      )
+    },
+    partialReloadGetBaz() {
+      this.$inertia.get(
+        '/visits/partial-reloads',
+        {
+          foo: this.foo,
+        },
+        {
+          only: ['headers', 'baz'],
+        },
+      )
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/PartialReloads.vue
+++ b/packages/vue3/tests/app/Pages/Visits/PartialReloads.vue
@@ -9,10 +9,14 @@
     <span @click="partialReloadVisit" class="visit">Update All (visit)</span>
     <span @click="partialReloadVisitFooBar" class="visit-foo-bar">'Only' foo + bar (visit)</span>
     <span @click="partialReloadVisitBaz" class="visit-baz">'Only' baz (visit)</span>
+    <span @click="partialReloadVisitExceptFooBar" class="visit-except-foo-bar">'Except' foo + bar (visit)</span>
+    <span @click="partialReloadVisitExceptBaz" class="visit-except-baz">'Except' baz (visit)</span>
 
     <span @click="partialReloadGet" class="get">Update All (GET)</span>
     <span @click="partialReloadGetFooBar" class="get-foo-bar">'Only' foo + bar (GET)</span>
     <span @click="partialReloadGetBaz" class="get-baz">'Only' baz (GET)</span>
+    <span @click="partialReloadGetExceptFooBar" class="get-except-foo-bar">'Except' foo + bar (GET)</span>
+    <span @click="partialReloadGetExceptBaz" class="get-except-baz">'Except' baz (GET)</span>
   </div>
 </template>
 <script>
@@ -47,6 +51,18 @@ export default {
         only: ['headers', 'baz'],
       })
     },
+    partialReloadVisitExceptFooBar() {
+      this.$inertia.visit('/visits/partial-reloads', {
+        data: { foo: this.foo },
+        except: ['foo', 'bar'],
+      })
+    },
+    partialReloadVisitExceptBaz() {
+      this.$inertia.visit('/visits/partial-reloads', {
+        data: { foo: this.foo },
+        except: ['baz'],
+      })
+    },
     partialReloadGet() {
       this.$inertia.get('/visits/partial-reloads', {
         foo: this.foo,
@@ -71,6 +87,28 @@ export default {
         },
         {
           only: ['headers', 'baz'],
+        },
+      )
+    },
+    partialReloadGetExceptFooBar() {
+      this.$inertia.get(
+        '/visits/partial-reloads',
+        {
+          foo: this.foo,
+        },
+        {
+          except: ['foo', 'bar'],
+        },
+      )
+    },
+    partialReloadGetExceptBaz() {
+      this.$inertia.get(
+        '/visits/partial-reloads',
+        {
+          foo: this.foo,
+        },
+        {
+          except: ['baz'],
         },
       )
     },

--- a/packages/vue3/tests/app/Pages/Visits/PreserveScroll.vue
+++ b/packages/vue3/tests/app/Pages/Visits/PreserveScroll.vue
@@ -1,0 +1,79 @@
+<template>
+  <div style="height: 800px; width: 600px">
+    <span class="text"
+      >This is the page that demonstrates scroll preservation with scroll regions when using manual visits</span
+    >
+    <span class="foo">Foo is now {{ foo }}</span>
+
+    <span @click="preserve" class="preserve">Preserve Scroll</span>
+    <span @click="preserveFalse" class="reset">Reset Scroll</span>
+    <span @click="preserveCallback" class="preserve-callback">Preserve Scroll (Callback)</span>
+    <span @click="preserveCallbackFalse" class="reset-callback">Reset Scroll (Callback)</span>
+    <span @click="preserveGet" class="preserve-get">Preserve Scroll (GET)</span>
+    <span @click="preserveGetFalse" class="reset-get">Reset Scroll (GET)</span>
+
+    <a href="/non-inertia" class="off-site">Off-site link</a>
+  </div>
+</template>
+<script>
+import WithScrollRegion from '@/Layouts/WithScrollRegion.vue'
+
+export default {
+  layout: WithScrollRegion,
+  props: {
+    foo: {
+      type: String,
+      default: 'default',
+    },
+  },
+  methods: {
+    preserve() {
+      this.$inertia.visit('/visits/preserve-scroll-page-two', {
+        data: { foo: 'foo' },
+        preserveScroll: true,
+      })
+    },
+    preserveFalse() {
+      this.$inertia.visit('/visits/preserve-scroll-page-two', {
+        data: { foo: 'bar' },
+      })
+    },
+    preserveCallback() {
+      this.$inertia.visit('/visits/preserve-scroll-page-two', {
+        data: { foo: 'baz' },
+        preserveScroll: (page) => {
+          alert(page)
+
+          return true
+        },
+      })
+    },
+    preserveCallbackFalse() {
+      this.$inertia.visit('/visits/preserve-scroll-page-two', {
+        data: { foo: 'foo' },
+        preserveScroll: (page) => {
+          alert(page)
+
+          return false
+        },
+      })
+    },
+    preserveGet() {
+      this.$inertia.get(
+        '/visits/preserve-scroll-page-two',
+        {
+          foo: 'bar',
+        },
+        {
+          preserveScroll: true,
+        },
+      )
+    },
+    preserveGetFalse() {
+      this.$inertia.get('/visits/preserve-scroll-page-two', {
+        foo: 'baz',
+      })
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/PreserveScrollFalse.vue
+++ b/packages/vue3/tests/app/Pages/Visits/PreserveScrollFalse.vue
@@ -1,0 +1,79 @@
+<template>
+  <div style="height: 800px; width: 600px">
+    <span class="text"
+      >This is the page that demonstrates scroll preservation without scroll regions when using manual visits</span
+    >
+    <span class="foo">Foo is now {{ foo }}</span>
+
+    <span @click="preserve" class="preserve">Preserve Scroll</span>
+    <span @click="preserveFalse" class="reset">Reset Scroll</span>
+    <span @click="preserveCallback" class="preserve-callback">Preserve Scroll (Callback)</span>
+    <span @click="preserveCallbackFalse" class="reset-callback">Reset Scroll (Callback)</span>
+    <span @click="preserveGet" class="preserve-get">Preserve Scroll (GET)</span>
+    <span @click="preserveGetFalse" class="reset-get">Reset Scroll (GET)</span>
+
+    <a href="/non-inertia" class="off-site">Off-site link</a>
+  </div>
+</template>
+<script>
+import WithoutScrollRegion from '@/Layouts/WithoutScrollRegion.vue'
+
+export default {
+  layout: WithoutScrollRegion,
+  props: {
+    foo: {
+      type: String,
+      default: 'default',
+    },
+  },
+  methods: {
+    preserve() {
+      this.$inertia.visit('/visits/preserve-scroll-false-page-two', {
+        data: { foo: 'foo' },
+        preserveScroll: true,
+      })
+    },
+    preserveFalse() {
+      this.$inertia.visit('/visits/preserve-scroll-false-page-two', {
+        data: { foo: 'bar' },
+      })
+    },
+    preserveCallback() {
+      this.$inertia.visit('/visits/preserve-scroll-false-page-two', {
+        data: { foo: 'baz' },
+        preserveScroll: (page) => {
+          alert(page)
+
+          return true
+        },
+      })
+    },
+    preserveCallbackFalse() {
+      this.$inertia.visit('/visits/preserve-scroll-false-page-two', {
+        data: { foo: 'foo' },
+        preserveScroll: (page) => {
+          alert(page)
+
+          return false
+        },
+      })
+    },
+    preserveGet() {
+      this.$inertia.get(
+        '/visits/preserve-scroll-false-page-two',
+        {
+          foo: 'bar',
+        },
+        {
+          preserveScroll: true,
+        },
+      )
+    },
+    preserveGetFalse() {
+      this.$inertia.get('/visits/preserve-scroll-false-page-two', {
+        foo: 'baz',
+      })
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/PreserveState.vue
+++ b/packages/vue3/tests/app/Pages/Visits/PreserveState.vue
@@ -1,0 +1,96 @@
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates preserve state on manual visits</span>
+    <span class="foo">Foo is now {{ foo }}</span>
+    <label>
+      Example Field
+      <input type="text" name="example-field" class="field" />
+    </label>
+
+    <span @click="preserve" class="preserve">[State] Preserve visit: true</span>
+    <span @click="preserveFalse" class="preserve-false">[State] Preserve visit: false</span>
+    <span @click="preserveCallback" class="preserve-callback">[State] Preserve Callback: true</span>
+    <span @click="preserveCallbackFalse" class="preserve-callback-false">[State] Preserve Callback: false</span>
+    <span @click="preserveGet" class="preserve-get">[State] Preserve GET: true</span>
+    <span @click="preserveGetFalse" class="preserve-get-false">[State] Preserve GET: false</span>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    foo: {
+      type: String,
+      default: 'default',
+    },
+  },
+  mounted() {
+    window._inertia_page_key = this.$.vnode.key
+  },
+  methods: {
+    preserve() {
+      this.$inertia.visit('/visits/preserve-state-page-two', {
+        data: { foo: 'bar' },
+        preserveState: true,
+      })
+    },
+    preserveFalse() {
+      this.$inertia.visit('/visits/preserve-state-page-two', {
+        data: { foo: 'baz' },
+        preserveState: false,
+      })
+    },
+    preserveCallback() {
+      this.$inertia.get(
+        '/visits/preserve-state-page-two',
+        {
+          foo: 'callback-bar',
+        },
+        {
+          preserveState: (page) => {
+            alert(page)
+
+            return true
+          },
+        },
+      )
+    },
+    preserveCallbackFalse() {
+      this.$inertia.get(
+        '/visits/preserve-state-page-two',
+        {
+          foo: 'callback-baz',
+        },
+        {
+          preserveState: (page) => {
+            alert(page)
+
+            return false
+          },
+        },
+      )
+    },
+    preserveGet() {
+      this.$inertia.get(
+        '/visits/preserve-state-page-two',
+        {
+          foo: 'get-bar',
+        },
+        {
+          preserveState: true,
+        },
+      )
+    },
+    preserveGetFalse() {
+      this.$inertia.get(
+        '/visits/preserve-state-page-two',
+        {
+          foo: 'get-baz',
+        },
+        {
+          preserveState: false,
+        },
+      )
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/Replace.vue
+++ b/packages/vue3/tests/app/Pages/Visits/Replace.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <span class="text">This is the links page that demonstrates manual replace</span>
+
+    <span @click="replace" class="replace">[State] Replace visit: true</span>
+    <span @click="replaceFalse" class="replace-false">[State] Replace visit: false</span>
+    <span @click="replaceGet" class="replace-get">[State] Replace GET: true</span>
+    <span @click="replaceGetFalse" class="replace-get-false">[State] Replace GET: false</span>
+  </div>
+</template>
+<script>
+export default {
+  methods: {
+    replace() {
+      this.$inertia.visit('/dump/get', {
+        replace: true,
+      })
+    },
+    replaceFalse() {
+      this.$inertia.visit('/dump/get', {
+        replace: false,
+      })
+    },
+    replaceGet() {
+      this.$inertia.get(
+        '/dump/get',
+        {},
+        {
+          replace: true,
+        },
+      )
+    },
+    replaceGetFalse() {
+      this.$inertia.get(
+        '/dump/get',
+        {},
+        {
+          replace: false,
+        },
+      )
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/Pages/Visits/UrlFragments.vue
+++ b/packages/vue3/tests/app/Pages/Visits/UrlFragments.vue
@@ -1,0 +1,56 @@
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates url fragment behaviour using manual visits</span>
+    <div style="width: 200vw; height: 200vh; margin-top: 50vh">
+      <!-- prettier-ignore -->
+      <div class="document-position">Document scroll position is {{ documentScrollLeft }} & {{ documentScrollTop }}</div>
+      <span @click="basicVisit" class="basic">Basic visit</span>
+      <span @click="fragmentVisit" class="fragment">Fragment visit</span>
+      <span @click="nonExistentFragmentVisit" class="non-existent-fragment">Non-existent fragment visit</span>
+
+      <span @click="basicGetVisit" class="basic-get">Basic GET visit</span>
+      <span @click="fragmentGetVisit" class="fragment-get">Fragment GET visit</span>
+      <span @click="nonExistentFragmentGetVisit" class="non-existent-fragment-get">Non-existent fragment visit</span>
+
+      <div id="target">This is the element with id 'target'</div>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    documentScrollTop: 0,
+    documentScrollLeft: 0,
+  }),
+  created() {
+    document.addEventListener('scroll', this.handleScrollEvent)
+  },
+  beforeDestroy() {
+    document.removeEventListener('scroll', this.handleScrollEvent)
+  },
+  methods: {
+    handleScrollEvent() {
+      this.documentScrollTop = document.documentElement.scrollTop
+      this.documentScrollLeft = document.documentElement.scrollLeft
+    },
+    basicVisit() {
+      this.$inertia.visit('/visits/url-fragments#target')
+    },
+    fragmentVisit() {
+      this.$inertia.visit('#target')
+    },
+    nonExistentFragmentVisit() {
+      this.$inertia.visit('/visits/url-fragments#non-existent-fragment')
+    },
+    basicGetVisit() {
+      this.$inertia.get('/visits/url-fragments#target')
+    },
+    fragmentGetVisit() {
+      this.$inertia.get('#target')
+    },
+    nonExistentFragmentGetVisit() {
+      this.$inertia.get('/visits/url-fragments#non-existent-fragment')
+    },
+  },
+}
+</script>

--- a/packages/vue3/tests/app/app.js
+++ b/packages/vue3/tests/app/app.js
@@ -1,0 +1,24 @@
+import { createInertiaApp, Link, router } from '@inertiajs/vue3'
+import { createApp, createSSRApp, h } from 'vue'
+
+window.testing = {}
+window.testing.Inertia = router
+
+createInertiaApp({
+  page: window.initialPage,
+  resolve: (name) => {
+    const pages = import.meta.glob('./Pages/**/*.vue', { eager: true })
+    return pages[`./Pages/${name}.vue`]
+  },
+  setup({ el, App, props, plugin }) {
+    const withPlugin = !window.location.pathname.startsWith('/plugin/without')
+
+    // Required for testing purposes
+    props.initialComponent.inheritAttrs = true
+
+    window.testing.vue = createSSRApp(App, props)
+    .component('InertiaLink', Link)
+    .use(withPlugin ? plugin : undefined)
+    .mount(el)
+  },
+})

--- a/packages/vue3/tests/app/app.js
+++ b/packages/vue3/tests/app/app.js
@@ -1,5 +1,5 @@
 import { createInertiaApp, Link, router } from '@inertiajs/vue3'
-import { createApp, createSSRApp, h } from 'vue'
+import { createSSRApp, h } from 'vue'
 
 window.testing = {}
 window.testing.Inertia = router

--- a/packages/vue3/tests/app/helpers.js
+++ b/packages/vue3/tests/app/helpers.js
@@ -1,0 +1,51 @@
+const path = require('path')
+const fs = require('fs')
+
+module.exports = {
+  render: (req, res, data) => {
+    data = {
+      component: req.path
+        .slice(1)
+        .split('/')
+        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+        .join('/')
+        .split('-')
+        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+        .join(''),
+      props: {},
+      url: req.path,
+      version: null,
+      ...data,
+    }
+
+    const partialDataHeader = req.headers['x-inertia-partial-data'] || ''
+    const partialComponentHeader = req.headers['x-inertia-partial-component'] || ''
+    data.props = Object.keys(data.props)
+      .filter(
+        (key) =>
+          !partialComponentHeader ||
+          partialComponentHeader !== data.component ||
+          !partialDataHeader ||
+          partialDataHeader.split(',').indexOf(key) > -1,
+      )
+      .reduce((carry, key) => {
+        carry[key] = typeof data.props[key] === 'function' ? data.props[key](data.props) : data.props[key]
+
+        return carry
+      }, {})
+
+    if (req.get('X-Inertia')) {
+      res.header('Vary', 'Accept')
+      res.header('X-Inertia', true)
+      return res.json(data)
+    }
+
+    return res.send(
+      fs
+        .readFileSync(path.resolve(__dirname, './dist/index.html'))
+        .toString()
+        .replace("'{{ placeholder }}'", JSON.stringify(data)),
+    )
+  },
+  location: (res, href) => res.status(409).header('X-Inertia-Location', href).send(''),
+}

--- a/packages/vue3/tests/app/helpers.js
+++ b/packages/vue3/tests/app/helpers.js
@@ -19,15 +19,14 @@ module.exports = {
     }
 
     const partialDataHeader = req.headers['x-inertia-partial-data'] || ''
+    const partialExceptHeader = req.headers['x-inertia-partial-except'] || ''
     const partialComponentHeader = req.headers['x-inertia-partial-component'] || ''
+
+    const isPartial = partialComponentHeader && partialComponentHeader === data.component
+
     data.props = Object.keys(data.props)
-      .filter(
-        (key) =>
-          !partialComponentHeader ||
-          partialComponentHeader !== data.component ||
-          !partialDataHeader ||
-          partialDataHeader.split(',').indexOf(key) > -1,
-      )
+      .filter((key) => !isPartial || !partialDataHeader || partialDataHeader.split(',').indexOf(key) > -1)
+      .filter((key) => !isPartial || !partialExceptHeader || partialExceptHeader.split(',').indexOf(key) == -1)
       .reduce((carry, key) => {
         carry[key] = typeof data.props[key] === 'function' ? data.props[key](data.props) : data.props[key]
 

--- a/packages/vue3/tests/app/index.html
+++ b/packages/vue3/tests/app/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Inertia Vue - Testing Environment</title>
+    <script>
+      window.initialPage = '{{ placeholder }}'
+    </script>
+    <script type="module" src="app.js"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/packages/vue3/tests/app/server.js
+++ b/packages/vue3/tests/app/server.js
@@ -1,0 +1,183 @@
+const path = require('path')
+const express = require('express')
+const inertia = require('./helpers')
+const bodyParser = require('body-parser')
+const multer = require('multer')
+
+const app = express()
+app.use(bodyParser.urlencoded({ extended: true }))
+app.use(bodyParser.json({ extended: true }))
+const upload = multer()
+
+// Used because Cypress does not allow you to navigate to a different origin URL within a single test.
+app.all('/non-inertia', (req, res) => res.send('This is a page that does not have the Inertia app loaded.'))
+
+// Intercepts all .js assets (including files loaded via code splitting)
+app.get(/.*\.js$/, (req, res) => res.sendFile(path.resolve(__dirname, './dist/', req.path.substr(1))))
+
+/**
+ * Used for testing the Inertia plugin is registered.
+ * @see plugin.test.js
+ */
+app.get('/plugin/*', (req, res) =>
+  inertia.render(req, res, {
+    component: 'Home',
+    props: {
+      example: 'FooBar',
+    },
+  }),
+)
+
+/**
+ * Our actual 'app' routes
+ */
+app.get('/', (req, res) =>
+  inertia.render(req, res, {
+    component: 'Home',
+    props: {
+      example: 'FooBar',
+    },
+  }),
+)
+
+app.get('/links/partial-reloads', (req, res) =>
+  inertia.render(req, res, {
+    component: 'Links/PartialReloads',
+    props: {
+      headers: req.headers,
+      foo: Number.parseInt(req.query.foo || 0) + 1,
+      bar: (props) => props.foo + 1,
+      baz: (props) => props.foo + 2,
+    },
+  }),
+)
+app.all('/links/preserve-state-page-two', (req, res) =>
+  inertia.render(req, res, { component: 'Links/PreserveState', props: { foo: req.query.foo } }),
+)
+app.all('/links/preserve-scroll-page-two', (req, res) =>
+  inertia.render(req, res, { component: 'Links/PreserveScroll', props: { foo: req.query.foo } }),
+)
+app.all('/links/preserve-scroll-false-page-two', (req, res) =>
+  inertia.render(req, res, { component: 'Links/PreserveScrollFalse', props: { foo: req.query.foo } }),
+)
+app.get('/links/as-warning/:method', (req, res) =>
+  inertia.render(req, res, { component: 'Links/AsWarning', props: { method: req.params.method } }),
+)
+app.get('/links/as-warning-false/:method', (req, res) =>
+  inertia.render(req, res, { component: 'Links/AsWarningFalse', props: { method: req.params.method } }),
+)
+app.get('/links/headers/version', (req, res) =>
+  inertia.render(req, res, { component: 'Links/Headers', version: 'example-version-header' }),
+)
+
+app.get('/visits/partial-reloads', (req, res) =>
+  inertia.render(req, res, {
+    component: 'Visits/PartialReloads',
+    props: {
+      headers: req.headers,
+      foo: Number.parseInt(req.query.foo || 0) + 1,
+      bar: (props) => props.foo + 1,
+      baz: (props) => props.foo + 2,
+    },
+  }),
+)
+app.all('/visits/preserve-state-page-two', (req, res) =>
+  inertia.render(req, res, { component: 'Visits/PreserveState', props: { foo: req.query.foo } }),
+)
+app.all('/visits/preserve-scroll-page-two', (req, res) =>
+  inertia.render(req, res, { component: 'Visits/PreserveScroll', props: { foo: req.query.foo } }),
+)
+app.all('/visits/preserve-scroll-false-page-two', (req, res) =>
+  inertia.render(req, res, { component: 'Visits/PreserveScrollFalse', props: { foo: req.query.foo } }),
+)
+app.post('/visits/events-errors', (req, res) =>
+  inertia.render(req, res, { component: 'Visits/Events', props: { errors: { foo: 'bar' } } }),
+)
+app.get('/visits/headers/version', (req, res) =>
+  inertia.render(req, res, { component: 'Visits/Headers', version: 'example-version-header' }),
+)
+
+app.post('/remember/form-helper/default', (req, res) =>
+  inertia.render(req, res, {
+    component: 'Remember/FormHelper/Default',
+    props: { errors: { name: 'Some name error', handle: 'The Handle was invalid' } },
+  }),
+)
+app.post('/remember/form-helper/remember', (req, res) =>
+  inertia.render(req, res, {
+    component: 'Remember/FormHelper/Remember',
+    props: { errors: { name: 'Some name error', handle: 'The Handle was invalid' } },
+  }),
+)
+
+app.post('/form-helper/data', (req, res) =>
+  inertia.render(req, res, {
+    component: 'FormHelper/Data',
+    props: { errors: { name: 'Some name error', handle: 'The Handle was invalid' } },
+  }),
+)
+app.post('/form-helper/errors', (req, res) =>
+  inertia.render(req, res, {
+    component: 'FormHelper/Errors',
+    props: { errors: { name: 'Some name error', handle: 'The Handle was invalid' } },
+  }),
+)
+app.post('/form-helper/events/errors', (req, res) =>
+  inertia.render(req, res, {
+    component: 'FormHelper/Events',
+    props: { errors: { name: 'Some name error', handle: 'The Handle was invalid' } },
+  }),
+)
+
+app.get('/dump/get', upload.any(), (req, res) =>
+  inertia.render(req, res, {
+    component: 'Dump',
+    props: { headers: req.headers, method: 'get', form: req.body, query: req.query, files: req.files },
+  }),
+)
+app.post('/dump/post', upload.any(), (req, res) =>
+  inertia.render(req, res, {
+    component: 'Dump',
+    props: { headers: req.headers, method: 'post', form: req.body, query: req.query, files: req.files },
+  }),
+)
+app.put('/dump/put', upload.any(), (req, res) =>
+  inertia.render(req, res, {
+    component: 'Dump',
+    props: { headers: req.headers, method: 'put', form: req.body, query: req.query, files: req.files },
+  }),
+)
+app.patch('/dump/patch', upload.any(), (req, res) =>
+  inertia.render(req, res, {
+    component: 'Dump',
+    props: { headers: req.headers, method: 'patch', form: req.body, query: req.query, files: req.files },
+  }),
+)
+app.delete('/dump/delete', upload.any(), (req, res) =>
+  inertia.render(req, res, {
+    component: 'Dump',
+    props: { headers: req.headers, method: 'delete', form: req.body, query: req.query, files: req.files },
+  }),
+)
+
+app.get('/persistent-layouts/shorthand/simple/page-a', (req, res) =>
+  inertia.render(req, res, { props: { foo: 'bar', baz: 'example' } }),
+)
+app.get('/persistent-layouts/shorthand/nested/page-a', (req, res) =>
+  inertia.render(req, res, { props: { foo: 'bar', baz: 'example' } }),
+)
+
+app.post('/events/errors', (req, res) =>
+  inertia.render(req, res, { component: 'Events', props: { errors: { foo: 'bar' } } }),
+)
+
+app.all('/sleep', (req, res) => setTimeout(() => res.send(''), 2000))
+app.post('/redirect', (req, res) => res.redirect(303, '/dump/get'))
+app.get('/location', ({ res }) => inertia.location(res, '/dump/get'))
+app.post('/redirect-external', (req, res) => inertia.location(res, '/non-inertia'))
+app.post('/disconnect', (req, res) => res.connection.destroy())
+app.post('/json', (req, res) => res.json({ foo: 'bar' }))
+
+app.all('*', (req, res) => inertia.render(req, res))
+
+app.listen(13715)

--- a/packages/vue3/tests/app/vite.config.js
+++ b/packages/vue3/tests/app/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': __dirname,
+    },
+  },
+  plugins: [vue()],
+})

--- a/packages/vue3/tests/cypress.config.ts
+++ b/packages/vue3/tests/cypress.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    specPattern: "cypress/integration/*.{js,jsx,ts,tsx}",
+    "baseUrl": "http://localhost:13715",
+    "video": false,
+    "screenshotOnRunFailure": false,
+    "retries": {
+      "runMode": 4,
+      "openMode": 2
+    }
+  },
+});

--- a/packages/vue3/tests/cypress/fixtures/example.json
+++ b/packages/vue3/tests/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/packages/vue3/tests/cypress/integration/error-modal.cy.js
+++ b/packages/vue3/tests/cypress/integration/error-modal.cy.js
@@ -1,0 +1,41 @@
+describe('Error Modal', () => {
+  beforeEach(() => {
+    cy.visit('/error-modal', {
+      onLoad: () =>
+        cy.on('window:load', () => {
+          alert('A location/non-SPA visit was detected')
+        }),
+    })
+  })
+
+  it('displays the modal containing the response as HTML when an invalid Inertia response comes back', () => {
+    cy.get('.invalid-visit').click()
+
+    cy.get('iframe').should('exist')
+    cy.get('iframe').should('have.length', 1)
+    cy.get('iframe')
+      .its('0.contentDocument')
+      .should('have.text', 'This is a page that does not have the Inertia app loaded.')
+  })
+
+  it('displays the modal with a helpful message when a regular JSON response comes back instead of an Inertia response', () => {
+    cy.get('.invalid-visit-json').click()
+
+    cy.get('iframe').should('exist')
+    cy.get('iframe').should('have.length', 1)
+    cy.get('iframe')
+      .its('0.contentDocument')
+      .should(
+        'contain.text',
+        'All Inertia requests must receive a valid Inertia response, however a plain JSON response was received.',
+      )
+    cy.get('iframe').its('0.contentDocument').should('contain.text', '{"foo":"bar"}')
+  })
+
+  it('can close the modal using the escape key', () => {
+    cy.get('.invalid-visit').click()
+    cy.get('iframe').should('exist')
+    cy.get('body').type('{esc}')
+    cy.get('iframe').should('not.exist')
+  })
+})

--- a/packages/vue3/tests/cypress/integration/events.cy.js
+++ b/packages/vue3/tests/cypress/integration/events.cy.js
@@ -1,0 +1,822 @@
+import { tap } from '../support/commands'
+
+const assertVisitObject = (visit) => {
+  expect(visit).to.be.an('object')
+  expect(visit).to.have.property('url')
+  expect(visit).to.have.property('method')
+  expect(visit).to.have.property('data')
+  expect(visit).to.have.property('headers')
+  expect(visit).to.have.property('preserveState')
+}
+const assertPageObject = (page) => {
+  expect(page).to.be.an('object')
+  expect(page).to.have.property('component')
+  expect(page).to.have.property('props')
+  expect(page).to.have.property('url')
+  expect(page).to.have.property('version')
+}
+const assertProgressObject = (progress) => {
+  expect(progress).to.have.property('percentage')
+  expect(progress).to.have.property('total')
+  expect(progress).to.have.property('loaded')
+  expect(progress.percentage).to.be.gte(0).and.lte(100)
+}
+
+describe('Events', () => {
+  let alert = null
+  beforeEach(() => {
+    cy.visit('/events', {
+      onLoad: () =>
+        cy.on('window:load', () => {
+          throw 'A location/non-SPA visit was detected'
+        }),
+    })
+
+    alert = cy.stub()
+    cy.on('window:alert', alert)
+  })
+
+  describe('Listeners', () => {
+    it('does not have any listeners by default', () => {
+      cy.get('.without-listeners')
+        .click()
+        .wait(30)
+        .then(() => {
+          expect(alert.getCalls()).to.have.length(0)
+        })
+    })
+
+    describe('Inertia.on', () => {
+      it('returns a callback that can be used to remove the global listener', () => {
+        cy.get('.remove-inertia-listener')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(3)
+            expect(alert.getCall(0)).to.be.calledWith('Removing Inertia.on Listener')
+            expect(alert.getCall(1)).to.be.calledWith('onBefore')
+            expect(alert.getCall(2)).to.be.calledWith('onStart')
+          })
+      })
+    })
+  })
+
+  describe('Hooks', () => {
+    describe('before', () => {
+      it('fires the event when a request is about to be made', () => {
+        const assertGlobalEvent = (event) => {
+          expect(event).to.be.an('CustomEvent')
+          expect(event.type).to.eq('inertia:before')
+
+          expect(event).to.have.property('cancelable')
+          expect(event.cancelable).to.be.true
+
+          expect(event).to.have.property('detail')
+          tap(event.detail, (detail) => {
+            expect(detail).to.be.an('object')
+            expect(detail).to.have.property('visit')
+            assertVisitObject(detail.visit)
+          })
+        }
+
+        cy.get('.before')
+          .click()
+          .wait(30)
+          .then(() => {
+            // Local Event Callback
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            assertVisitObject(alert.getCall(1).lastArg)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(2)).to.be.calledWith('Inertia.on(before)')
+            assertGlobalEvent(alert.getCall(3).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(4)).to.be.calledWith('addEventListener(inertia:before)')
+            assertGlobalEvent(alert.getCall(5).lastArg)
+
+            // Ensure the listeners did not prevent the visit
+            expect(alert.getCall(6)).to.be.calledWith('onStart')
+          })
+          .get('.link-before')
+          .click()
+          .wait(30)
+          .then(() => {
+            // Link Event Callback
+            expect(alert.getCall(7)).to.be.calledWith('linkOnBefore')
+            assertVisitObject(alert.getCall(8).lastArg)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(9)).to.be.calledWith('Inertia.on(before)')
+            assertGlobalEvent(alert.getCall(10).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(11)).to.be.calledWith('addEventListener(inertia:before)')
+            assertGlobalEvent(alert.getCall(12).lastArg)
+
+            // Ensure the listeners did not prevent the visit
+            expect(alert.getCall(13)).to.be.calledWith('linkOnStart')
+          })
+      })
+
+      describe('Local Event Callbacks', () => {
+        it('can prevent the visit by returning false ', () => {
+          cy.get('.before-prevent-local')
+            .click()
+            .wait(30)
+            .then(() => {
+              expect(alert.getCalls()).to.have.length(1)
+              expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            })
+            .get('.link-before-prevent-local')
+            .click()
+            .wait(30)
+            .then(() => {
+              expect(alert.getCalls()).to.have.length(2)
+              expect(alert.getCall(1)).to.be.calledWith('linkOnBefore')
+            })
+        })
+      })
+
+      describe('Global Inertia.on', () => {
+        it('can prevent the visit by returning false ', () => {
+          cy.get('.before-prevent-global-inertia')
+            .click()
+            .wait(30)
+            .then(() => {
+              expect(alert.getCalls()).to.have.length(3)
+              expect(alert.getCall(0)).to.be.calledWith('onBefore')
+              expect(alert.getCall(1)).to.be.calledWith('addEventListener(inertia:before)')
+              expect(alert.getCall(2)).to.be.calledWith('Inertia.on(before)')
+            })
+        })
+      })
+
+      describe('Global addEventListener', () => {
+        it('can prevent the visit by using preventDefault', () => {
+          cy.get('.before-prevent-global-native')
+            .click()
+            .wait(30)
+            .then(() => {
+              expect(alert.getCalls()).to.have.length(3)
+              expect(alert.getCall(0)).to.be.calledWith('onBefore')
+              expect(alert.getCall(1)).to.be.calledWith('Inertia.on(before)')
+              expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:before)')
+            })
+        })
+      })
+    })
+
+    describe('cancelToken', () => {
+      it('fires when the request is starting', () => {
+        const assertCancelToken = (token) => {
+          expect(token).to.be.an('object')
+          expect(token).to.have.property('cancel')
+        }
+
+        cy.get('.canceltoken')
+          .click()
+          .wait(30)
+          .then(() => {
+            // Assert that it only gets fired locally.
+            expect(alert.getCalls()).to.have.length(2)
+
+            // Local Event Callback
+            expect(alert.getCall(0)).to.be.calledWith('onCancelToken')
+            assertCancelToken(alert.getCall(1).lastArg)
+          })
+          .get('.link-canceltoken')
+          .click()
+          .wait(30)
+          .then(() => {
+            // Assert that it only gets fired locally.
+            expect(alert.getCalls()).to.have.length(4)
+
+            // Link Event Callback
+            expect(alert.getCall(2)).to.be.calledWith('linkOnCancelToken')
+            assertCancelToken(alert.getCall(3).lastArg)
+          })
+      })
+    })
+
+    describe('cancel', () => {
+      it('fires when the request was cancelled', () => {
+        cy.get('.cancel')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(2)
+            expect(alert.getCall(0)).to.be.calledWith('onCancel')
+            expect(alert.getCall(1)).to.be.calledWith(undefined)
+          })
+          .get('.link-cancel')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(4)
+            expect(alert.getCall(2)).to.be.calledWith('linkOnCancel')
+            expect(alert.getCall(3)).to.be.calledWith(undefined)
+          })
+      })
+    })
+
+    describe('start', () => {
+      it('fires when the request has started', () => {
+        const assertGlobalEvent = (event) => {
+          expect(event).to.be.an('CustomEvent')
+          expect(event.type).to.eq('inertia:start')
+
+          expect(event).to.have.property('cancelable')
+          expect(event.cancelable).to.be.false
+
+          expect(event).to.have.property('detail')
+          tap(event.detail, (detail) => {
+            expect(detail).to.be.an('object')
+            expect(detail).to.have.property('visit')
+            assertVisitObject(detail.visit)
+          })
+        }
+
+        cy.get('.start')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(6)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(0)).to.be.calledWith('Inertia.on(start)')
+            assertGlobalEvent(alert.getCall(1).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:start)')
+            assertGlobalEvent(alert.getCall(3).lastArg)
+
+            // Local Event Callback
+            expect(alert.getCall(4)).to.be.calledWith('onStart')
+            assertVisitObject(alert.getCall(5).lastArg)
+          })
+          .get('.link-start')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(12)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(6)).to.be.calledWith('Inertia.on(start)')
+            assertGlobalEvent(alert.getCall(7).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(8)).to.be.calledWith('addEventListener(inertia:start)')
+            assertGlobalEvent(alert.getCall(9).lastArg)
+
+            // Local Event Callback
+            expect(alert.getCall(10)).to.be.calledWith('linkOnStart')
+            assertVisitObject(alert.getCall(11).lastArg)
+          })
+      })
+    })
+
+    describe('progress', () => {
+      it('fires when the request has files and upload progression occurs', () => {
+        const assertGlobalEvent = (event) => {
+          expect(event).to.be.an('CustomEvent')
+          expect(event.type).to.eq('inertia:progress')
+
+          expect(event).to.have.property('cancelable')
+          expect(event.cancelable).to.be.false
+
+          expect(event).to.have.property('detail')
+          tap(event.detail, (detail) => {
+            expect(detail).to.be.an('object')
+            expect(detail).to.have.property('progress')
+            assertProgressObject(detail.progress)
+          })
+        }
+
+        cy.get('.progress')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(6)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(0)).to.be.calledWith('Inertia.on(progress)')
+            assertGlobalEvent(alert.getCall(1).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:progress)')
+            assertGlobalEvent(alert.getCall(3).lastArg)
+
+            // Local Event Callback
+            expect(alert.getCall(4)).to.be.calledWith('onProgress')
+            assertProgressObject(alert.getCall(5).lastArg)
+          })
+          .get('.link-progress')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(12)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(6)).to.be.calledWith('Inertia.on(progress)')
+            assertGlobalEvent(alert.getCall(7).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(8)).to.be.calledWith('addEventListener(inertia:progress)')
+            assertGlobalEvent(alert.getCall(9).lastArg)
+
+            // Local Event Callback
+            expect(alert.getCall(10)).to.be.calledWith('linkOnProgress')
+            assertProgressObject(alert.getCall(11).lastArg)
+          })
+      })
+
+      it('does not fire when the request has no files', () => {
+        cy.get('.progress-no-files')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(1)
+            expect(alert.getCall(0)).to.be.calledWith('progressNoFilesOnBefore')
+          })
+          .get('.link-progress-no-files')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(2)
+            expect(alert.getCall(1)).to.be.calledWith('linkProgressNoFilesOnBefore')
+          })
+      })
+
+      describe('error', () => {
+        it('fires when the request finishes with validation errors', () => {
+          const assertErrorsObject = (errors) => {
+            expect(errors).to.be.an('object')
+            expect(errors).to.have.property('foo')
+            expect(errors.foo).to.eq('bar')
+          }
+          const assertGlobalEvent = (event) => {
+            expect(event).to.be.an('CustomEvent')
+            expect(event.type).to.eq('inertia:error')
+
+            expect(event).to.have.property('cancelable')
+            expect(event.cancelable).to.be.false
+
+            expect(event).to.have.property('detail')
+            tap(event.detail, (detail) => {
+              expect(detail).to.be.an('object')
+              expect(detail).to.have.property('errors')
+              assertErrorsObject(detail.errors)
+            })
+          }
+
+          cy.get('.error')
+            .click()
+            .wait(30)
+            .then(() => {
+              expect(alert.getCalls()).to.have.length(6)
+
+              // Global Inertia Event Listener
+              expect(alert.getCall(0)).to.be.calledWith('Inertia.on(error)')
+              assertGlobalEvent(alert.getCall(1).lastArg)
+
+              // Global Native Event Listener
+              expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:error)')
+              assertGlobalEvent(alert.getCall(3).lastArg)
+
+              // Local Event Callback
+              expect(alert.getCall(4)).to.be.calledWith('onError')
+              assertErrorsObject(alert.getCall(5).lastArg)
+            })
+            .get('.link-error')
+            .click()
+            .wait(30)
+            .then(() => {
+              expect(alert.getCalls()).to.have.length(12)
+
+              // Global Inertia Event Listener
+              expect(alert.getCall(6)).to.be.calledWith('Inertia.on(error)')
+              assertGlobalEvent(alert.getCall(7).lastArg)
+
+              // Global Native Event Listener
+              expect(alert.getCall(8)).to.be.calledWith('addEventListener(inertia:error)')
+              assertGlobalEvent(alert.getCall(9).lastArg)
+
+              // Local Event Callback
+              expect(alert.getCall(10)).to.be.calledWith('linkOnError')
+              assertErrorsObject(alert.getCall(11).lastArg)
+            })
+        })
+      })
+
+      describe('Local Event Callbacks', () => {
+        it('can delay onFinish from firing by returning a promise', () => {
+          cy.get('.error-promise')
+            .click()
+            .wait(50)
+            .then(() => {
+              expect(alert.getCalls()).to.have.length(3)
+              expect(alert.getCall(0)).to.be.calledWith('onError')
+              expect(alert.getCall(1)).to.be.calledWith(
+                'onFinish should have been fired by now if Promise functionality did not work',
+              )
+              expect(alert.getCall(2)).to.be.calledWith('onFinish')
+            })
+            .get('.link-error-promise')
+            .click()
+            .wait(50)
+            .then(() => {
+              expect(alert.getCalls()).to.have.length(6)
+              expect(alert.getCall(3)).to.be.calledWith('linkOnError')
+              expect(alert.getCall(4)).to.be.calledWith(
+                'onFinish should have been fired by now if Promise functionality did not work',
+              )
+              expect(alert.getCall(5)).to.be.calledWith('linkOnFinish')
+            })
+        })
+      })
+    })
+
+    describe('success', () => {
+      it('fires when the request finished without validation errors', () => {
+        const assertGlobalEvent = (event) => {
+          expect(event).to.be.an('CustomEvent')
+          expect(event.type).to.eq('inertia:success')
+
+          expect(event).to.have.property('cancelable')
+          expect(event.cancelable).to.be.false
+
+          expect(event).to.have.property('detail')
+          tap(event.detail, (detail) => {
+            expect(detail).to.be.an('object')
+            expect(detail).to.have.property('page')
+            assertPageObject(detail.page)
+          })
+        }
+
+        cy.get('.success')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(6)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(0)).to.be.calledWith('Inertia.on(success)')
+            assertGlobalEvent(alert.getCall(1).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:success)')
+            assertGlobalEvent(alert.getCall(3).lastArg)
+
+            // Local Event Callback
+            expect(alert.getCall(4)).to.be.calledWith('onSuccess')
+            assertPageObject(alert.getCall(5).lastArg)
+          })
+          .get('.link-success')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(12)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(6)).to.be.calledWith('Inertia.on(success)')
+            assertGlobalEvent(alert.getCall(7).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(8)).to.be.calledWith('addEventListener(inertia:success)')
+            assertGlobalEvent(alert.getCall(9).lastArg)
+
+            // Local Event Callback
+            expect(alert.getCall(10)).to.be.calledWith('linkOnSuccess')
+            assertPageObject(alert.getCall(11).lastArg)
+          })
+      })
+
+      describe('Local Event Callbacks', () => {
+        it('can delay onFinish from firing by returning a promise', () => {
+          cy.get('.success-promise')
+            .click()
+            .wait(50)
+            .then(() => {
+              expect(alert.getCalls()).to.have.length(3)
+              expect(alert.getCall(0)).to.be.calledWith('onSuccess')
+              expect(alert.getCall(1)).to.be.calledWith(
+                'onFinish should have been fired by now if Promise functionality did not work',
+              )
+              expect(alert.getCall(2)).to.be.calledWith('onFinish')
+            })
+            .get('.link-success-promise')
+            .click()
+            .wait(50)
+            .then(() => {
+              expect(alert.getCalls()).to.have.length(6)
+              expect(alert.getCall(3)).to.be.calledWith('linkOnSuccess')
+              expect(alert.getCall(4)).to.be.calledWith(
+                'onFinish should have been fired by now if Promise functionality did not work',
+              )
+              expect(alert.getCall(5)).to.be.calledWith('linkOnFinish')
+            })
+        })
+      })
+    })
+
+    describe('invalid', () => {
+      it('gets fired when a non-Inertia response is received', () => {
+        const assertResponseObject = (response) => {
+          expect(response).to.be.an('object')
+          expect(response).to.have.property('headers')
+          expect(response).to.have.property('data')
+          expect(response).to.have.property('status')
+        }
+        const assertGlobalEvent = (event) => {
+          expect(event).to.be.an('CustomEvent')
+          expect(event.type).to.eq('inertia:invalid')
+
+          expect(event).to.have.property('cancelable')
+          expect(event.cancelable).to.be.true
+
+          expect(event).to.have.property('detail')
+          tap(event.detail, (detail) => {
+            expect(detail).to.be.an('object')
+            expect(detail).to.have.property('response')
+            assertResponseObject(detail.response)
+          })
+        }
+
+        cy.get('.invalid')
+          .click()
+          .wait(50)
+          .then(() => {
+            expect(alert.getCalls()).to.be.length(4)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(0)).to.be.calledWith('Inertia.on(invalid)')
+            assertGlobalEvent(alert.getCall(1).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:invalid)')
+            assertGlobalEvent(alert.getCall(3).lastArg)
+          })
+      })
+    })
+
+    describe('exception', () => {
+      it('gets fired when an unexpected situation occurs (e.g. network disconnect)', () => {
+        const assertExceptionObject = (detail) => {
+          expect(detail).to.be.an('object')
+          expect(detail).to.have.property('exception')
+          expect(detail.exception.code).to.eq('ERR_NETWORK')
+        }
+        const assertGlobalEvent = (event) => {
+          expect(event).to.be.an('CustomEvent')
+          expect(event.type).to.eq('inertia:exception')
+
+          expect(event).to.have.property('cancelable')
+          expect(event.cancelable).to.be.true
+
+          expect(event).to.have.property('detail')
+          assertExceptionObject(event.detail)
+        }
+
+        cy
+          .on('uncaught:exception', (e) => {
+            const valid = e.name === "AxiosError";
+            return !valid;
+          })
+          .get('.exception')
+          .click()
+          .wait(2000) // The browser will 'wait' for a bit when the connection has been dropped server-side.
+          .then(() => {
+            expect(alert.getCalls()).to.be.length(4)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(0)).to.be.calledWith('Inertia.on(exception)')
+            assertGlobalEvent(alert.getCall(1).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:exception)')
+            assertGlobalEvent(alert.getCall(3).lastArg)
+          })
+      })
+    })
+
+    describe('finish', () => {
+      it('fires when the request completes', () => {
+        const assertGlobalEvent = (event) => {
+          expect(event).to.be.an('CustomEvent')
+          expect(event.type).to.eq('inertia:finish')
+
+          expect(event).to.have.property('cancelable')
+          expect(event.cancelable).to.be.false
+
+          expect(event).to.have.property('detail')
+          tap(event.detail, (detail) => {
+            expect(detail).to.be.an('object')
+            expect(detail).to.have.property('visit')
+            assertVisitObject(detail.visit)
+          })
+        }
+
+        cy.get('.finish')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(6)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(0)).to.be.calledWith('Inertia.on(finish)')
+            assertGlobalEvent(alert.getCall(1).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:finish)')
+            assertGlobalEvent(alert.getCall(3).lastArg)
+
+            // Local Event Callback
+            expect(alert.getCall(4)).to.be.calledWith('onFinish')
+            assertVisitObject(alert.getCall(5).lastArg)
+          })
+          .get('.link-finish')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(12)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(6)).to.be.calledWith('Inertia.on(finish)')
+            assertGlobalEvent(alert.getCall(7).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(8)).to.be.calledWith('addEventListener(inertia:finish)')
+            assertGlobalEvent(alert.getCall(9).lastArg)
+
+            // Local Event Callback
+            expect(alert.getCall(10)).to.be.calledWith('linkOnFinish')
+            assertVisitObject(alert.getCall(11).lastArg)
+          })
+      })
+    })
+
+    describe('navigate', () => {
+      it('fires when the page navigates away after a successful request', () => {
+        const assertGlobalEvent = (event) => {
+          expect(event).to.be.an('CustomEvent')
+          expect(event.type).to.eq('inertia:navigate')
+
+          expect(event).to.have.property('cancelable')
+          expect(event.cancelable).to.be.false
+
+          expect(event).to.have.property('detail')
+          tap(event.detail, (detail) => {
+            expect(detail).to.be.an('object')
+            expect(detail).to.have.property('page')
+            assertPageObject(detail.page)
+          })
+        }
+
+        cy.get('.navigate')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(4)
+
+            // Global Inertia Event Listener
+            expect(alert.getCall(0)).to.be.calledWith('Inertia.on(navigate)')
+            assertGlobalEvent(alert.getCall(1).lastArg)
+
+            // Global Native Event Listener
+            expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:navigate)')
+            assertGlobalEvent(alert.getCall(3).lastArg)
+          })
+      })
+    })
+  })
+
+  describe('Lifecycles', () => {
+    it('fires all expected events in the correct order on a successful request', () => {
+      cy.get('.lifecycle-success')
+        .click()
+        .wait(30)
+        .then(() => {
+          expect(alert.getCalls()).to.have.length(16)
+
+          expect(alert.getCall(0)).to.be.calledWith('onBefore')
+          expect(alert.getCall(1)).to.be.calledWith('Inertia.on(before)')
+          expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:before)')
+
+          expect(alert.getCall(3)).to.be.calledWith('onCancelToken')
+
+          expect(alert.getCall(4)).to.be.calledWith('Inertia.on(start)')
+          expect(alert.getCall(5)).to.be.calledWith('addEventListener(inertia:start)')
+          expect(alert.getCall(6)).to.be.calledWith('onStart')
+
+          expect(alert.getCall(7)).to.be.calledWith('Inertia.on(progress)')
+          expect(alert.getCall(8)).to.be.calledWith('addEventListener(inertia:progress)')
+          expect(alert.getCall(9)).to.be.calledWith('onProgress')
+
+          expect(alert.getCall(10)).to.be.calledWith('Inertia.on(success)')
+          expect(alert.getCall(11)).to.be.calledWith('addEventListener(inertia:success)')
+          expect(alert.getCall(12)).to.be.calledWith('onSuccess')
+
+          expect(alert.getCall(13)).to.be.calledWith('Inertia.on(finish)')
+          expect(alert.getCall(14)).to.be.calledWith('addEventListener(inertia:finish)')
+          expect(alert.getCall(15)).to.be.calledWith('onFinish')
+        })
+    })
+
+    it('fires all expected events in the correct order on an error request', () => {
+      cy.get('.lifecycle-error')
+        .click()
+        .wait(30)
+        .then(() => {
+          expect(alert.getCalls()).to.have.length(18)
+
+          expect(alert.getCall(0)).to.be.calledWith('onBefore')
+          expect(alert.getCall(1)).to.be.calledWith('Inertia.on(before)')
+          expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:before)')
+
+          expect(alert.getCall(3)).to.be.calledWith('onCancelToken')
+
+          expect(alert.getCall(4)).to.be.calledWith('Inertia.on(start)')
+          expect(alert.getCall(5)).to.be.calledWith('addEventListener(inertia:start)')
+          expect(alert.getCall(6)).to.be.calledWith('onStart')
+
+          expect(alert.getCall(7)).to.be.calledWith('Inertia.on(progress)')
+          expect(alert.getCall(8)).to.be.calledWith('addEventListener(inertia:progress)')
+          expect(alert.getCall(9)).to.be.calledWith('onProgress')
+
+          // Firing, because the page URL is different even though the component is the same.
+          expect(alert.getCall(10)).to.be.calledWith('Inertia.on(navigate)')
+          expect(alert.getCall(11)).to.be.calledWith('addEventListener(inertia:navigate)')
+
+          expect(alert.getCall(12)).to.be.calledWith('Inertia.on(error)')
+          expect(alert.getCall(13)).to.be.calledWith('addEventListener(inertia:error)')
+          expect(alert.getCall(14)).to.be.calledWith('onError')
+
+          expect(alert.getCall(15)).to.be.calledWith('Inertia.on(finish)')
+          expect(alert.getCall(16)).to.be.calledWith('addEventListener(inertia:finish)')
+          expect(alert.getCall(17)).to.be.calledWith('onFinish')
+        })
+    })
+
+    describe('Cancelling', () => {
+      it('cancels a visit before it completes', () => {
+        cy.get('.lifecycle-cancel')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(12)
+
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            expect(alert.getCall(1)).to.be.calledWith('Inertia.on(before)')
+            expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:before)')
+
+            expect(alert.getCall(3)).to.be.calledWith('onCancelToken')
+
+            expect(alert.getCall(4)).to.be.calledWith('Inertia.on(start)')
+            expect(alert.getCall(5)).to.be.calledWith('addEventListener(inertia:start)')
+            expect(alert.getCall(6)).to.be.calledWith('onStart')
+
+            expect(alert.getCall(7)).to.be.calledWith('CANCELLING!')
+            expect(alert.getCall(8)).to.be.calledWith('onCancel')
+
+            expect(alert.getCall(9)).to.be.calledWith('Inertia.on(finish)')
+            expect(alert.getCall(10)).to.be.calledWith('addEventListener(inertia:finish)')
+            expect(alert.getCall(11)).to.be.calledWith('onFinish')
+          })
+      })
+
+      it('prevents onCancel from firing when the request is already finished', () => {
+        cy.get('.lifecycle-cancel-after-finish')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(17)
+
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            expect(alert.getCall(1)).to.be.calledWith('Inertia.on(before)')
+            expect(alert.getCall(2)).to.be.calledWith('addEventListener(inertia:before)')
+
+            expect(alert.getCall(3)).to.be.calledWith('onCancelToken')
+
+            expect(alert.getCall(4)).to.be.calledWith('Inertia.on(start)')
+            expect(alert.getCall(5)).to.be.calledWith('addEventListener(inertia:start)')
+            expect(alert.getCall(6)).to.be.calledWith('onStart')
+
+            expect(alert.getCall(7)).to.be.calledWith('Inertia.on(progress)')
+            expect(alert.getCall(8)).to.be.calledWith('addEventListener(inertia:progress)')
+            expect(alert.getCall(9)).to.be.calledWith('onProgress')
+
+            expect(alert.getCall(10)).to.be.calledWith('Inertia.on(success)')
+            expect(alert.getCall(11)).to.be.calledWith('addEventListener(inertia:success)')
+            expect(alert.getCall(12)).to.be.calledWith('onSuccess')
+
+            expect(alert.getCall(13)).to.be.calledWith('Inertia.on(finish)')
+            expect(alert.getCall(14)).to.be.calledWith('addEventListener(inertia:finish)')
+            expect(alert.getCall(15)).to.be.calledWith('onFinish')
+
+            expect(alert.getCall(16)).to.be.calledWith('CANCELLING!')
+          })
+      })
+    })
+  })
+})

--- a/packages/vue3/tests/cypress/integration/form-helper.cy.js
+++ b/packages/vue3/tests/cypress/integration/form-helper.cy.js
@@ -1,0 +1,818 @@
+import { tap } from '../support/commands'
+
+describe('Form Helper', () => {
+  describe('Methods', () => {
+    beforeEach(() => {
+      cy.visit('/form-helper/methods', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('#remember').check()
+    })
+
+    it('can submit the form using the POST method', () => {
+      cy.get('.post').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('post')
+          expect(query).to.be.empty
+          expect(form).to.have.property('name')
+          expect(form.name).to.eq('foo')
+          expect(form).to.have.property('remember')
+          expect(form.remember).to.eq(true)
+        })
+    })
+
+    it('can submit the form using the PUT method', () => {
+      cy.get('.put').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('put')
+          expect(query).to.be.empty
+          expect(form).to.have.property('name')
+          expect(form.name).to.eq('foo')
+          expect(form).to.have.property('remember')
+          expect(form.remember).to.eq(true)
+        })
+    })
+
+    it('can submit the form using the PATCH method', () => {
+      cy.get('.patch').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('patch')
+          expect(query).to.be.empty
+          expect(form).to.have.property('name')
+          expect(form.name).to.eq('foo')
+          expect(form).to.have.property('remember')
+          expect(form.remember).to.eq(true)
+        })
+    })
+
+    it('can submit the form using the DELETE method', () => {
+      cy.get('.delete').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('delete')
+          expect(query).to.be.empty
+          expect(form).to.have.property('name')
+          expect(form.name).to.eq('foo')
+          expect(form).to.have.property('remember')
+          expect(form.remember).to.eq(true)
+        })
+    })
+  })
+
+  describe('Transform', () => {
+    beforeEach(() => {
+      cy.visit('/form-helper/transform', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('#remember').check()
+    })
+
+    it('can transform the form prior to submission using the POST method', () => {
+      cy.get('.post').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('post')
+          expect(query).to.be.empty
+          expect(form).to.have.property('name')
+          expect(form.name).to.eq('bar')
+          expect(form).to.have.property('remember')
+          expect(form.remember).to.eq(true)
+        })
+    })
+
+    it('can transform the form prior to submission using the PUT method', () => {
+      cy.get('.put').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('put')
+          expect(query).to.be.empty
+          expect(form).to.have.property('name')
+          expect(form.name).to.eq('baz')
+          expect(form).to.have.property('remember')
+          expect(form.remember).to.eq(true)
+        })
+    })
+
+    it('can transform the form prior to submission using the PATCH method', () => {
+      cy.get('.patch').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('patch')
+          expect(query).to.be.empty
+          expect(form).to.have.property('name')
+          expect(form.name).to.eq('foo')
+          expect(form).to.have.property('remember')
+          expect(form.remember).to.eq(true)
+        })
+    })
+
+    it('can transform the form prior to submission using the DELETE method', () => {
+      cy.get('.delete').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('delete')
+          expect(query).to.be.empty
+          expect(form).to.have.property('name')
+          expect(form.name).to.eq('bar')
+          expect(form).to.have.property('remember')
+          expect(form.remember).to.eq(true)
+        })
+    })
+  })
+
+  describe('Errors', () => {
+    beforeEach(() => {
+      cy.visit('/form-helper/errors', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.errors-status').should('have.text', 'Form has no errors')
+      cy.get('#name').clear().type('A')
+      cy.get('#handle').clear().type('B')
+      cy.get('#remember').check()
+    })
+
+    it('can display form errors', () => {
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('not.exist')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('.submit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+    })
+
+    it('can clear all form errors', () => {
+      cy.get('.submit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('.clear').click()
+
+      cy.get('.errors-status').should('have.text', 'Form has no errors')
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('not.exist')
+      cy.get('.remember_error').should('not.exist')
+    })
+
+    it('does not reset fields back to their initial values when it clears all form errors', () => {
+      cy.get('.submit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'B')
+      cy.get('#remember').should('be.checked')
+
+      cy.get('.clear').click()
+
+      cy.get('.errors-status').should('have.text', 'Form has no errors')
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('not.exist')
+      cy.get('.remember_error').should('not.exist')
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'B')
+      cy.get('#remember').should('be.checked')
+    })
+
+    it('can clear a subset of form errors', () => {
+      cy.get('.submit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('.clear-one').click()
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('not.exist')
+      cy.get('.remember_error').should('not.exist')
+    })
+
+    it('does not reset fields back to their initial values when it clears a subset of form errors', () => {
+      cy.get('.submit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'B')
+      cy.get('#remember').should('be.checked')
+
+      cy.get('.clear-one').click()
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('not.exist')
+      cy.get('.remember_error').should('not.exist')
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'B')
+      cy.get('#remember').should('be.checked')
+    })
+
+    it('can set a single error', () => {
+      cy.get('.set-one').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('have.text', 'Manually set Handle error')
+      cy.get('.remember_error').should('not.exist')
+    })
+
+    it('can set multiple errors', () => {
+      cy.get('.set').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/errors')
+
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Manually set Name error')
+      cy.get('.handle_error').should('have.text', 'Manually set Handle error')
+      cy.get('.remember_error').should('not.exist')
+    })
+  })
+
+  describe('Data', () => {
+    beforeEach(() => {
+      cy.visit('/form-helper/data', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+    })
+
+    it('can reset all fields to their initial values', () => {
+      cy.get('#name').clear().type('A')
+      cy.get('#remember').check()
+
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'example')
+      cy.get('#remember').should('be.checked')
+
+      cy.get('.submit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/data')
+
+      cy.get('.reset').click()
+
+      cy.get('#name').should('have.value', 'foo')
+      cy.get('#handle').should('have.value', 'example')
+      cy.get('#remember').should('not.be.checked')
+    })
+
+    it('can reset a single field to its initial value', () => {
+      cy.get('#name').clear().type('A')
+      cy.get('#handle').clear().type('B')
+      cy.get('#remember').check()
+
+      cy.get('.submit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/data')
+
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'B')
+      cy.get('#remember').should('be.checked')
+
+      cy.get('.reset-one').click()
+
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'example')
+      cy.get('#remember').should('be.checked')
+    })
+
+    it('does not reset errors when it resets a field to its initial value', () => {
+      cy.get('#name').clear().type('A')
+      cy.get('#handle').clear().type('B')
+      cy.get('#remember').check()
+
+      cy.get('.submit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/data')
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'B')
+      cy.get('#remember').should('be.checked')
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+
+      cy.get('.reset-one').click()
+
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'example')
+      cy.get('#remember').should('be.checked')
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+    })
+
+    it('does not reset errors when it resets all fields to their initial values', () => {
+      cy.get('#name').clear().type('A')
+      cy.get('#handle').clear().type('B')
+      cy.get('#remember').check()
+
+      cy.get('.submit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/form-helper/data')
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'B')
+      cy.get('#remember').should('be.checked')
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+
+      cy.get('.reset-one').click()
+
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'example')
+      cy.get('#remember').should('be.checked')
+      cy.get('.errors-status').should('have.text', 'Form has errors')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+    })
+
+    describe('Update "reset" defaults', () => {
+      beforeEach(() => {
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'example')
+        cy.get('#remember').should('not.be.checked')
+      })
+
+      it('can assign the current values as the new defaults', () => {
+        cy.get('#name').clear().type('A')
+        cy.get('#handle').clear().type('B')
+        cy.get('#remember').check()
+
+        cy.get('.reassign').click()
+
+        cy.get('#name').clear().type('foo')
+        cy.get('#handle').clear().type('example')
+        cy.get('#remember').uncheck()
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'example')
+        cy.get('#remember').should('not.be.checked')
+
+        cy.get('.reset').click()
+
+        cy.get('#name').should('have.value', 'A')
+        cy.get('#handle').should('have.value', 'B')
+        cy.get('#remember').should('be.checked')
+      })
+
+      it('can assign new defaults for multiple fields', () => {
+        cy.get('.reassign-object').click()
+
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'example')
+        cy.get('#remember').should('not.be.checked')
+        cy.get('.reset-one').click()
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'updated handle')
+        cy.get('#remember').should('not.be.checked')
+        cy.get('.reset').click()
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'updated handle')
+        cy.get('#remember').should('be.checked')
+      })
+
+      it('can assign new default for a single field', () => {
+        cy.get('.reassign-single').click()
+
+        cy.get('#name').should('have.value', 'foo')
+        cy.get('#handle').should('have.value', 'example')
+        cy.get('#remember').should('not.be.checked')
+        cy.get('.reset').click()
+        cy.get('#name').should('have.value', 'single value')
+        cy.get('#handle').should('have.value', 'example')
+        cy.get('#remember').should('not.be.checked')
+      })
+    })
+  })
+
+  describe('Events', () => {
+    let alert = null
+    beforeEach(() => {
+      cy.visit('/form-helper/events', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      alert = cy.stub()
+      cy.on('window:alert', alert)
+    })
+
+    describe('onBefore', () => {
+      it('fires when a request is about to be made', () => {
+        cy.get('.before')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            tap(alert.getCall(1).lastArg, (visit) => {
+              // Assert this is the request/visit object.
+              expect(visit).to.be.an('object')
+              expect(visit).to.have.property('url')
+              expect(visit).to.have.property('method')
+              expect(visit).to.have.property('data')
+              expect(visit).to.have.property('headers')
+              expect(visit).to.have.property('preserveState')
+            })
+          })
+      })
+
+      it('can prevent the visit from starting by returning false', () => {
+        cy.get('.before-cancel')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(1)
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+          })
+      })
+
+      it('will reset the successful and recently successful statuses immediately when the form gets (re)submitted', () => {
+        cy.get('.success-status').should('have.text', 'Form was not successful')
+        cy.get('.recently-status').should('have.text', 'Form was not recently successful')
+
+        cy.get('.submit').click()
+        cy.get('.success-status').should('have.text', 'Form was successful')
+        cy.get('.recently-status').should('have.text', 'Form was recently successful')
+
+        cy.get('.before-cancel').click()
+        cy.get('.success-status').should('have.text', 'Form was not successful')
+        cy.get('.recently-status').should('have.text', 'Form was not recently successful')
+      })
+    })
+
+    describe('onStart', () => {
+      it('fires when the request has started', () => {
+        cy.get('.start')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(2)).to.be.calledWith('onStart')
+            tap(alert.getCall(3).lastArg, (visit) => {
+              // Assert this is the request/visit object.
+              expect(visit).to.be.an('object')
+              expect(visit).to.have.property('url')
+              expect(visit).to.have.property('method')
+              expect(visit).to.have.property('data')
+              expect(visit).to.have.property('headers')
+              expect(visit).to.have.property('preserveState')
+            })
+          })
+      })
+
+      it('marks the form as processing', () => {
+        cy.get('.success-processing')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(2)).to.be.calledWith('onCancelToken')
+            expect(alert.getCall(3)).to.be.calledWith(false)
+            expect(alert.getCall(4)).to.be.calledWith('onStart')
+            expect(alert.getCall(5)).to.be.calledWith(true)
+          })
+      })
+    })
+
+    describe('onProgress', () => {
+      it('fires when the form has files (and upload progression occurs)', () => {
+        cy.get('.progress')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(3)).to.be.calledWith('onProgress')
+            tap(alert.getCall(4).lastArg, (event) => {
+              expect(event).to.have.property('percentage')
+              expect(event).to.have.property('total')
+              expect(event).to.have.property('loaded')
+              expect(event.percentage).to.be.gte(0).and.lte(100)
+            })
+          })
+      })
+
+      it('does not fire when the form has no files', () => {
+        cy.get('.no-progress')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(10)
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            expect(alert.getCall(1)).to.be.calledWith(null)
+            expect(alert.getCall(2)).to.be.calledWith('onCancelToken')
+            expect(alert.getCall(3)).to.be.calledWith(null)
+            expect(alert.getCall(4)).to.be.calledWith('onStart')
+            expect(alert.getCall(5)).to.be.calledWith(null)
+            expect(alert.getCall(6)).to.be.calledWith('onSuccess')
+            expect(alert.getCall(7)).to.be.calledWith(null)
+            expect(alert.getCall(8)).to.be.calledWith('onFinish')
+            expect(alert.getCall(9)).to.be.calledWith(null)
+          })
+      })
+
+      it('updates the progress property of the form', () => {
+        cy.get('.success-progress')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(4)).to.be.calledWith('onStart')
+            expect(alert.getCall(5)).to.be.calledWith(null)
+
+            expect(alert.getCall(6)).to.be.calledWith('onProgress')
+            tap(alert.getCall(7).lastArg, (event) => {
+              expect(event).to.have.property('percentage')
+              expect(event).to.have.property('total')
+              expect(event).to.have.property('loaded')
+              expect(event.percentage).to.be.gte(0).and.lte(100)
+            })
+          })
+      })
+    })
+
+    describe('onCancel', () => {
+      it('fires when the request was cancelled', () => {
+        cy.get('.cancel')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(4)).to.be.calledWith('onCancel')
+          })
+      })
+    })
+
+    describe('onSuccess', () => {
+      it('fires the request succeeds without validation errors', () => {
+        cy.get('.success')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            expect(alert.getCall(1)).to.be.calledWith('onCancelToken')
+            expect(alert.getCall(2)).to.be.calledWith('onStart')
+            expect(alert.getCall(3)).to.be.calledWith('onSuccess')
+            tap(alert.getCall(4).lastArg, (page) => {
+              expect(page).to.be.an('object')
+              expect(page).to.have.property('component')
+              expect(page).to.have.property('props')
+              expect(page).to.have.property('url')
+              expect(page).to.have.property('version')
+            })
+          })
+      })
+
+      it('marks the form as no longer processing', () => {
+        cy.get('.success-processing')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(4)).to.be.calledWith('onStart')
+            expect(alert.getCall(5)).to.be.calledWith(true)
+
+            expect(alert.getCall(6)).to.be.calledWith('onSuccess')
+            expect(alert.getCall(7)).to.be.calledWith(false)
+          })
+      })
+
+      it('resets the progress property back to null', () => {
+        cy.get('.success-progress')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(6)).to.be.calledWith('onProgress')
+            tap(alert.getCall(7).lastArg, (event) => {
+              expect(event).to.have.property('percentage')
+              expect(event).to.have.property('total')
+              expect(event).to.have.property('loaded')
+              expect(event.percentage).to.be.gte(0).and.lte(100)
+            })
+
+            expect(alert.getCall(8)).to.be.calledWith('onSuccess')
+            expect(alert.getCall(9)).to.be.calledWith(null)
+          })
+      })
+
+      it('can delay onFinish from firing by returning a promise', () => {
+        cy.get('.success-promise')
+          .click()
+          .wait(50)
+          .then(() => {
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            expect(alert.getCall(1)).to.be.calledWith('onCancelToken')
+            expect(alert.getCall(2)).to.be.calledWith('onStart')
+            expect(alert.getCall(3)).to.be.calledWith('onSuccess')
+            expect(alert.getCall(4)).to.be.calledWith(
+              'onFinish should have been fired by now if Promise functionality did not work',
+            )
+            expect(alert.getCall(5)).to.be.calledWith('onFinish')
+          })
+      })
+
+      it('clears all existing errors and resets the hasErrors prop', () => {
+        cy.get('.success-reset-errors')
+          .click()
+          .wait(50)
+          .then(() => {
+            expect(alert.getCalls()).to.have.length(10)
+
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            expect(alert.getCall(1)).to.be.calledWith(false)
+
+            expect(alert.getCall(2)).to.be.calledWith('onError')
+            expect(alert.getCall(3)).to.be.calledWith(true)
+
+            expect(alert.getCall(4)).to.be.calledWith('onStart')
+            expect(alert.getCall(5)).to.be.calledWith(true)
+            tap(alert.getCall(6).lastArg, (errors) => {
+              expect(errors).to.be.an('object')
+              expect(errors).to.have.property('name')
+              expect(errors.name).to.eq('Some name error')
+            })
+
+            expect(alert.getCall(7)).to.be.calledWith('onSuccess')
+            expect(alert.getCall(8)).to.be.calledWith(false)
+            expect(alert.getCall(9)).to.be.an('object')
+            expect(alert.getCall(9).lastArg).to.be.empty
+          })
+      })
+
+      it('will mark the form as being submitted successfully', () => {
+        cy.get('.success-status').should('have.text', 'Form was not successful')
+
+        cy.get('.submit').click()
+
+        cy.get('.success-status').should('have.text', 'Form was successful')
+      })
+
+      it('will only mark the form as "recently successful" for two seconds', () => {
+        cy.get('.success-status').should('have.text', 'Form was not successful')
+        cy.get('.recently-status').should('have.text', 'Form was not recently successful')
+
+        cy.get('.submit').click()
+
+        cy.get('.success-status').should('have.text', 'Form was successful')
+        cy.get('.recently-status').should('have.text', 'Form was recently successful')
+        cy.wait(2020).then(() => {
+          cy.get('.success-status').should('have.text', 'Form was successful')
+          cy.get('.recently-status').should('have.text', 'Form was not recently successful')
+        })
+      })
+    })
+
+    describe('onError', () => {
+      it('fires when the request finishes with validation errors', () => {
+        cy.get('.error')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            expect(alert.getCall(1)).to.be.calledWith('onCancelToken')
+            expect(alert.getCall(2)).to.be.calledWith('onStart')
+            expect(alert.getCall(3)).to.be.calledWith('onError')
+            tap(alert.getCall(4).lastArg, (errors) => {
+              expect(errors).to.be.an('object')
+              expect(errors).to.have.property('name')
+              expect(errors.name).to.eq('Some name error')
+            })
+          })
+      })
+
+      it('marks the form as no longer processing', () => {
+        cy.get('.error-processing')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(4)).to.be.calledWith('onStart')
+            expect(alert.getCall(5)).to.be.calledWith(true)
+
+            expect(alert.getCall(6)).to.be.calledWith('onError')
+            expect(alert.getCall(7)).to.be.calledWith(false)
+          })
+      })
+
+      it('resets the progress property back to null', () => {
+        cy.get('.error-progress')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(6)).to.be.calledWith('onProgress')
+            tap(alert.getCall(7).lastArg, (event) => {
+              expect(event).to.have.property('percentage')
+              expect(event).to.have.property('total')
+              expect(event).to.have.property('loaded')
+              expect(event.percentage).to.be.gte(0).and.lte(100)
+            })
+
+            expect(alert.getCall(8)).to.be.calledWith('onError')
+            expect(alert.getCall(9)).to.be.calledWith(null)
+          })
+      })
+
+      it('sets form errors', () => {
+        cy.get('.errors-set-on-error')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(2)).to.be.calledWith('onStart')
+            expect(alert.getCall(3)).to.be.an('object')
+            expect(alert.getCall(3).lastArg).to.be.empty
+
+            expect(alert.getCall(4)).to.be.calledWith('onError')
+            tap(alert.getCall(5).lastArg, (errors) => {
+              expect(errors).to.be.an('object')
+              expect(errors).to.have.property('name')
+              expect(errors.name).to.eq('Some name error')
+            })
+          })
+      })
+
+      it('can delay onFinish from firing by returning a promise', () => {
+        cy.get('.error-promise')
+          .click()
+          .wait(50)
+          .then(() => {
+            expect(alert.getCall(0)).to.be.calledWith('onBefore')
+            expect(alert.getCall(1)).to.be.calledWith('onCancelToken')
+            expect(alert.getCall(2)).to.be.calledWith('onStart')
+            expect(alert.getCall(3)).to.be.calledWith('onError')
+            expect(alert.getCall(4)).to.be.calledWith(
+              'onFinish should have been fired by now if Promise functionality did not work',
+            )
+            expect(alert.getCall(5)).to.be.calledWith('onFinish')
+          })
+      })
+    })
+
+    describe('onFinish', () => {
+      it('fires when the request is completed', () => {
+        cy.get('.successful-request')
+          .click()
+          .wait(30)
+          .then(() => {
+            expect(alert.getCall(4)).to.be.calledWith('onFinish')
+          })
+      })
+    })
+  })
+})

--- a/packages/vue3/tests/cypress/integration/inertia.cy.js
+++ b/packages/vue3/tests/cypress/integration/inertia.cy.js
@@ -1,0 +1,7 @@
+describe('Inertia', () => {
+  it('mounts the initial page', () => {
+    cy.visit('/')
+
+    cy.get('.text').should('have.text', 'This is the Test App Entrypoint page')
+  })
+})

--- a/packages/vue3/tests/cypress/integration/links.cy.js
+++ b/packages/vue3/tests/cypress/integration/links.cy.js
@@ -1,0 +1,1154 @@
+import { tap } from '../support/commands'
+
+describe('Links', () => {
+  it('visits a different page', () => {
+    cy.visit('/', {
+      onLoad: () =>
+        cy.on('window:load', () => {
+          throw 'A location/non-SPA visit was detected'
+        }),
+    })
+
+    cy.get('.links-method').click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/links/method')
+
+    cy.get('.text').should('have.text', 'This is the links page that demonstrates inertia-link methods')
+  })
+
+  it('can make a location visit', () => {
+    cy.visit('/links/location', {
+      onLoad: () =>
+        cy.on('window:load', () => {
+          alert('A location/non-SPA visit was detected')
+        }),
+    })
+
+    const alert = cy.stub()
+    cy.on('window:alert', alert)
+
+    cy.get('.example')
+      .click()
+      .then(() => {
+        expect(alert.getCalls()).to.have.length(1)
+        expect(alert.getCall(0)).to.be.calledWith('A location/non-SPA visit was detected')
+
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ headers }) => {
+            expect(headers).to.not.have.property('x-inertia')
+          })
+      })
+  })
+
+  describe('Auto-cancellation', () => {
+    it('will automatically cancel a pending visits when a new request is made', () => {
+      cy.visit('/links/automatic-cancellation', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      const alert = cy.stub()
+      cy.on('window:alert', alert)
+
+      cy.get('.visit')
+        .click()
+        .click()
+        .wait(30)
+        .then(() => {
+          expect(alert.getCalls()).to.have.length(3)
+          expect(alert.getCall(0)).to.be.calledWith('started')
+          expect(alert.getCall(1)).to.be.calledWith('cancelled')
+          expect(alert.getCall(2)).to.be.calledWith('started')
+        })
+    })
+  })
+
+  describe('Method', () => {
+    beforeEach(() => {
+      cy.visit('/links/method', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+    })
+
+    it('can use the GET method', () => {
+      cy.get('.get').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('get')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+
+    it('can use the POST method', () => {
+      cy.get('.post').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('post')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+
+    it('can use the PUT method', () => {
+      cy.get('.put').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('put')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+
+    it('can use the PATCH method', () => {
+      cy.get('.patch').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('patch')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+
+    it('can use the DELETE method', () => {
+      cy.get('.delete').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('delete')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+  })
+
+  describe('Data', () => {
+    describe('plain objects', () => {
+      beforeEach(() => {
+        cy.intercept('/dump/**').as('spy')
+        cy.visit('/links/data/object', {
+          onLoad: () =>
+            cy.on('window:load', () => {
+              throw 'A location/non-SPA visit was detected'
+            }),
+        })
+      })
+
+      describe('GET method', () => {
+        it('passes data as params', () => {
+          cy.get('.get').click()
+
+          cy.wait('@spy').then(({ request, response }) => {
+            expect(request.url).to.eq(Cypress.config().baseUrl + '/dump/get?foo=get')
+            expect(request.headers).to.contain.key('content-type')
+            expect(request.headers['content-type']).to.contain('application/json')
+            expect(request.method).to.eq('GET')
+            expect(response.body.props.form).to.be.empty
+            expect(response.body.props.files).to.be.undefined
+          })
+        })
+
+        describe('query string array formatter', () => {
+          it('can use the brackets query string array formatter', () => {
+            cy.get('.qsaf-brackets').click()
+            cy.wait('@spy')
+              .its('request.url')
+              .should('eq', Cypress.config().baseUrl + '/dump/get?a[]=b&a[]=c')
+          })
+
+          it('can use the indices query string array formatter', () => {
+            cy.get('.qsaf-indices').click()
+            cy.wait('@spy')
+              .its('request.url')
+              .should('eq', Cypress.config().baseUrl + '/dump/get?a[0]=b&a[1]=c')
+          })
+
+          it('defaults to using the brackets query string array formatter', () => {
+            cy.get('.qsaf-default').click()
+            cy.wait('@spy')
+              .its('request.url')
+              .should('eq', Cypress.config().baseUrl + '/dump/get?a[]=b&a[]=c')
+          })
+        })
+      })
+
+      it('can pass data using the POST method', () => {
+        cy.get('.post').click()
+        cy.wait('@spy').then(({ request, response }) => {
+          expect(request.url).to.eq(Cypress.config().baseUrl + '/dump/post')
+          expect(request.headers).to.contain.key('content-type')
+          expect(request.headers['content-type']).to.contain('application/json')
+          expect(request.method).to.eq('POST')
+          expect(response.body.props.form).to.contain.key('bar')
+          expect(response.body.props.form.bar).to.eq('post')
+          expect(response.body.props.files).to.be.undefined
+        })
+      })
+
+      it('can pass data using the PUT method', () => {
+        cy.get('.put').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('application/json')
+
+            expect(method).to.eq('put')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('baz')
+            expect(form.baz).to.eq('put')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the PATCH method', () => {
+        cy.get('.patch').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('application/json')
+
+            expect(method).to.eq('patch')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('patch')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the DELETE method', () => {
+        cy.get('.delete').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('application/json')
+
+            expect(method).to.eq('delete')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('bar')
+            expect(form.bar).to.eq('delete')
+            expect(files).to.be.empty
+          })
+      })
+    })
+
+    describe('FormData objects', () => {
+      beforeEach(() => {
+        cy.visit('/links/data/form-data', {
+          onLoad: () =>
+            cy.on('window:load', () => {
+              throw 'A location/non-SPA visit was detected'
+            }),
+        })
+      })
+
+      it('can pass data using the POST method', () => {
+        cy.get('.post').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('post')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('bar')
+            expect(form.bar).to.eq('baz')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the PUT method', () => {
+        cy.get('.put').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('put')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('bar')
+            expect(form.bar).to.eq('baz')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the PATCH method', () => {
+        cy.get('.patch').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('patch')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('bar')
+            expect(form.bar).to.eq('baz')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the DELETE method', () => {
+        cy.get('.delete').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('delete')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('bar')
+            expect(form.bar).to.eq('baz')
+            expect(files).to.be.empty
+          })
+      })
+    })
+
+    describe('auto-converted objects (when files are present)', () => {
+      beforeEach(() => {
+        cy.visit('/links/data/auto-converted', {
+          onLoad: () =>
+            cy.on('window:load', () => {
+              throw 'A location/non-SPA visit was detected'
+            }),
+        })
+      })
+
+      it('auto-converts objects to form-data when files are present using the POST method', () => {
+        cy.get('.post').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('post')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('bar')
+            expect(files).to.not.be.empty
+          })
+      })
+
+      it('auto-converts objects to form-data when files are present using the PUT method', () => {
+        cy.get('.put').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('put')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('bar')
+            expect(files).to.not.be.empty
+          })
+      })
+
+      it('auto-converts objects to form-data when files are present using the PATCH method', () => {
+        cy.get('.patch').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('patch')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('bar')
+            expect(files).to.not.be.empty
+          })
+      })
+
+      it('auto-converts objects to form-data when files are present using the DELETE method', () => {
+        cy.get('.delete').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('delete')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('bar')
+            expect(files).to.not.be.empty
+          })
+      })
+    })
+  })
+
+  describe('Headers', () => {
+    it('has the default set of headers', () => {
+      cy.visit('/links/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.default').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia'])
+          expect(headers).to.not.contain.key('x-inertia-version')
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+        })
+    })
+
+    it('starts using the x-inertia-version header when a version was given from the back-end', () => {
+      cy.visit('/links/headers/version', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.default').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.key('x-inertia-version')
+          expect(headers['x-inertia-version']).to.eq('example-version-header')
+        })
+    })
+
+    it('allows to set custom headers', () => {
+      cy.visit('/links/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.custom').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia', 'foo'])
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+          expect(headers['foo']).to.eq('bar')
+        })
+    })
+
+    it('cannot override built-in Inertia headers', () => {
+      cy.visit('/links/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.overridden').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia', 'bar'])
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+          expect(headers['bar']).to.eq('baz')
+        })
+    })
+  })
+
+  describe('Replace', () => {
+    beforeEach(() => {
+      cy.visit('/')
+      cy.window().then((window) => (window._inertia_spa_page_load = true))
+      cy.get('.links-replace').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/replace')
+    })
+
+    afterEach(() => {
+      cy.window().should('have.prop', '_inertia_spa_page_load');
+    })
+
+    it('replaces the current history state', () => {
+      cy.get('.replace').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/')
+
+      cy.go(1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+    })
+
+    it('does not replace the current history state when it is set to false', () => {
+      cy.get('.replace-false').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/replace')
+
+      cy.go(1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+    })
+  })
+
+  describe('Preserve state', () => {
+    beforeEach(() => {
+      cy.visit('/links/preserve-state', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+    })
+
+    it("preserves the page's local state", () => {
+      cy.get('.foo').should('have.text', 'Foo is now default')
+      cy.get('.field').type('Example value')
+
+      cy.window().should('have.property', '_inertia_page_key')
+      cy.window().then((window) => {
+        const componentKey = window._inertia_page_key
+
+        cy.get('.preserve').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-state-page-two')
+
+        cy.window().then((window) => {
+          expect(componentKey).to.eq(window._inertia_page_key)
+          cy.get('.foo').should('have.text', 'Foo is now bar')
+          cy.get('.field').should('have.value', 'Example value')
+        })
+      })
+    })
+
+    it("preserves the page's local state (callback)", () => {
+      cy.get('.foo').should('have.text', 'Foo is now default')
+      cy.get('.field').type('Example value')
+
+      cy.window().should('have.property', '_inertia_page_key')
+      cy.window().then((window) => {
+        const componentKey = window._inertia_page_key
+
+        cy.get('.preserve-callback').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-state-page-two')
+
+        cy.window().then((window) => {
+          expect(componentKey).to.eq(window._inertia_page_key)
+          cy.get('.foo').should('have.text', 'Foo is now callback-bar')
+          cy.get('.field').should('have.value', 'Example value')
+        })
+      })
+    })
+
+    it("does not preserve the page's local state", () => {
+      cy.get('.foo').should('have.text', 'Foo is now default')
+      cy.get('.field').type('Another value')
+
+      cy.window().should('have.property', '_inertia_page_key')
+      cy.window().then((window) => {
+        const componentKey = window._inertia_page_key
+
+        cy.get('.preserve-false').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-state-page-two')
+
+        cy.window().then((window) => {
+          expect(componentKey).to.not.eq(window._inertia_page_key)
+          cy.get('.foo').should('have.text', 'Foo is now baz')
+          cy.get('.field').should('have.value', '')
+        })
+      })
+    })
+
+    it("does not preserve the page's local state (callback)", () => {
+      cy.get('.foo').should('have.text', 'Foo is now default')
+      cy.get('.field').type('Another value')
+
+      cy.window().should('have.property', '_inertia_page_key')
+      cy.window().then((window) => {
+        const componentKey = window._inertia_page_key
+
+        cy.get('.preserve-callback-false').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-state-page-two')
+
+        cy.window().then((window) => {
+          expect(componentKey).to.not.eq(window._inertia_page_key)
+          cy.get('.foo').should('have.text', 'Foo is now callback-baz')
+          cy.get('.field').should('have.value', '')
+        })
+      })
+    })
+  })
+
+  describe('Preserve scroll', () => {
+    let alert = null
+
+    beforeEach(() => {
+      alert = cy.stub()
+      cy.on('window:alert', alert)
+    })
+
+    describe('disabled (default)', () => {
+      beforeEach(() => {
+        cy.visit('/links/preserve-scroll-false')
+        cy.get('.foo').should('have.text', 'Foo is now default')
+        cy.scrollTo('5px', '7px')
+        cy.get('#slot').scrollTo('10px', '15px')
+        cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+        cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+      })
+
+      it('does not reset untracked scroll regions in persistent layouts', () => {
+        cy.get('.reset')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-false-page-two')
+
+            cy.get('.foo').should('have.text', 'Foo is now bar')
+            cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+
+      it('does not reset untracked scroll regions in persistent layouts when returning false from a preserveScroll callback', () => {
+        cy.get('.reset-callback')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-false-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now foo')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+
+            // Assert that the page is passed in to the callback
+            expect(alert.getCalls()).to.have.length(1)
+            tap(alert.getCall(0).lastArg, (page) => {
+              expect(page).to.be.an('object')
+              expect(page).to.have.property('component')
+              expect(page).to.have.property('props')
+              expect(page).to.have.property('url')
+              expect(page).to.have.property('version')
+            })
+          })
+      })
+
+      it('does not restore untracked scroll regions when pressing the back button', () => {
+        cy.get('.reset')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-false-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now bar')
+            cy.get('#slot').scrollTo(0, 0)
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-false')
+            cy.get('.foo').should('have.text', 'Foo is now default')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+          })
+      })
+
+      it('does not restore untracked scroll regions when returning true from a preserveScroll callback', () => {
+        cy.get('.preserve-callback')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-false-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now baz')
+            cy.get('#slot').scrollTo(0, 0)
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+
+            // Assert that the page is passed in to the callback
+            expect(alert.getCalls()).to.have.length(1)
+            tap(alert.getCall(0).lastArg, (page) => {
+              expect(page).to.be.an('object')
+              expect(page).to.have.property('component')
+              expect(page).to.have.property('props')
+              expect(page).to.have.property('url')
+              expect(page).to.have.property('version')
+            })
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-false')
+            cy.get('.foo').should('have.text', 'Foo is now default')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+          })
+      })
+
+      it('does not restore untracked scroll regions when pressing the back button from another website', () => {
+        cy.get('.off-site')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/non-inertia')
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-false')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+          })
+      })
+    })
+
+    describe('enabled', () => {
+      beforeEach(() => {
+        cy.visit('/links/preserve-scroll')
+        cy.get('.foo').should('have.text', 'Foo is now default')
+        cy.scrollTo('5px', '7px')
+        cy.get('#slot').scrollTo('10px', '15px')
+        cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+        cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+      })
+
+      it('resets scroll regions to the top when doing a regular visit', () => {
+        cy.get('.reset')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now bar')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+          })
+      })
+
+      it('resets scroll regions to the top when returning false from a preserveScroll callback', () => {
+        cy.get('.reset-callback')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now foo')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+
+            // Assert that the page is passed in to the callback
+            expect(alert.getCalls()).to.have.length(1)
+            tap(alert.getCall(0).lastArg, (page) => {
+              expect(page).to.be.an('object')
+              expect(page).to.have.property('component')
+              expect(page).to.have.property('props')
+              expect(page).to.have.property('url')
+              expect(page).to.have.property('version')
+            })
+          })
+      })
+
+      it('preserves scroll regions when using the "preserve-scroll" feature', () => {
+        cy.get('.preserve')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now baz')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+
+      it('preserves scroll regions when using the "preserve-scroll" feature from a callback', () => {
+        cy.get('.preserve-callback')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now baz')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+
+            cy.then(() => {
+              // Assert that the page is passed in to the callback
+              expect(alert.getCalls()).to.have.length(1)
+              tap(alert.getCall(0).lastArg, (page) => {
+                expect(page).to.be.an('object')
+                expect(page).to.have.property('component')
+                expect(page).to.have.property('props')
+                expect(page).to.have.property('url')
+                expect(page).to.have.property('version')
+              })
+            })
+          })
+      })
+
+      it('restores all tracked scroll regions when pressing the back button', () => {
+        cy.get('.preserve')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll-page-two')
+            cy.get('#slot').scrollTo(0, 0)
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll')
+
+            cy.get('.foo').should('have.text', 'Foo is now default')
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+
+      it.skip('restores all tracked scroll regions when pressing the back button from another website', () => {
+        cy.get('.off-site')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/non-inertia')
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/links/preserve-scroll')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+    })
+  })
+
+  describe('URL fragment navigation (& automatic scrolling)', () => {
+    /** @see https://github.com/inertiajs/inertia/pull/257 */
+
+    beforeEach(() => {
+      cy.visit('/links/url-fragments', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/url-fragments')
+      cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+    })
+
+    it('Scrolls to the fragment element when making a visit to a different page', () => {
+      cy.get('.basic').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/url-fragments#target')
+      cy.get('.document-position').should('not.have.text', 'Document scroll position is 0 & 0')
+    })
+
+    it('Scrolls to the fragment element when making a visit to the same page', () => {
+      cy.get('.fragment').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/url-fragments#target')
+      cy.get('.document-position').should('not.have.text', 'Document scroll position is 0 & 0')
+    })
+
+    it('Does not scroll to the fragment element when it does not exist on the page', () => {
+      cy.get('.non-existent-fragment').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/url-fragments#non-existent-fragment')
+      cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+    })
+  })
+
+  describe('Partial Reloads', () => {
+    beforeEach(() => {
+      cy.visit('/links/partial-reloads', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+      cy.get('.foo-text').should('have.text', 'Foo is now 1')
+      cy.get('.bar-text').should('have.text', 'Bar is now 2')
+      cy.get('.baz-text').should('have.text', 'Baz is now 3')
+    })
+
+    it('does not have headers specific to partial reloads when the feature is not being used', () => {
+      cy.get('.all').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/partial-reloads')
+
+      cy.window().should('have.property', '_inertia_props')
+      cy.window()
+        .then((window) => window._inertia_props)
+        .then(({ headers }) => {
+          expect(headers).to.not.contain.keys(['x-inertia-partial-component', 'x-inertia-partial-data'])
+        })
+    })
+
+    it('has headers specific to partial reloads', () => {
+      cy.get('.foo-bar').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/partial-reloads')
+
+      cy.window().should('have.property', '_inertia_props')
+      cy.window()
+        .then((window) => window._inertia_props)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys([
+            'accept',
+            'x-requested-with',
+            'x-inertia',
+            'x-inertia-partial-component',
+            'x-inertia-partial-data',
+          ])
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+          expect(headers['x-inertia-partial-data']).to.eq('headers,foo,bar')
+          expect(headers['x-inertia-partial-component']).to.eq('Links/PartialReloads')
+        })
+    })
+
+    it('it updates all props when the feature is not being used', () => {
+      cy.get('.all').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/partial-reloads')
+
+      cy.get('.foo-text').should('have.text', 'Foo is now 2')
+      cy.get('.bar-text').should('have.text', 'Bar is now 3')
+      cy.get('.baz-text').should('have.text', 'Baz is now 4')
+    })
+
+    it('it only updates props that are passed through "only"', () => {
+      cy.get('.foo-bar').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/partial-reloads')
+      cy.get('.foo-text').should('have.text', 'Foo is now 2')
+      cy.get('.bar-text').should('have.text', 'Bar is now 3')
+      cy.get('.baz-text').should('have.text', 'Baz is now 3')
+
+      cy.get('.baz').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/partial-reloads')
+      cy.get('.foo-text').should('have.text', 'Foo is now 2')
+      cy.get('.bar-text').should('have.text', 'Bar is now 3')
+      cy.get('.baz-text').should('have.text', 'Baz is now 5')
+
+      cy.get('.all').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/partial-reloads')
+      cy.get('.foo-text').should('have.text', 'Foo is now 3')
+      cy.get('.bar-text').should('have.text', 'Bar is now 4')
+      cy.get('.baz-text').should('have.text', 'Baz is now 5')
+    })
+  })
+
+  describe('Redirects', () => {
+    let alert = null
+    beforeEach(() => {
+      cy.visit('/', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            alert('A location/non-SPA visit was detected')
+          }),
+      })
+
+      alert = cy.stub()
+      cy.on('window:alert', alert)
+    })
+
+    it('follows 303 redirects', () => {
+      cy.get('.links-redirect')
+        .click()
+        .wait(50)
+        .then(() => {
+          cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+          expect(alert.getCalls()).to.have.length(0)
+        })
+    })
+
+    it('follows external redirects', () => {
+      cy.get('.links-redirect-external')
+        .click()
+        .wait(50)
+        .then(() => {
+          cy.url().should('eq', Cypress.config().baseUrl + '/non-inertia')
+          expect(alert.getCalls()).to.have.length(1)
+          expect(alert.getCall(0)).to.be.calledWith('A location/non-SPA visit was detected')
+        })
+    })
+  })
+
+  describe('"as" warning', () => {
+    it('shows no warning when using GET inertia-links', () => {
+      cy.visit('/links/as-warning/get', {
+        onBeforeLoad: (window) => {
+          cy.spy(window.console, 'warn').as('consoleWarn')
+        },
+      })
+
+      cy.get('@consoleWarn').should('not.be.called')
+    })
+
+    it('shows a warning when using POST inertia-links using the anchor tag', () => {
+      cy.visit('/links/as-warning/post', {
+        onBeforeLoad: (window) => {
+          cy.spy(window.console, 'warn').as('consoleWarn')
+        },
+      })
+
+      cy.get('@consoleWarn').should(
+        'be.calledWith',
+        'Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\n' +
+          'Please specify a more appropriate element using the "as" attribute. For example:\n\n' +
+          '<Link href="/example" method="post" as="button">...</Link>',
+      )
+    })
+
+    it('shows no warning when using POST inertia-links "as" a non-anchor tag', () => {
+      cy.visit('/links/as-warning-false/post', {
+        onBeforeLoad: (window) => {
+          cy.spy(window.console, 'warn').as('consoleWarn')
+        },
+      })
+
+      cy.get('@consoleWarn').should('not.be.called')
+    })
+
+    it('shows a warning when using PUT inertia-links using the anchor tag', () => {
+      cy.visit('/links/as-warning/put', {
+        onBeforeLoad: (window) => {
+          cy.spy(window.console, 'warn').as('consoleWarn')
+        },
+      })
+
+      cy.get('@consoleWarn').should(
+        'be.calledWith',
+        'Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\n' +
+          'Please specify a more appropriate element using the "as" attribute. For example:\n\n' +
+          '<Link href="/example" method="put" as="button">...</Link>',
+      )
+    })
+
+    it('shows no warning when using PUT inertia-links "as" a non-anchor tag', () => {
+      cy.visit('/links/as-warning-false/put', {
+        onBeforeLoad: (window) => {
+          cy.spy(window.console, 'warn').as('consoleWarn')
+        },
+      })
+
+      cy.get('@consoleWarn').should('not.be.called')
+    })
+
+    it('shows a warning when using PATCH inertia-links using the anchor tag', () => {
+      cy.visit('/links/as-warning/patch', {
+        onBeforeLoad: (window) => {
+          cy.spy(window.console, 'warn').as('consoleWarn')
+        },
+      })
+
+      cy.get('@consoleWarn').should(
+        'be.calledWith',
+        'Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\n' +
+          'Please specify a more appropriate element using the "as" attribute. For example:\n\n' +
+          '<Link href="/example" method="patch" as="button">...</Link>',
+      )
+    })
+
+    it('shows no warning when using PATCH inertia-links "as" a non-anchor tag', () => {
+      cy.visit('/links/as-warning-false/patch', {
+        onBeforeLoad: (window) => {
+          cy.spy(window.console, 'warn').as('consoleWarn')
+        },
+      })
+
+      cy.get('@consoleWarn').should('not.be.called')
+    })
+
+    it('shows a warning when using DELETE inertia-links using the anchor tag', () => {
+      cy.visit('/links/as-warning/delete', {
+        onBeforeLoad: (window) => {
+          cy.spy(window.console, 'warn').as('consoleWarn')
+        },
+      })
+
+      cy.get('@consoleWarn').should(
+        'be.calledWith',
+        'Creating POST/PUT/PATCH/DELETE <a> links is discouraged as it causes "Open Link in New Tab/Window" accessibility issues.\n\n' +
+          'Please specify a more appropriate element using the "as" attribute. For example:\n\n' +
+          '<Link href="/example" method="delete" as="button">...</Link>',
+      )
+    })
+
+    it('shows no warning when using DELETE inertia-links "as" a non-anchor tag', () => {
+      cy.visit('/links/as-warning-false/delete', {
+        onBeforeLoad: (window) => {
+          cy.spy(window.console, 'warn').as('consoleWarn')
+        },
+      })
+
+      cy.get('@consoleWarn').should('not.be.called')
+    })
+  })
+})

--- a/packages/vue3/tests/cypress/integration/links.cy.js
+++ b/packages/vue3/tests/cypress/integration/links.cy.js
@@ -1002,6 +1002,20 @@ describe('Links', () => {
       cy.get('.bar-text').should('have.text', 'Bar is now 4')
       cy.get('.baz-text').should('have.text', 'Baz is now 5')
     })
+
+    it('it only updates props that are not passed through "except"', () => {
+      cy.get('.except-foo-bar').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/partial-reloads')
+      cy.get('.foo-text').should('have.text', 'Foo is now 1')
+      cy.get('.bar-text').should('have.text', 'Bar is now 2')
+      cy.get('.baz-text').should('have.text', 'Baz is now 4')
+
+      cy.get('.except-baz').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/links/partial-reloads')
+      cy.get('.foo-text').should('have.text', 'Foo is now 2')
+      cy.get('.bar-text').should('have.text', 'Bar is now 3')
+      cy.get('.baz-text').should('have.text', 'Baz is now 4')
+    })
   })
 
   describe('Redirects', () => {

--- a/packages/vue3/tests/cypress/integration/manual-visits.cy.js
+++ b/packages/vue3/tests/cypress/integration/manual-visits.cy.js
@@ -1,0 +1,1506 @@
+import { tap } from '../support/commands'
+
+describe('Manual Visits', () => {
+  it('visits a different page', () => {
+    cy.visit('/', {
+      onLoad: () =>
+        cy.on('window:load', () => {
+          throw 'A location/non-SPA visit was detected'
+        }),
+    })
+
+    cy.get('.visits-method').click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/visits/method')
+
+    cy.get('.text').should('have.text', 'This is the page that demonstrates manual visit methods')
+  })
+
+  it('can make a location visit', () => {
+    cy.visit('/visits/location', {
+      onLoad: () =>
+        cy.on('window:load', () => {
+          alert('A location/non-SPA visit was detected')
+        }),
+    })
+
+    const alert = cy.stub()
+    cy.on('window:alert', alert)
+
+    cy.get('.example')
+      .click()
+      .then(() => {
+        expect(alert.getCalls()).to.have.length(1)
+        expect(alert.getCall(0)).to.be.calledWith('A location/non-SPA visit was detected')
+
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ headers }) => {
+            expect(headers).to.not.have.property('x-inertia')
+          })
+      })
+  })
+
+  describe('Auto-cancellation', () => {
+    it('will automatically cancel a pending visits when a new request is made', () => {
+      cy.visit('/visits/automatic-cancellation', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      const alert = cy.stub()
+      cy.on('window:alert', alert)
+
+      cy.get('.visit')
+        .click()
+        .click()
+        .wait(30)
+        .then(() => {
+          expect(alert.getCalls()).to.have.length(3)
+          expect(alert.getCall(0)).to.be.calledWith('started')
+          expect(alert.getCall(1)).to.be.calledWith('cancelled')
+          expect(alert.getCall(2)).to.be.calledWith('started')
+        })
+    })
+  })
+
+  describe('Method', () => {
+    beforeEach(() => {
+      cy.visit('/visits/method', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+    })
+
+    it('can use the visit method without any options to make a GET request', () => {
+      cy.get('.visit-get').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('get')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+
+    it('can use the visit method with a specific "method" option to manually set the request method', () => {
+      cy.get('.visit-specific').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('patch')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+
+    it('can use the GET method', () => {
+      cy.get('.get').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('get')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+
+    it('can use the POST method', () => {
+      cy.get('.post').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('post')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+
+    it('can use the PUT method', () => {
+      cy.get('.put').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('put')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+
+    it('can use the PATCH method', () => {
+      cy.get('.patch').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('patch')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+
+    it('can use the DELETE method', () => {
+      cy.get('.delete').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, query }) => {
+          expect(method).to.eq('delete')
+          expect(query).to.be.empty
+          expect(form).to.be.empty
+        })
+    })
+  })
+
+  describe('Data', () => {
+    describe('plain objects', () => {
+      beforeEach(() => {
+        cy.intercept('/dump/**').as('spy')
+        cy.visit('/visits/data/object', {
+          onLoad: () =>
+            cy.on('window:load', () => {
+              throw 'A location/non-SPA visit was detected'
+            }),
+        })
+      })
+
+      it('passes data as params by default when using the visit method', () => {
+        cy.get('.visit').click()
+
+        cy.wait('@spy').then(({ request, response }) => {
+          expect(request.url).to.eq(Cypress.config().baseUrl + '/dump/get?foo=visit')
+          expect(request.headers).to.contain.key('content-type')
+          expect(request.headers['content-type']).to.contain('application/json')
+          expect(request.method).to.eq('GET')
+          expect(response.body.props.form).to.be.empty
+          expect(response.body.props.files).to.be.undefined
+        })
+      })
+
+      describe('GET method', () => {
+        it('passes data as params', () => {
+          cy.get('.get').click()
+
+          cy.wait('@spy').then(({ request, response }) => {
+            expect(request.url).to.eq(Cypress.config().baseUrl + '/dump/get?bar=get')
+            expect(request.headers).to.contain.key('content-type')
+            expect(request.headers['content-type']).to.contain('application/json')
+            expect(request.method).to.eq('GET')
+            expect(response.body.props.form).to.be.empty
+            expect(response.body.props.files).to.be.undefined
+          })
+        })
+
+        describe('query string array formatter', () => {
+          it('can use the brackets query string array formatter', () => {
+            cy.get('.qsaf-brackets').click()
+            cy.wait('@spy')
+              .its('request.url')
+              .should('eq', Cypress.config().baseUrl + '/dump/get?a[]=b&a[]=c')
+          })
+
+          it('can use the indices query string array formatter', () => {
+            cy.get('.qsaf-indices').click()
+            cy.wait('@spy')
+              .its('request.url')
+              .should('eq', Cypress.config().baseUrl + '/dump/get?a[0]=b&a[1]=c')
+          })
+
+          it('defaults to using the brackets query string array formatter', () => {
+            cy.get('.qsaf-default').click()
+            cy.wait('@spy')
+              .its('request.url')
+              .should('eq', Cypress.config().baseUrl + '/dump/get?a[]=b&a[]=c')
+          })
+        })
+      })
+
+      it('can pass data using the POST method', () => {
+        cy.get('.post').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('application/json')
+
+            expect(method).to.eq('post')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('baz')
+            expect(form.baz).to.eq('post')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the PUT method', () => {
+        cy.get('.put').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('application/json')
+
+            expect(method).to.eq('put')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('put')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the PATCH method', () => {
+        cy.get('.patch').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('application/json')
+
+            expect(method).to.eq('patch')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('bar')
+            expect(form.bar).to.eq('patch')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the DELETE method', () => {
+        cy.get('.delete').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('application/json')
+
+            expect(method).to.eq('delete')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('baz')
+            expect(form.baz).to.eq('delete')
+            expect(files).to.be.empty
+          })
+      })
+    })
+
+    describe('FormData objects', () => {
+      beforeEach(() => {
+        cy.visit('/visits/data/form-data', {
+          onLoad: () =>
+            cy.on('window:load', () => {
+              throw 'A location/non-SPA visit was detected'
+            }),
+        })
+      })
+
+      it('can pass data using the visit method when specifying a non-GET "method" option', () => {
+        cy.get('.visit').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('post')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('visit')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the POST method', () => {
+        cy.get('.post').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('post')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('baz')
+            expect(form.baz).to.eq('post')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the PUT method', () => {
+        cy.get('.put').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('put')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('put')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the PATCH method', () => {
+        cy.get('.patch').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('patch')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('bar')
+            expect(form.bar).to.eq('patch')
+            expect(files).to.be.empty
+          })
+      })
+
+      it('can pass data using the DELETE method', () => {
+        cy.get('.delete').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('delete')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('baz')
+            expect(form.baz).to.eq('delete')
+            expect(files).to.be.empty
+          })
+      })
+    })
+
+    describe('auto-converted objects (when files are present)', () => {
+      beforeEach(() => {
+        cy.visit('/visits/data/auto-converted', {
+          onLoad: () =>
+            cy.on('window:load', () => {
+              throw 'A location/non-SPA visit was detected'
+            }),
+        })
+      })
+
+      it('auto-converts objects to form-data when files are present using the POST method', () => {
+        cy.get('.post').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('post')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('bar')
+            expect(files).to.not.be.empty
+          })
+      })
+
+      it('auto-converts objects to form-data when files are present using the PUT method', () => {
+        cy.get('.put').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('put')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('bar')
+            expect(files).to.not.be.empty
+          })
+      })
+
+      it('auto-converts objects to form-data when files are present using the PATCH method', () => {
+        cy.get('.patch').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('patch')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('bar')
+            expect(files).to.not.be.empty
+          })
+      })
+
+      it('auto-converts objects to form-data when files are present using the DELETE method', () => {
+        cy.get('.delete').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+        cy.window().should('have.property', '_inertia_request_dump')
+        cy.window()
+          .then((window) => window._inertia_request_dump)
+          .then(({ method, headers, form, files, query }) => {
+            expect(headers).to.contain.key('content-type')
+            expect(headers['content-type']).to.contain('multipart/form-data; boundary=')
+
+            expect(method).to.eq('delete')
+            expect(query).to.be.empty
+            expect(form).to.contain.key('foo')
+            expect(form.foo).to.eq('bar')
+            expect(files).to.not.be.empty
+          })
+      })
+    })
+  })
+
+  describe('Headers', () => {
+    it('has the default set of headers', () => {
+      cy.visit('/visits/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.default').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia'])
+          expect(headers).to.not.contain.key('x-inertia-version')
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+        })
+    })
+
+    it('starts using the x-inertia-version header when a version was given from the back-end', () => {
+      cy.visit('/visits/headers/version', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.default').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.key('x-inertia-version')
+          expect(headers['x-inertia-version']).to.eq('example-version-header')
+        })
+    })
+
+    it('allows to set custom headers using the visit method', () => {
+      cy.visit('/visits/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.visit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia', 'foo'])
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+          expect(headers['foo']).to.eq('bar')
+        })
+    })
+
+    it('allows to set custom headers using the GET method', () => {
+      cy.visit('/visits/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.get').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia', 'bar'])
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+          expect(headers['bar']).to.eq('baz')
+        })
+    })
+
+    it('allows to set custom headers using the POST method', () => {
+      cy.visit('/visits/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.post').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia', 'baz'])
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+          expect(headers['baz']).to.eq('foo')
+        })
+    })
+
+    it('allows to set custom headers using the PUT method', () => {
+      cy.visit('/visits/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.put').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/put')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia', 'foo'])
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+          expect(headers['foo']).to.eq('bar')
+        })
+    })
+
+    it('allows to set custom headers using the PATCH method', () => {
+      cy.visit('/visits/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.patch').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/patch')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia', 'bar'])
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+          expect(headers['bar']).to.eq('baz')
+        })
+    })
+
+    it('allows to set custom headers using the DELETE method', () => {
+      cy.visit('/visits/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.delete').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/delete')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia', 'baz'])
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+          expect(headers['baz']).to.eq('foo')
+        })
+    })
+
+    it('cannot override built-in Inertia headers', () => {
+      cy.visit('/visits/headers', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+
+      cy.get('.overridden').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ headers }) => {
+          expect(headers).to.contain.keys(['accept', 'x-requested-with', 'x-inertia', 'bar'])
+          expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+          expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+          expect(headers['x-inertia']).to.eq('true')
+          expect(headers['bar']).to.eq('baz')
+        })
+    })
+  })
+
+  describe('Replace', () => {
+    beforeEach(() => {
+      cy.visit('/')
+      cy.window().then((window) => (window._inertia_spa_page_load = true))
+      cy.get('.visits-replace').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/visits/replace')
+    })
+
+    afterEach(() => {
+      cy.window().should('have.prop', '_inertia_spa_page_load');
+    })
+
+    it('replaces the current history state (visit method)', () => {
+      cy.get('.replace').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/')
+
+      cy.go(1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+    })
+
+    it('replaces the current history state (GET method)', () => {
+      cy.get('.replace-get').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/')
+
+      cy.go(1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+    })
+
+    it('does not replace the current history state when it is set to false (visit method)', () => {
+      cy.get('.replace-false').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/visits/replace')
+
+      cy.go(1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+    })
+
+    it('does not replace the current history state when it is set to false (GET method)', () => {
+      cy.get('.replace-get-false').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/visits/replace')
+
+      cy.go(1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+    })
+  })
+
+  describe('Preserve state', () => {
+    beforeEach(() => {
+      cy.visit('/visits/preserve-state', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+    })
+
+    it("preserves the page's local state (visit method)", () => {
+      cy.get('.foo').should('have.text', 'Foo is now default')
+      cy.get('.field').type('Example value')
+
+      cy.window().should('have.property', '_inertia_page_key')
+      cy.window().then((window) => {
+        const componentKey = window._inertia_page_key
+
+        cy.get('.preserve').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-state-page-two')
+
+        cy.window().then((window) => {
+          expect(componentKey).to.eq(window._inertia_page_key)
+          cy.get('.foo').should('have.text', 'Foo is now bar')
+          cy.get('.field').should('have.value', 'Example value')
+        })
+      })
+    })
+
+    it("preserves the page's local state (GET method)", () => {
+      cy.get('.foo').should('have.text', 'Foo is now default')
+      cy.get('.field').type('Example value')
+
+      cy.window().should('have.property', '_inertia_page_key')
+      cy.window().then((window) => {
+        const componentKey = window._inertia_page_key
+
+        cy.get('.preserve-get').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-state-page-two')
+
+        cy.window().then((window) => {
+          expect(componentKey).to.eq(window._inertia_page_key)
+          cy.get('.foo').should('have.text', 'Foo is now get-bar')
+          cy.get('.field').should('have.value', 'Example value')
+        })
+      })
+    })
+
+    it("preserves the page's local state (callback)", () => {
+      cy.get('.foo').should('have.text', 'Foo is now default')
+      cy.get('.field').type('Example value')
+
+      cy.window().should('have.property', '_inertia_page_key')
+      cy.window().then((window) => {
+        const componentKey = window._inertia_page_key
+
+        cy.get('.preserve-callback').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-state-page-two')
+
+        cy.window().then((window) => {
+          expect(componentKey).to.eq(window._inertia_page_key)
+          cy.get('.foo').should('have.text', 'Foo is now callback-bar')
+          cy.get('.field').should('have.value', 'Example value')
+        })
+      })
+    })
+
+    it("does not preserve the page's local state (visit method)", () => {
+      cy.get('.foo').should('have.text', 'Foo is now default')
+      cy.get('.field').type('Another value')
+
+      cy.window().should('have.property', '_inertia_page_key')
+      cy.window().then((window) => {
+        const componentKey = window._inertia_page_key
+
+        cy.get('.preserve-false').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-state-page-two')
+
+        cy.window().then((window) => {
+          expect(componentKey).to.not.eq(window._inertia_page_key)
+          cy.get('.foo').should('have.text', 'Foo is now baz')
+          cy.get('.field').should('have.value', '')
+        })
+      })
+    })
+
+    it("does not preserve the page's local state (GET method)", () => {
+      cy.get('.foo').should('have.text', 'Foo is now default')
+      cy.get('.field').type('Another value')
+
+      cy.window().should('have.property', '_inertia_page_key')
+      cy.window().then((window) => {
+        const componentKey = window._inertia_page_key
+
+        cy.get('.preserve-get-false').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-state-page-two')
+
+        cy.window().then((window) => {
+          expect(componentKey).to.not.eq(window._inertia_page_key)
+          cy.get('.foo').should('have.text', 'Foo is now get-baz')
+          cy.get('.field').should('have.value', '')
+        })
+      })
+    })
+
+    it("does not preserve the page's local state (callback)", () => {
+      cy.get('.foo').should('have.text', 'Foo is now default')
+      cy.get('.field').type('Another value')
+
+      cy.window().should('have.property', '_inertia_page_key')
+      cy.window().then((window) => {
+        const componentKey = window._inertia_page_key
+
+        cy.get('.preserve-callback-false').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-state-page-two')
+
+        cy.window().then((window) => {
+          expect(componentKey).to.not.eq(window._inertia_page_key)
+          cy.get('.foo').should('have.text', 'Foo is now callback-baz')
+          cy.get('.field').should('have.value', '')
+        })
+      })
+    })
+  })
+
+  describe('Preserve scroll', () => {
+    let alert = null
+
+    beforeEach(() => {
+      alert = cy.stub()
+      cy.on('window:alert', alert)
+    })
+
+    describe('disabled (default)', () => {
+      beforeEach(() => {
+        cy.visit('/visits/preserve-scroll-false')
+        cy.get('.foo').should('have.text', 'Foo is now default')
+        cy.scrollTo('5px', '7px')
+        cy.get('#slot').scrollTo('10px', '15px')
+        cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+        cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+      })
+
+      it('does not reset untracked scroll regions in persistent layouts (visit method)', () => {
+        cy.get('.reset')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-false-page-two')
+
+            cy.get('.foo').should('have.text', 'Foo is now bar')
+            cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+
+      it('does not reset untracked scroll regions in persistent layouts (GET method)', () => {
+        cy.get('.reset-get')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-false-page-two')
+
+            cy.get('.foo').should('have.text', 'Foo is now baz')
+            cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+
+      it('does not reset untracked scroll regions in persistent layouts when returning false from a preserveScroll callback', () => {
+        cy.get('.reset-callback')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-false-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now foo')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+
+            // Assert that the page is passed in to the callback
+            expect(alert.getCalls()).to.have.length(1)
+            tap(alert.getCall(0).lastArg, (page) => {
+              expect(page).to.be.an('object')
+              expect(page).to.have.property('component')
+              expect(page).to.have.property('props')
+              expect(page).to.have.property('url')
+              expect(page).to.have.property('version')
+            })
+          })
+      })
+
+      it('does not restore untracked scroll regions when pressing the back button (visit method)', () => {
+        cy.get('.reset')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-false-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now bar')
+            cy.get('#slot').scrollTo(0, 0)
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-false')
+            cy.get('.foo').should('have.text', 'Foo is now default')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+          })
+      })
+
+      it('does not restore untracked scroll regions when pressing the back button (GET method)', () => {
+        cy.get('.reset-get')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-false-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now baz')
+            cy.get('#slot').scrollTo(0, 0)
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-false')
+            cy.get('.foo').should('have.text', 'Foo is now default')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+          })
+      })
+
+      it('does not restore untracked scroll regions when returning true from a preserveScroll callback', () => {
+        cy.get('.preserve-callback')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-false-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now baz')
+            cy.get('#slot').scrollTo(0, 0)
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+
+            // Assert that the page is passed in to the callback
+            expect(alert.getCalls()).to.have.length(1)
+            tap(alert.getCall(0).lastArg, (page) => {
+              expect(page).to.be.an('object')
+              expect(page).to.have.property('component')
+              expect(page).to.have.property('props')
+              expect(page).to.have.property('url')
+              expect(page).to.have.property('version')
+            })
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-false')
+            cy.get('.foo').should('have.text', 'Foo is now default')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+          })
+      })
+
+      it('does not restore untracked scroll regions when pressing the back button from another website', () => {
+        cy.get('.off-site')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/non-inertia')
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-false')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+          })
+      })
+    })
+
+    describe('enabled', () => {
+      beforeEach(() => {
+        cy.visit('/visits/preserve-scroll')
+        cy.get('.foo').should('have.text', 'Foo is now default')
+        cy.scrollTo('5px', '7px')
+        cy.get('#slot').scrollTo('10px', '15px')
+        cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+        cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+      })
+
+      it('resets scroll regions to the top when doing a regular visit (visit method)', () => {
+        cy.get('.reset')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now bar')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+          })
+      })
+
+      it('resets scroll regions to the top when doing a regular visit (GET method)', () => {
+        cy.get('.reset-get')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now baz')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+          })
+      })
+
+      it('resets scroll regions to the top when returning false from a preserveScroll callback', () => {
+        cy.get('.reset-callback')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now foo')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+
+            // Assert that the page is passed in to the callback
+            expect(alert.getCalls()).to.have.length(1)
+            tap(alert.getCall(0).lastArg, (page) => {
+              expect(page).to.be.an('object')
+              expect(page).to.have.property('component')
+              expect(page).to.have.property('props')
+              expect(page).to.have.property('url')
+              expect(page).to.have.property('version')
+            })
+          })
+      })
+
+      it('preserves scroll regions when using the "preserve-scroll" feature (visit method)', () => {
+        cy.get('.preserve')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now foo')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+
+      it('preserves scroll regions when using the "preserve-scroll" feature (GET method)', () => {
+        cy.get('.preserve-get')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now bar')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+
+      it('preserves scroll regions when using the "preserve-scroll" feature from a callback', () => {
+        cy.get('.preserve-callback')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-page-two')
+            cy.get('.foo').should('have.text', 'Foo is now baz')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+
+            cy.then(() => {
+              // Assert that the page is passed in to the callback
+              expect(alert.getCalls()).to.have.length(1)
+              tap(alert.getCall(0).lastArg, (page) => {
+                expect(page).to.be.an('object')
+                expect(page).to.have.property('component')
+                expect(page).to.have.property('props')
+                expect(page).to.have.property('url')
+                expect(page).to.have.property('version')
+              })
+            })
+          })
+      })
+
+      it('restores all tracked scroll regions when pressing the back button (visit method)', () => {
+        cy.get('.preserve')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-page-two')
+            cy.get('#slot').scrollTo(0, 0)
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll')
+
+            cy.get('.foo').should('have.text', 'Foo is now default')
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+
+      it('restores all tracked scroll regions when pressing the back button (GET method)', () => {
+        cy.get('.preserve-get')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll-page-two')
+            cy.get('#slot').scrollTo(0, 0)
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 0 & 0')
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll')
+
+            cy.get('.foo').should('have.text', 'Foo is now default')
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+
+      it.skip('restores all tracked scroll regions when pressing the back button from another website', () => {
+        cy.get('.off-site')
+          .click({ force: true })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/non-inertia')
+
+            return cy.go(-1)
+          })
+          .then(() => {
+            cy.url().should('eq', Cypress.config().baseUrl + '/visits/preserve-scroll')
+
+            cy.get('.document-position').should('have.text', 'Document scroll position is 5 & 7')
+            cy.get('.slot-position').should('have.text', 'Slot scroll position is 10 & 15')
+          })
+      })
+    })
+  })
+
+  describe('URL fragment navigation (& automatic scrolling)', () => {
+    /** @see https://github.com/inertiajs/inertia/pull/257 */
+
+    beforeEach(() => {
+      cy.visit('/visits/url-fragments', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+      cy.url().should('eq', Cypress.config().baseUrl + '/visits/url-fragments')
+      cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+    })
+
+    describe('visit-method', () => {
+      it('Scrolls to the fragment element when making a visit to a different page', () => {
+        cy.get('.basic').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/url-fragments#target')
+        cy.get('.document-position').should('not.have.text', 'Document scroll position is 0 & 0')
+      })
+
+      it('Scrolls to the fragment element when making a visit to the same page', () => {
+        cy.get('.fragment').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/url-fragments#target')
+        cy.get('.document-position').should('not.have.text', 'Document scroll position is 0 & 0')
+      })
+
+      it('Does not scroll to the fragment element when it does not exist on the page', () => {
+        cy.get('.non-existent-fragment').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/url-fragments#non-existent-fragment')
+        cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+      })
+    })
+
+    describe('GET-method', () => {
+      it('Scrolls to the fragment element when making a visit to a different page', () => {
+        cy.get('.basic-get').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/url-fragments#target')
+        cy.get('.document-position').should('not.have.text', 'Document scroll position is 0 & 0')
+      })
+
+      it('Scrolls to the fragment element when making a visit to the same page', () => {
+        cy.get('.fragment-get').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/url-fragments#target')
+        cy.get('.document-position').should('not.have.text', 'Document scroll position is 0 & 0')
+      })
+
+      it('Does not scroll to the fragment element when it does not exist on the page', () => {
+        cy.get('.non-existent-fragment-get').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/url-fragments#non-existent-fragment')
+        cy.get('.document-position').should('have.text', 'Document scroll position is 0 & 0')
+      })
+    })
+  })
+
+  describe('Partial Reloads', () => {
+    beforeEach(() => {
+      cy.visit('/visits/partial-reloads', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+      cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+      cy.get('.foo-text').should('have.text', 'Foo is now 1')
+      cy.get('.bar-text').should('have.text', 'Bar is now 2')
+      cy.get('.baz-text').should('have.text', 'Baz is now 3')
+    })
+
+    describe('visit-method', () => {
+      it('does not have headers specific to partial reloads when the feature is not being used', () => {
+        cy.get('.visit').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+
+        cy.window().should('have.property', '_inertia_props')
+        cy.window()
+          .then((window) => window._inertia_props)
+          .then(({ headers }) => {
+            expect(headers).to.not.contain.keys(['x-inertia-partial-component', 'x-inertia-partial-data'])
+          })
+      })
+
+      it('has headers specific to partial reloads', () => {
+        cy.get('.visit-foo-bar').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+
+        cy.window().should('have.property', '_inertia_props')
+        cy.window()
+          .then((window) => window._inertia_props)
+          .then(({ headers }) => {
+            expect(headers).to.contain.keys([
+              'accept',
+              'x-requested-with',
+              'x-inertia',
+              'x-inertia-partial-component',
+              'x-inertia-partial-data',
+            ])
+            expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+            expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+            expect(headers['x-inertia']).to.eq('true')
+            expect(headers['x-inertia-partial-data']).to.eq('headers,foo,bar')
+            expect(headers['x-inertia-partial-component']).to.eq('Visits/PartialReloads')
+          })
+      })
+
+      it('it updates all props when the feature is not being used', () => {
+        cy.get('.visit').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+
+        cy.get('.foo-text').should('have.text', 'Foo is now 2')
+        cy.get('.bar-text').should('have.text', 'Bar is now 3')
+        cy.get('.baz-text').should('have.text', 'Baz is now 4')
+      })
+
+      it('it only updates props that are passed through "only"', () => {
+        cy.get('.visit-foo-bar').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+        cy.get('.foo-text').should('have.text', 'Foo is now 2')
+        cy.get('.bar-text').should('have.text', 'Bar is now 3')
+        cy.get('.baz-text').should('have.text', 'Baz is now 3')
+
+        cy.get('.visit-baz').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+        cy.get('.foo-text').should('have.text', 'Foo is now 2')
+        cy.get('.bar-text').should('have.text', 'Bar is now 3')
+        cy.get('.baz-text').should('have.text', 'Baz is now 5')
+
+        cy.get('.visit').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+        cy.get('.foo-text').should('have.text', 'Foo is now 3')
+        cy.get('.bar-text').should('have.text', 'Bar is now 4')
+        cy.get('.baz-text').should('have.text', 'Baz is now 5')
+      })
+    })
+
+    describe('GET-method', () => {
+      it('does not have headers specific to partial reloads when the feature is not being used', () => {
+        cy.get('.get').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+
+        cy.window().should('have.property', '_inertia_props')
+        cy.window()
+          .then((window) => window._inertia_props)
+          .then(({ headers }) => {
+            expect(headers).to.not.contain.keys(['x-inertia-partial-component', 'x-inertia-partial-data'])
+          })
+      })
+
+      it('has headers specific to partial reloads', () => {
+        cy.get('.get-foo-bar').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+
+        cy.window().should('have.property', '_inertia_props')
+        cy.window()
+          .then((window) => window._inertia_props)
+          .then(({ headers }) => {
+            expect(headers).to.contain.keys([
+              'accept',
+              'x-requested-with',
+              'x-inertia',
+              'x-inertia-partial-component',
+              'x-inertia-partial-data',
+            ])
+            expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+            expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+            expect(headers['x-inertia']).to.eq('true')
+            expect(headers['x-inertia-partial-data']).to.eq('headers,foo,bar')
+            expect(headers['x-inertia-partial-component']).to.eq('Visits/PartialReloads')
+          })
+      })
+
+      it('it updates all props when the feature is not being used', () => {
+        cy.get('.get').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+
+        cy.get('.foo-text').should('have.text', 'Foo is now 2')
+        cy.get('.bar-text').should('have.text', 'Bar is now 3')
+        cy.get('.baz-text').should('have.text', 'Baz is now 4')
+      })
+
+      it('it only updates props that are passed through "only"', () => {
+        cy.get('.get-foo-bar').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+        cy.get('.foo-text').should('have.text', 'Foo is now 2')
+        cy.get('.bar-text').should('have.text', 'Bar is now 3')
+        cy.get('.baz-text').should('have.text', 'Baz is now 3')
+
+        cy.get('.get-baz').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+        cy.get('.foo-text').should('have.text', 'Foo is now 2')
+        cy.get('.bar-text').should('have.text', 'Bar is now 3')
+        cy.get('.baz-text').should('have.text', 'Baz is now 5')
+
+        cy.get('.get').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+        cy.get('.foo-text').should('have.text', 'Foo is now 3')
+        cy.get('.bar-text').should('have.text', 'Bar is now 4')
+        cy.get('.baz-text').should('have.text', 'Baz is now 5')
+      })
+    })
+  })
+
+  describe('Error bags', () => {
+    beforeEach(() => {
+      cy.visit('/visits/error-bags', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            throw 'A location/non-SPA visit was detected'
+          }),
+      })
+      cy.url().should('eq', Cypress.config().baseUrl + '/visits/error-bags')
+    })
+
+    it('does not use error bags by default', () => {
+      cy.get('.default').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, headers }) => {
+          expect(method).to.eq('post')
+          expect(headers).to.not.contain.key('x-inertia-error-bag')
+        })
+    })
+
+    it('uses error bags using the visit method', () => {
+      cy.get('.visit').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, headers }) => {
+          expect(method).to.eq('post')
+          expect(form).to.contain.key('foo')
+          expect(form.foo).to.eq('bar')
+          expect(headers).to.contain.key('x-inertia-error-bag')
+          expect(headers['x-inertia-error-bag']).to.contain('visitErrorBag')
+        })
+    })
+
+    it('uses error bags using the GET method', () => {
+      cy.get('.get').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/post')
+
+      cy.window().should('have.property', '_inertia_request_dump')
+      cy.window()
+        .then((window) => window._inertia_request_dump)
+        .then(({ method, form, headers }) => {
+          expect(method).to.eq('post')
+          expect(form).to.contain.key('foo')
+          expect(form.foo).to.eq('baz')
+          expect(headers).to.contain.key('x-inertia-error-bag')
+          expect(headers['x-inertia-error-bag']).to.contain('postErrorBag')
+        })
+    })
+  })
+
+  describe('Redirects', () => {
+    let alert = null
+    beforeEach(() => {
+      cy.visit('/', {
+        onLoad: () =>
+          cy.on('window:load', () => {
+            alert('A location/non-SPA visit was detected')
+          }),
+      })
+
+      alert = cy.stub()
+      cy.on('window:alert', alert)
+    })
+
+    it('follows 303 redirects', () => {
+      cy.get('.visits-redirect')
+        .click()
+        .wait(50)
+        .then(() => {
+          cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+          expect(alert.getCalls()).to.have.length(0)
+        })
+    })
+
+    it('follows external redirects', () => {
+      cy.get('.visits-redirect-external')
+        .click()
+        .wait(50)
+        .then(() => {
+          cy.url().should('eq', Cypress.config().baseUrl + '/non-inertia')
+          expect(alert.getCalls()).to.have.length(1)
+          expect(alert.getCall(0)).to.be.calledWith('A location/non-SPA visit was detected')
+        })
+    })
+  })
+})

--- a/packages/vue3/tests/cypress/integration/manual-visits.cy.js
+++ b/packages/vue3/tests/cypress/integration/manual-visits.cy.js
@@ -1291,7 +1291,7 @@ describe('Manual Visits', () => {
           })
       })
 
-      it('has headers specific to partial reloads', () => {
+      it('has headers specific to "only" partial reloads', () => {
         cy.get('.visit-foo-bar').click()
         cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
 
@@ -1310,6 +1310,29 @@ describe('Manual Visits', () => {
             expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
             expect(headers['x-inertia']).to.eq('true')
             expect(headers['x-inertia-partial-data']).to.eq('headers,foo,bar')
+            expect(headers['x-inertia-partial-component']).to.eq('Visits/PartialReloads')
+          })
+      })
+
+      it('has headers specific to "except" partial reloads', () => {
+        cy.get('.visit-except-foo-bar').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+
+        cy.window().should('have.property', '_inertia_props')
+        cy.window()
+          .then((window) => window._inertia_props)
+          .then(({ headers }) => {
+            expect(headers).to.contain.keys([
+              'accept',
+              'x-requested-with',
+              'x-inertia',
+              'x-inertia-partial-component',
+              'x-inertia-partial-except',
+            ])
+            expect(headers['accept']).to.eq('text/html, application/xhtml+xml')
+            expect(headers['x-requested-with']).to.eq('XMLHttpRequest')
+            expect(headers['x-inertia']).to.eq('true')
+            expect(headers['x-inertia-partial-except']).to.eq('foo,bar')
             expect(headers['x-inertia-partial-component']).to.eq('Visits/PartialReloads')
           })
       })
@@ -1341,6 +1364,20 @@ describe('Manual Visits', () => {
         cy.get('.foo-text').should('have.text', 'Foo is now 3')
         cy.get('.bar-text').should('have.text', 'Bar is now 4')
         cy.get('.baz-text').should('have.text', 'Baz is now 5')
+      })
+
+      it('it only updates props that are not passed through "except"', () => {
+        cy.get('.visit-except-foo-bar').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+        cy.get('.foo-text').should('have.text', 'Foo is now 1')
+        cy.get('.bar-text').should('have.text', 'Bar is now 2')
+        cy.get('.baz-text').should('have.text', 'Baz is now 4')
+
+        cy.get('.visit-except-baz').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+        cy.get('.foo-text').should('have.text', 'Foo is now 2')
+        cy.get('.bar-text').should('have.text', 'Bar is now 3')
+        cy.get('.baz-text').should('have.text', 'Baz is now 4')
       })
     })
 
@@ -1407,6 +1444,20 @@ describe('Manual Visits', () => {
         cy.get('.foo-text').should('have.text', 'Foo is now 3')
         cy.get('.bar-text').should('have.text', 'Bar is now 4')
         cy.get('.baz-text').should('have.text', 'Baz is now 5')
+      })
+
+      it('it only updates props that are not passed through "except"', () => {
+        cy.get('.get-except-foo-bar').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+        cy.get('.foo-text').should('have.text', 'Foo is now 1')
+        cy.get('.bar-text').should('have.text', 'Bar is now 2')
+        cy.get('.baz-text').should('have.text', 'Baz is now 4')
+
+        cy.get('.get-except-baz').click()
+        cy.url().should('eq', Cypress.config().baseUrl + '/visits/partial-reloads')
+        cy.get('.foo-text').should('have.text', 'Foo is now 2')
+        cy.get('.bar-text').should('have.text', 'Bar is now 3')
+        cy.get('.baz-text').should('have.text', 'Baz is now 4')
       })
     })
   })

--- a/packages/vue3/tests/cypress/integration/pages.cy.js
+++ b/packages/vue3/tests/cypress/integration/pages.cy.js
@@ -1,0 +1,158 @@
+describe('Pages', () => {
+  it('receives data from the controllers as props', () => {
+    cy.visit('/')
+
+    cy.window().then((window) => {
+      const inertiaRoot = window.testing.vue.$
+      const page = inertiaRoot.subTree.component
+
+      // When props are not declared, they become attrs
+      expect(page.attrs).to.have.property('example')
+      expect(page.attrs.example).to.equal('FooBar')
+    })
+  })
+
+  describe('Persistent Layouts', () => {
+    describe('Render Function', () => {
+      it('can have a persistent layout', () => {
+        cy.visit('/persistent-layouts/render-function/simple/page-a')
+
+        cy.window().then((window) => {
+          // window.testing.vue.$.vnode.component.subTree.component.uid
+          const inertiaRoot = window.testing.vue.$
+          const layoutA = inertiaRoot.subTree.component
+          const layoutAUid = layoutA.uid
+          expect(layoutAUid).is.not.null
+
+          cy.get('.text').should('have.text', 'Simple Persistent Layout - Page A')
+
+          cy.get('a').click()
+          cy.url().should('eq', Cypress.config().baseUrl + '/persistent-layouts/render-function/simple/page-b')
+
+          cy.get('.text')
+            .should('have.text', 'Simple Persistent Layout - Page B')
+            .then(() => {
+              const layoutB = inertiaRoot.subTree.component
+
+              expect(layoutB.uid).to.eq(layoutAUid)
+            })
+        })
+      })
+
+      it('can create more complex layout arrangements using nested layouts', () => {
+        cy.visit('/persistent-layouts/render-function/nested/page-a')
+
+        cy.window().then((window) => {
+          const inertiaRoot = window.testing.vue.$
+          const siteLayoutA = inertiaRoot.subTree.component
+          const siteLayoutAUid = siteLayoutA.uid
+          expect(siteLayoutAUid).is.not.null
+          const nestedLayoutA = siteLayoutA.subTree.children[0]
+          const nestedLayoutAUid = nestedLayoutA.uid
+          expect(nestedLayoutAUid).is.not.null
+
+          cy.get('.text').should('have.text', 'Nested Persistent Layout - Page A')
+
+          cy.get('a').click()
+          cy.url().should('eq', Cypress.config().baseUrl + '/persistent-layouts/render-function/nested/page-b')
+
+          cy.get('.text')
+            .should('have.text', 'Nested Persistent Layout - Page B')
+            .then(() => {
+              const siteLayoutB = inertiaRoot.subTree.component
+              const nestedLayoutB = siteLayoutB.subTree.children[0]
+
+              expect(siteLayoutB.uid).to.eq(siteLayoutAUid)
+              expect(nestedLayoutB.uid).to.eq(nestedLayoutAUid)
+            })
+        })
+      })
+    })
+
+    describe('Shorthand', () => {
+      it('can have a persistent layout', () => {
+        cy.visit('/persistent-layouts/shorthand/simple/page-a')
+
+        cy.window().then((window) => {
+          const inertiaRoot = window.testing.vue.$
+          const layoutA = inertiaRoot.subTree.component
+          const layoutAUid = layoutA.uid
+          expect(layoutAUid).is.not.null
+
+          cy.get('.text').should('have.text', 'Simple Persistent Layout - Page A')
+
+          cy.get('a').click()
+          cy.url().should('eq', Cypress.config().baseUrl + '/persistent-layouts/shorthand/simple/page-b')
+
+          cy.get('.text')
+            .should('have.text', 'Simple Persistent Layout - Page B')
+            .then(() => {
+              const layoutB = inertiaRoot.subTree.component
+
+              expect(layoutB.uid).to.eq(layoutAUid)
+            })
+        })
+      })
+
+      it('has the page props available within the persistent layout', () => {
+        cy.visit('/persistent-layouts/shorthand/simple/page-a')
+
+        cy.url().should('eq', Cypress.config().baseUrl + '/persistent-layouts/shorthand/simple/page-a')
+        cy.window().should('have.property', '_inertia_page_props')
+        cy.window().should('have.property', '_inertia_site_layout_props')
+        cy.window().then((window) => {
+          expect(window._inertia_page_props).to.not.be.undefined
+          expect(window._inertia_page_props).to.have.keys('foo', 'baz')
+          expect(window._inertia_site_layout_props).to.not.be.undefined
+          expect(window._inertia_site_layout_props).to.have.keys('foo', 'baz')
+        })
+      })
+
+      it('can create more complex layout arrangements using nested persistent layouts', () => {
+        cy.visit('/persistent-layouts/shorthand/nested/page-a')
+
+        cy.window().then((window) => {
+          const inertiaRoot = window.testing.vue.$
+          const siteLayoutA = inertiaRoot.subTree.component
+          const siteLayoutAUid = siteLayoutA.uid
+          expect(siteLayoutAUid).is.not.null
+          const nestedLayoutA = siteLayoutA.subTree.children[0]
+          const nestedLayoutAUid = nestedLayoutA.uid
+          expect(nestedLayoutAUid).is.not.null
+
+          cy.get('.text').as('pageLabel').should('have.text', 'Nested Persistent Layout - Page A')
+
+          cy.get('a').click()
+          cy.url().should('eq', Cypress.config().baseUrl + '/persistent-layouts/shorthand/nested/page-b')
+
+          cy.get('.text')
+            .should('have.text', 'Nested Persistent Layout - Page B')
+            .then(() => {
+              const siteLayoutB = inertiaRoot.subTree.component
+              const nestedLayoutB = siteLayoutB.subTree.children[0]
+
+              expect(siteLayoutB.uid).to.eq(siteLayoutAUid)
+              expect(nestedLayoutB.uid).to.eq(nestedLayoutAUid)
+            })
+        })
+      })
+
+      it('has the page props available within all nested persistent layouts', () => {
+        cy.visit('/persistent-layouts/shorthand/nested/page-a')
+
+        cy.url().should('eq', Cypress.config().baseUrl + '/persistent-layouts/shorthand/nested/page-a')
+        cy.window().should('have.property', '_inertia_page_props')
+        cy.window().should('have.property', '_inertia_site_layout_props')
+        cy.window().should('have.property', '_inertia_nested_layout_props')
+        cy.window().then((window) => {
+          expect(window._inertia_page_props).to.not.be.undefined
+          expect(window._inertia_page_props).to.have.keys('foo', 'baz')
+          expect(window._inertia_site_layout_props).to.not.be.undefined
+          expect(window._inertia_site_layout_props).to.have.keys('foo', 'baz')
+          expect(window._inertia_nested_layout_props).to.not.be.undefined
+          expect(window._inertia_nested_layout_props).to.have.keys('foo', 'baz')
+        })
+      })
+    })
+  })
+})

--- a/packages/vue3/tests/cypress/integration/plugin.cy.js
+++ b/packages/vue3/tests/cypress/integration/plugin.cy.js
@@ -1,0 +1,48 @@
+describe('Plugin', () => {
+  describe('$page helper', () => {
+    it('has the helper injected into the Vue component', () => {
+      cy.visit('/')
+
+      cy.window().then((window) => {
+        const vueInstance = window.testing.vue
+
+        expect(vueInstance.$page).to.deep.equal(vueInstance.$inertia.page)
+      })
+    })
+
+    it('misses the helper when not registered', () => {
+      cy.visit('/plugin/without')
+
+      cy.window().then((window) => {
+        const inertiaRoot = window.testing.vue.$
+        const page = inertiaRoot.subTree.component
+
+        expect(page.$page).to.be.undefined
+      })
+    })
+  })
+
+  describe('$inertia helper', () => {
+    it('has the helper injected into the Vue component', () => {
+      cy.visit('/')
+
+      cy.window().then((window) => {
+        const vueInstance = window.testing.vue
+
+        expect(vueInstance.$inertia).to.deep.equal(window.testing.Inertia)
+        expect(vueInstance.$.appContext.config.globalProperties.$inertia).to.deep.equal(window.testing.Inertia)
+      })
+    })
+
+    it('misses the helper when not registered', () => {
+      cy.visit('/plugin/without')
+
+      cy.window().then((window) => {
+        const inertiaRoot = window.testing.vue.$
+        const page = inertiaRoot.subTree.component
+
+        expect(page.$inertia).to.be.undefined
+      })
+    })
+  })
+})

--- a/packages/vue3/tests/cypress/integration/remember.cy.js
+++ b/packages/vue3/tests/cypress/integration/remember.cy.js
@@ -1,0 +1,294 @@
+describe('Remember (local state caching)', () => {
+  it('does not remember anything as of default', () => {
+    cy.visit('/remember/default')
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/default')
+
+    cy.get('#name').clear().type('A')
+    cy.get('#remember').check()
+    cy.get('#untracked').clear().type('B')
+
+    cy.get('.link').click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+    cy.go(-1)
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/default')
+
+    cy.get('#name').should('not.have.value', 'A')
+    cy.get('#remember').should('not.be.checked')
+    cy.get('#untracked').should('not.have.value', 'B')
+  })
+
+  it('remembers tracked fields using the array syntax', () => {
+    cy.visit('/remember/array')
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/array')
+
+    cy.get('#name').clear().type('A')
+    cy.get('#remember').check()
+    cy.get('#untracked').clear().type('B')
+
+    cy.get('.link').click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+    cy.go(-1)
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/array')
+
+    cy.get('#name').should('have.value', 'A')
+    cy.get('#remember').should('be.checked')
+    cy.get('#untracked').should('not.have.value', 'B')
+  })
+
+  it('remembers tracked fields using the object syntax', () => {
+    cy.visit('/remember/object')
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/object')
+
+    cy.get('#name').clear().type('A')
+    cy.get('#remember').check()
+    cy.get('#untracked').clear().type('B')
+
+    cy.get('.link').click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+    cy.go(-1)
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/object')
+
+    cy.get('#name').should('have.value', 'A')
+    cy.get('#remember').should('be.checked')
+    cy.get('#untracked').should('not.have.value', 'B')
+  })
+
+  it('remembers tracked fields using the string syntax', () => {
+    cy.visit('/remember/string')
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/string')
+
+    cy.get('#name').clear().type('A')
+    cy.get('#remember').check()
+    cy.get('#untracked').clear().type('B')
+
+    cy.get('.link').click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+    cy.go(-1)
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/string')
+
+    cy.get('#name').should('have.value', 'A')
+    cy.get('#remember').should('not.be.checked')
+    cy.get('#untracked').should('not.have.value', 'B')
+  })
+
+  it('restores remembered data when pressing the back button', () => {
+    cy.visit('/remember/multiple-components')
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/multiple-components')
+
+    cy.get('#name').clear().type('D')
+    cy.get('#remember').check()
+    cy.get('#untracked').clear().type('C')
+    cy.get('.a-name').clear().type('A1')
+    cy.get('.a-untracked').clear().type('A2')
+    cy.get('.b-name').clear().type('B1')
+    cy.get('.b-remember').check()
+    cy.get('.b-untracked').clear().type('B2')
+
+    cy.get('.link').click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+    cy.go(-1)
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/multiple-components')
+
+    cy.get('#name').should('have.value', 'D')
+    cy.get('#remember').should('be.checked')
+    cy.get('#untracked').should('not.have.value', 'C')
+    // Component "A" uses a string-style key (key: 'Users/Create')
+    cy.get('.a-name').should('have.value', 'A1')
+    cy.get('.a-remember').should('not.be.checked')
+    cy.get('.a-untracked').should('not.have.value', 'C')
+    // Component "B" uses a callback-style key (key: () => `Users/Edit:${this.user.id}`)
+    cy.get('.b-name').should('have.value', 'B1')
+    cy.get('.b-remember').should('be.checked')
+    cy.get('.b-untracked').should('not.have.value', 'C')
+  })
+
+  it.skip('restores remembered data when pressing the back button from another website', { retries: 10 }, () => {
+    cy.visit('/remember/multiple-components')
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/multiple-components')
+
+    cy.get('#name').clear().type('D')
+    cy.get('#remember').check()
+    cy.get('#untracked').clear().type('C')
+    cy.get('.a-name').clear().type('A1')
+    cy.get('.a-untracked').clear().type('A2')
+    cy.get('.b-name').clear().type('B1')
+    cy.get('.b-remember').check()
+    cy.get('.b-untracked').clear().type('B2')
+
+    cy.get('.off-site').click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/non-inertia')
+
+    cy.go(-1)
+    cy.url().should('eq', Cypress.config().baseUrl + '/remember/multiple-components')
+
+    cy.get('#name').should('have.value', 'D')
+    cy.get('#remember').should('be.checked')
+    cy.get('#untracked').should('not.have.value', 'C') // Somehow this fails often on my Cypress install, so we'll just re-try the test 10 times.
+    // Component "A" uses a string-style key (key: 'Users/Create')
+    cy.get('.a-name').should('have.value', 'A1')
+    cy.get('.a-remember').should('not.be.checked')
+    cy.get('.a-untracked').should('not.have.value', 'C')
+    // Component "B" uses a callback-style key (key: () => `Users/Edit:${this.user.id}`)
+    cy.get('.b-name').should('have.value', 'B1')
+    cy.get('.b-remember').should('be.checked')
+    cy.get('.b-untracked').should('not.have.value', 'C')
+  })
+
+  describe('form helper', () => {
+    it('does not remember form data as of default', () => {
+      cy.visit('/remember/form-helper/default')
+      cy.url().should('eq', Cypress.config().baseUrl + '/remember/form-helper/default')
+
+      cy.get('#name').clear().type('A')
+      cy.get('#handle').clear().type('B')
+      cy.get('#remember').check()
+      cy.get('#untracked').clear().type('C')
+
+      cy.get('.link').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/remember/form-helper/default')
+
+      cy.get('#name').should('not.have.value', 'A')
+      cy.get('#handle').should('not.have.value', 'B')
+      cy.get('#remember').should('not.be.checked')
+      cy.get('#untracked').should('not.have.value', 'C')
+    })
+
+    it('does not remember form errors as of default', () => {
+      cy.visit('/remember/form-helper/default')
+      cy.url().should('eq', Cypress.config().baseUrl + '/remember/form-helper/default')
+
+      cy.get('#name').clear().type('A')
+      cy.get('#handle').clear().type('B')
+      cy.get('#remember').check()
+      cy.get('#untracked').type('C')
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('not.exist')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('.submit').click()
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('.link').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/remember/form-helper/default')
+
+      cy.get('#name').should('not.have.value', 'A')
+      cy.get('#handle').should('not.have.value', 'B')
+      cy.get('#remember').should('not.be.checked')
+      cy.get('#untracked').should('not.have.value', 'C')
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('not.exist')
+      cy.get('.remember_error').should('not.exist')
+    })
+
+    it('remembers form data when tracked', () => {
+      cy.visit('/remember/form-helper/remember')
+      cy.url().should('eq', Cypress.config().baseUrl + '/remember/form-helper/remember')
+
+      cy.get('#name').clear().type('A')
+      cy.get('#handle').clear().type('B')
+      cy.get('#remember').check()
+      cy.get('#untracked').type('C')
+
+      cy.get('.link').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/remember/form-helper/remember')
+
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'B')
+      cy.get('#remember').should('be.checked')
+      cy.get('#untracked').should('not.have.value', 'C')
+    })
+
+    it('remembers form errors when tracked', () => {
+      cy.visit('/remember/form-helper/remember')
+      cy.url().should('eq', Cypress.config().baseUrl + '/remember/form-helper/remember')
+
+      cy.get('#name').clear().type('A')
+      cy.get('#handle').clear().type('B')
+      cy.get('#remember').check()
+      cy.get('#untracked').type('C')
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('not.exist')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('.submit').click()
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('.link').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/remember/form-helper/remember')
+
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'B')
+      cy.get('#remember').should('be.checked')
+      cy.get('#untracked').should('not.have.value', 'C')
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+    })
+
+    it('remembers the last state of a form when tracked', () => {
+      cy.visit('/remember/form-helper/remember')
+      cy.url().should('eq', Cypress.config().baseUrl + '/remember/form-helper/remember')
+
+      cy.get('#name').clear().type('A')
+      cy.get('#handle').clear().type('B')
+      cy.get('#remember').check()
+      cy.get('#untracked').type('C')
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('not.exist')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('.submit').click()
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'B')
+      cy.get('#remember').should('be.checked')
+      cy.get('#untracked').should('have.value', 'C') // Only due to visit POST/PUT/PATCH/DELETE method's default preserveState option.
+      cy.get('.name_error').should('have.text', 'Some name error')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('.reset-one').click()
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'example')
+      cy.get('#remember').should('be.checked')
+      cy.get('#untracked').should('have.value', 'C') // Unchanged from above
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+
+      cy.get('.link').click()
+      cy.url().should('eq', Cypress.config().baseUrl + '/dump/get')
+
+      cy.go(-1)
+      cy.url().should('eq', Cypress.config().baseUrl + '/remember/form-helper/remember')
+
+      cy.get('#name').should('have.value', 'A')
+      cy.get('#handle').should('have.value', 'example')
+      cy.get('#remember').should('be.checked')
+      cy.get('#untracked').should('not.have.value', 'C') // Untracked, so now reset (page state was lost)
+      cy.get('.name_error').should('not.exist')
+      cy.get('.handle_error').should('have.text', 'The Handle was invalid')
+      cy.get('.remember_error').should('not.exist')
+    })
+  })
+})

--- a/packages/vue3/tests/cypress/support/commands.ts
+++ b/packages/vue3/tests/cypress/support/commands.ts
@@ -1,0 +1,42 @@
+/// <reference types="cypress" />
+// ***********************************************
+// This example commands.ts shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+//
+// declare global {
+//   namespace Cypress {
+//     interface Chainable {
+//       login(email: string, password: string): Chainable<void>
+//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
+//     }
+//   }
+// }
+
+export const tap = (value: any, callback: (value: any) => void) => {
+    callback(value)
+    return value
+}

--- a/packages/vue3/tests/cypress/support/component.ts
+++ b/packages/vue3/tests/cypress/support/component.ts
@@ -1,0 +1,39 @@
+// ***********************************************************
+// This example support/component.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+
+import { mount } from 'cypress/vue'
+
+// Augment the Cypress namespace to include type definitions for
+// your custom command.
+// Alternatively, can be defined in cypress/support/component.d.ts
+// with a <reference path="./component" /> at the top of your spec.
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
+
+Cypress.Commands.add('mount', mount)
+
+// Example use:
+// cy.mount(MyComponent)

--- a/packages/vue3/tests/cypress/support/e2e.ts
+++ b/packages/vue3/tests/cypress/support/e2e.ts
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/packages/vue3/tests/nodemon.json
+++ b/packages/vue3/tests/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["server.js", "app/"],
+  "ext": "js, vue",
+  "ignore": ["app/dist/**"]
+}

--- a/packages/vue3/tests/package.json
+++ b/packages/vue3/tests/package.json
@@ -1,0 +1,31 @@
+{
+  "private": true,
+  "scripts": {
+    "ci": "start-server-and-test server:run http://localhost:13715 cypress:run",
+    "cypress:run": "cypress-repeat run -n 5 --until-passes",
+    "gui": "start-server-and-test server:run http://localhost:13715 cypress:open",
+    "cypress:open": "CYPRESS_FAIL_FAST_PLUGIN=false cypress open",
+    "server:run": "vite build app && node app/server.js",
+    "test": "npm run ci",
+    "test:gui": "npm run gui",
+    "dev": "npx nodemon --exec 'npm run server:run'"
+  },
+  "dependencies": {
+    "@inertiajs/core": "file:../../core",
+    "@inertiajs/vue3": "file:..",
+    "vue": "^3.4.27"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.4",
+    "body-parser": "^1.20.2",
+    "cypress": "^13.9.0",
+    "cypress-repeat": "^2.3.4",
+    "eslint": "^9.2.0",
+    "eslint-plugin-cypress": "^3.2.0",
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
+    "nodemon": "^3.1.0",
+    "start-server-and-test": "^2.0.3",
+    "vite": "^5.2.0"
+  }
+}


### PR DESCRIPTION
Vue 2 being EOL, tests should be upgraded to Vue 3. 

- Every packages used for the tests are up to date
- Made no unnecessary edits to the tests
- Tests are pretty close to identical to Vue 2 version
- Updated github workflow

Goal: Give the possibility to drop Vue 2 adapter painlessly. Vue 2 adapter is outdated and preventing update to the latest NodeJS LTS in the workflow.

**Visual differences between tests from Vue2 and Vue3**

![Capture d’écran, le 2024-05-11 à 20 59 09](https://github.com/inertiajs/inertia/assets/490234/a8027ff0-5c7e-4a5f-b54d-285e7d7b476f)
![Capture d’écran, le 2024-05-11 à 20 59 23](https://github.com/inertiajs/inertia/assets/490234/683856e1-8120-4e2e-b45c-3836aebe188c)
![Capture d’écran, le 2024-05-11 à 20 59 38](https://github.com/inertiajs/inertia/assets/490234/c2b1c4bb-6d55-46d3-8451-8eeac939fe43)
![Capture d’écran, le 2024-05-11 à 20 59 58](https://github.com/inertiajs/inertia/assets/490234/db7a5454-451a-4618-ae16-5106d0d4892a)
![Capture d’écran, le 2024-05-11 à 21 00 13](https://github.com/inertiajs/inertia/assets/490234/67c92c67-23b2-4e76-a8d0-f74de8d48c4e)
![Capture d’écran, le 2024-05-11 à 21 00 55](https://github.com/inertiajs/inertia/assets/490234/35c1ce53-df81-4f26-bd86-0f2ce19506af)