### PR TITLE
[1.x] Deep merge properties

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,4 +1,5 @@
 import { default as Axios, AxiosResponse } from 'axios'
+import deepmerge from 'deepmerge'
 import debounce from './debounce'
 import {
   fireBeforeEvent,
@@ -387,7 +388,9 @@ export class Router {
 
         const pageResponse: Page = response.data
         if (isPartial && pageResponse.component === this.page.component) {
-          pageResponse.props = { ...this.page.props, ...pageResponse.props }
+          pageResponse.props = deepmerge(this.page.props, pageResponse.props, {
+            arrayMerge: (_target: any[], source: any[]) => source,
+          })
         }
         preserveScroll = this.resolvePreserveOption(preserveScroll, pageResponse) as boolean
         preserveState = this.resolvePreserveOption(preserveState, pageResponse)


### PR DESCRIPTION
Deep merge props on partial visits instead of simple concatenation, to preserve deeply nested props that are not present in the partial response. Array values will be replaced with new values.

Introduces required changes for https://github.com/inertiajs/inertia-laravel/pull/620

Initial response:
```json
{
  "user": {
    "id": 1,
    "name": "New user",
    "email": "boris@example.com"
  }
}
```

Partial request:
```js
router.put(
  '/profile',
  {
    name: 'Boris Lepikhin'
  },
  {
    only: ['user.name'],
  }
)
```

Page props (`auth.user.id` preserved):
```json
{
  "user": {
    "id": 1,
    "name": "New user",
    "email": "boris@example.com"
  }
}
```