### PR TITLE
Fix `preserveScroll` and `preserveState` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For changes prior to v1.0.0, see the [legacy releases](https://legacy.inertiajs.
 
 ## [Unreleased](https://github.com/inertiajs/inertia/compare/v1.1.0...HEAD)
 
+- Fix `preserveScroll` and `preserveState` types ([#1882](https://github.com/inertiajs/inertia/pull/1882))
 - Add Svelte TypeScript support ([#1866](https://github.com/inertiajs/inertia/pull/1866))
 
 ## [v1.1.0](https://github.com/inertiajs/inertia/compare/v1.0.16...v1.1.0)

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -236,7 +236,7 @@ export class Router {
     }
   }
 
-  protected resolvePreserveOption(value: PreserveStateOption, page: Page): boolean | string {
+  protected resolvePreserveOption(value: PreserveStateOption, page: Page): boolean {
     if (typeof value === 'function') {
       return value(page)
     } else if (value === 'errors') {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -55,7 +55,7 @@ export type PageHandler = ({
   preserveState: PreserveStateOption
 }) => Promise<unknown>
 
-export type PreserveStateOption = boolean | string | ((page: Page) => boolean)
+export type PreserveStateOption = boolean | 'errors' | ((page: Page) => boolean)
 
 export type Progress = AxiosProgressEvent
 


### PR DESCRIPTION
Right now the `PreserveStateOption` type (used for the `preserveScroll` and `preserveState` options) accepts a generic string — however the only string value that's supported is `'errors'`, so I've tightened up this type to reflect that.

I've also updated the return type for `resolvePreserveOption`, which should only ever return a boolean.