### PR TITLE
Revert "deep merge properties (#1877)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For changes prior to v1.0.0, see the [legacy releases](https://legacy.inertiajs.
 ## [Unreleased](https://github.com/inertiajs/inertia/compare/v1.1.0...HEAD)
 
 - Fix `preserveScroll` and `preserveState` types ([#1882](https://github.com/inertiajs/inertia/pull/1882))
-- Add Svelte TypeScript support ([#1866](https://github.com/inertiajs/inertia/pull/1866))
+- Revert "merge props from partial reloads" ([#1895](https://github.com/inertiajs/inertia/pull/1895))
 
 ## [v1.1.0](https://github.com/inertiajs/inertia/compare/v1.0.16...v1.1.0)
 

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,5 +1,4 @@
 import { default as Axios, AxiosResponse } from 'axios'
-import deepmerge from 'deepmerge'
 import debounce from './debounce'
 import {
   fireBeforeEvent,
@@ -388,9 +387,7 @@ export class Router {
 
         const pageResponse: Page = response.data
         if (isPartial && pageResponse.component === this.page.component) {
-          pageResponse.props = deepmerge(this.page.props, pageResponse.props, {
-            arrayMerge: (_target: any[], source: any[]) => source,
-          })
+          pageResponse.props = { ...this.page.props, ...pageResponse.props }
         }
         preserveScroll = this.resolvePreserveOption(preserveScroll, pageResponse) as boolean
         preserveState = this.resolvePreserveOption(preserveState, pageResponse)


### PR DESCRIPTION
Resolves #1885
Resolves #1883

This PR reverts the changes in #1877, which added deep merging of properties on partial reloads. Unfortunately this has some issues, specifically in situations where props that are objects have keys removed during a partial reload.