### PR TITLE
Introduce `formDataArrayFormat` option

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -286,12 +286,13 @@ export class Router {
       onSuccess = () => {},
       onError = () => {},
       queryStringArrayFormat = 'brackets',
+      formDataArrayFormat = 'indices',
     }: VisitOptions = {},
   ): void {
     let url = typeof href === 'string' ? hrefToUrl(href) : href
 
     if ((hasFiles(data) || forceFormData) && !(data instanceof FormData)) {
-      data = objectToFormData(data)
+      data = objectToFormData(data, new FormData(), null, formDataArrayFormat)
     }
 
     if (!(data instanceof FormData)) {
@@ -313,6 +314,7 @@ export class Router {
       errorBag,
       forceFormData,
       queryStringArrayFormat,
+      formDataArrayFormat,
       cancelled: false,
       completed: false,
       interrupted: false,
@@ -340,6 +342,7 @@ export class Router {
       onSuccess,
       onError,
       queryStringArrayFormat,
+      formDataArrayFormat,
       cancelToken: new AbortController(),
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -63,6 +63,8 @@ export type LocationVisit = {
   preserveScroll: boolean
 }
 
+export type SerializationArrayFormat = 'indices' | 'brackets'
+
 export type Visit = {
   method: Method
   data: RequestPayload
@@ -74,7 +76,8 @@ export type Visit = {
   headers: Record<string, string>
   errorBag: string | null
   forceFormData: boolean
-  queryStringArrayFormat: 'indices' | 'brackets'
+  queryStringArrayFormat: SerializationArrayFormat
+  formDataArrayFormat: SerializationArrayFormat
 }
 
 export type GlobalEventsMap = {

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -1,6 +1,6 @@
 import deepmerge from 'deepmerge'
 import * as qs from 'qs'
-import { FormDataConvertible, Method } from './types'
+import { FormDataConvertible, Method, SerializationArrayFormat } from './types'
 
 export function hrefToUrl(href: string | URL): URL {
   return new URL(href.toString(), window.location.toString())
@@ -10,7 +10,7 @@ export function mergeDataIntoQueryString(
   method: Method,
   href: URL | string,
   data: Record<string, FormDataConvertible>,
-  qsArrayFormat: 'indices' | 'brackets' = 'brackets',
+  qsArrayFormat: SerializationArrayFormat = 'brackets',
 ): [string, Record<string, FormDataConvertible>] {
   const hasHost = /^https?:\/\//.test(href.toString())
   const hasAbsolutePath = hasHost || href.toString().startsWith('/')

--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -5,6 +5,7 @@ import {
   PreserveStateOption,
   Progress,
   router,
+  SerializationArrayFormat,
   shouldIntercept,
 } from '@inertiajs/core'
 import { createElement, forwardRef, useCallback } from 'react'
@@ -31,7 +32,8 @@ interface BaseInertiaLinkProps {
   onCancel?: () => void
   onSuccess?: () => void
   onError?: () => void
-  queryStringArrayFormat?: 'indices' | 'brackets'
+  queryStringArrayFormat?: SerializationArrayFormat
+  formDataArrayFormat?: SerializationArrayFormat
 }
 
 export type InertiaLinkProps = BaseInertiaLinkProps &
@@ -53,6 +55,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
       except = [],
       headers = {},
       queryStringArrayFormat = 'brackets',
+      formDataArrayFormat = 'indices',
       onClick = noop,
       onCancelToken = noop,
       onBefore = noop,
@@ -82,6 +85,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
             only,
             except,
             headers,
+            formDataArrayFormat,
             onCancelToken,
             onBefore,
             onStart,

--- a/packages/svelte/src/components/Link.svelte
+++ b/packages/svelte/src/components/Link.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { FormDataConvertible, Method, PreserveStateOption } from '@inertiajs/core'
+  import type { FormDataConvertible, Method, PreserveStateOption, SerializationArrayFormat } from '@inertiajs/core'
   import { inertia } from '../index'
 
   export let href: string
@@ -12,7 +12,8 @@
   export let only: string[] = []
   export let except: string[] = []
   export let headers: Record<string, string> = {}
-  export let queryStringArrayFormat: 'brackets' | 'indices' = 'brackets'
+  export let queryStringArrayFormat: SerializationArrayFormat = 'brackets'
+  export let formDataArrayFormat: SerializationArrayFormat = 'indices'
 
   $: asProp = method !== 'get' ? 'button' : as.toLowerCase()
   $: elProps =
@@ -36,6 +37,7 @@
     except,
     headers,
     queryStringArrayFormat,
+    formDataArrayFormat,
   }}
   {...$$restProps}
   {...elProps}

--- a/packages/vue2/src/link.ts
+++ b/packages/vue2/src/link.ts
@@ -5,6 +5,7 @@ import {
   PreserveStateOption,
   Progress,
   router,
+  SerializationArrayFormat,
   shouldIntercept,
 } from '@inertiajs/core'
 import { FunctionalComponentOptions, PropType } from 'vue'
@@ -28,7 +29,8 @@ export interface InertiaLinkProps {
   onFinish?: () => void
   onCancel?: () => void
   onSuccess?: () => void
-  queryStringArrayFormat?: 'brackets' | 'indices'
+  queryStringArrayFormat?: SerializationArrayFormat
+  formDataArrayFormat?: SerializationArrayFormat
 }
 
 type InertiaLink = FunctionalComponentOptions<InertiaLinkProps>
@@ -76,8 +78,12 @@ const Link: InertiaLink = {
       default: () => ({}),
     },
     queryStringArrayFormat: {
-      type: String as PropType<'brackets' | 'indices'>,
+      type: String as PropType<SerializationArrayFormat>,
       default: 'brackets',
+    },
+    formDataArrayFormat: {
+      type: String as PropType<SerializationArrayFormat>,
+      default: 'indices',
     },
   },
   render(h, { props, data, children }) {
@@ -134,6 +140,7 @@ const Link: InertiaLink = {
                 only: props.only,
                 except: props.except,
                 headers: props.headers,
+                formDataArrayFormat: props.formDataArrayFormat,
                 // @ts-expect-error
                 onCancelToken: data.on.cancelToken,
                 // @ts-expect-error

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -1,4 +1,12 @@
-import { mergeDataIntoQueryString, Method, PageProps, Progress, router, shouldIntercept } from '@inertiajs/core'
+import {
+  mergeDataIntoQueryString,
+  Method,
+  PageProps,
+  Progress,
+  router,
+  SerializationArrayFormat,
+  shouldIntercept,
+} from '@inertiajs/core'
 import { defineComponent, DefineComponent, h, PropType } from 'vue'
 
 export interface InertiaLinkProps {
@@ -20,7 +28,8 @@ export interface InertiaLinkProps {
   onFinish?: () => void
   onCancel?: () => void
   onSuccess?: () => void
-  queryStringArrayFormat?: 'brackets' | 'indices'
+  queryStringArrayFormat?: SerializationArrayFormat
+  formDataArrayFormat?: SerializationArrayFormat
 }
 
 type InertiaLink = DefineComponent<InertiaLinkProps>
@@ -69,8 +78,12 @@ const Link: InertiaLink = defineComponent({
       default: () => ({}),
     },
     queryStringArrayFormat: {
-      type: String as PropType<'brackets' | 'indices'>,
+      type: String as PropType<SerializationArrayFormat>,
       default: 'brackets',
+    },
+    formDataArrayFormat: {
+      type: String as PropType<SerializationArrayFormat>,
+      default: 'indices',
     },
   },
   setup(props, { slots, attrs }) {
@@ -103,6 +116,7 @@ const Link: InertiaLink = defineComponent({
                 only: props.only,
                 except: props.except,
                 headers: props.headers,
+                formDataArrayFormat: props.formDataArrayFormat,
                 // @ts-expect-error
                 onCancelToken: attrs.onCancelToken || (() => ({})),
                 // @ts-expect-error


### PR DESCRIPTION
This PR adds a new `formDataArrayFormat` option to `Link` and `router.visit` that duplicates the logic of `queryStringArrayFormat`, but for formData arrays serialization.


### Rationale

Currently, multipart form data arrays are always serialized using indices:

```
------WebKitFormBoundarynVnO6UtO8ts1Qa5q
Content-Disposition: form-data; name="model[files][0]"; filename="aliens.png"
Content-Type: image/png


------WebKitFormBoundarynVnO6UtO8ts1Qa5q
Content-Disposition: form-data; name="model[files][1]"; filename="ufo.jpg"
Content-Type: image/jpeg
```

Rails (or more precisely [Rack](https://github.com/rack/rack/blob/main/lib/rack/query_parser.rb#L116-L122)) parses this as hashes with keys `'0'` and `'1'`. To support scenarios like a file input with the `multiple` attribute, we need to allow the tweaking of this behavior.

This PR introduces the `formDataArrayFormat` option to `router.visit`. With this option set to `'brackets'`, we serialize the keys in the format required by Rack/Rails:

```js
  form.post(`/models`, {
    formDataArrayFormat: 'brackets',
  })
```

```
------WebKitFormBoundaryxrZa60F5B7gxV5aG
Content-Disposition: form-data; name="model[files][]"; filename="aliens.png"
Content-Type: image/png


------WebKitFormBoundaryxrZa60F5B7gxV5aG
Content-Disposition: form-data; name="model[files][]"; filename="ufo.jpg"
Content-Type: image/jpeg
```

### Notes

I have set `formDataArrayFormat` to `'indices'` by default to preserve the current behavior. We might want to synchronize `formDataArrayFormat` and `queryStringArrayFormat` values at some point (or even introduce more general option), but this could be a breaking change.