### PR TITLE
[1.x] Update .gitattributes to exclude playgrounds/ from linguist inference

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # exclude playgrounds/ since otherwise the project gets classified as mainly php based.
 # https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#summary
-playgrounds/ linguist-vendored
+playgrounds/** linguist-vendored
 
 * text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
+# exclude playgrounds/ since otherwise the project gets classified as mainly php based.
+# https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#summary
+playgrounds/ linguist-vendored
+
 * text=auto


### PR DESCRIPTION
I realized the project is being classified as php based, but I think it would be more acurate to say it is based on javascript?

This is useful when people search for projects by language, if I'm looking for a javascript project on github, it would right now be excluded from search results, as it is being tagged as mainly php based.