### PR TITLE
Skip intercepting non-left button clicks on links

### DIFF
--- a/packages/core/src/shouldIntercept.ts
+++ b/packages/core/src/shouldIntercept.ts
@@ -8,9 +8,6 @@ export default function shouldIntercept(event: MouseEvent | KeyboardEvent): bool
     (isLink && event.ctrlKey) ||
     (isLink && event.metaKey) ||
     (isLink && event.shiftKey) ||
-    // The auxiliary button (middle button) was pressed. All major browsers
-    // except Safari trigger the `auxclick` instead of `click`, so this is to
-    // ensure we do not intercept middle clicks in Safari.
-    (isLink && 'button' in event && event.button === 1)
+    (isLink && 'button' in event && event.button !== 0)
   )
 }

--- a/packages/core/src/shouldIntercept.ts
+++ b/packages/core/src/shouldIntercept.ts
@@ -1,4 +1,4 @@
-export default function shouldIntercept(event: KeyboardEvent): boolean {
+export default function shouldIntercept(event: MouseEvent | KeyboardEvent): boolean {
   const isLink = (event.currentTarget as HTMLElement).tagName.toLowerCase() === 'a'
   return !(
     (event.target && (event?.target as HTMLElement).isContentEditable) ||
@@ -7,6 +7,10 @@ export default function shouldIntercept(event: KeyboardEvent): boolean {
     (isLink && event.altKey) ||
     (isLink && event.ctrlKey) ||
     (isLink && event.metaKey) ||
-    (isLink && event.shiftKey)
+    (isLink && event.shiftKey) ||
+    // The auxiliary button (middle button) was pressed. All major browsers
+    // except Safari trigger the `auxclick` instead of `click`, so this is to
+    // ensure we do not intercept middle clicks in Safari.
+    (isLink && 'button' in event && event.button === 1)
   )
 }


### PR DESCRIPTION
Fixes #1772 #1329 #1679

All major browsers except Safari trigger the `auxclick` instead of `click` when the middle button is clicked on a mouse. WebKit has a [long-standing bug](https://bugs.webkit.org/show_bug.cgi?id=22382) that does not adhere to this behavior, so Safari dispatches a plain old `click` event instead. But alas, we can key off of the [`button` property on `MouseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#value) to detect if this is an auxiliary click, and skip intercepting in that case.

I had to tweak the TypeScript types here to handle receiving a `MouseEvent` and discriminate accordingly.