### PR TITLE
Fix types and remove use of deprecated browser event prop

### DIFF
--- a/packages/core/src/shouldIntercept.ts
+++ b/packages/core/src/shouldIntercept.ts
@@ -3,7 +3,6 @@ export default function shouldIntercept(event: MouseEvent | KeyboardEvent): bool
   return !(
     (event.target && (event?.target as HTMLElement).isContentEditable) ||
     event.defaultPrevented ||
-    (isLink && event.which > 1) ||
     (isLink && event.altKey) ||
     (isLink && event.ctrlKey) ||
     (isLink && event.metaKey) ||

--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -17,7 +17,7 @@ interface BaseInertiaLinkProps {
   href: string
   method?: Method
   headers?: Record<string, string>
-  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
+  onClick?: (event: React.MouseEvent<Element>) => void
   preserveScroll?: PreserveStateOption
   preserveState?: PreserveStateOption
   replace?: boolean
@@ -67,10 +67,10 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
     ref,
   ) => {
     const visit = useCallback(
-      (event) => {
+      (event: React.MouseEvent) => {
         onClick(event)
 
-        if (shouldIntercept(event)) {
+        if (shouldIntercept(event.nativeEvent)) {
           event.preventDefault()
 
           router.visit(href, {


### PR DESCRIPTION
Thanks to some crafty sleuthing by @shengslogar (https://github.com/inertiajs/inertia/pull/1908#issuecomment-2190390026), there are a few things to clean up after #1908:

- The event we were passing to `shouldIntercept` from the React adapter was the React synthetic event, which does not have all the properties of the underlying native event. It seems wise to keep the intercept helper function framework-agnostic, so this change now passes the `event.nativeEvent` to `shouldIntercept`.
- The `event.which` property is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/which). The purpose it previously served for evaluating `MouseEvent` eligibility is now covered by the newly-introduced `event.button` check.
- I realized TypeScript didn't have my back here to catch the type mismatch mismatch, so I added a type signature to the `visit` function and expanded the `onClick` prop signature (since this is a polymorphic element, this may not always be an `HTMLAnchorElement`).