### PR TITLE
Prepend title instead of appending to meta items

### DIFF
--- a/packages/react/src/Head.ts
+++ b/packages/react/src/Head.ts
@@ -90,7 +90,7 @@ const Head: InertiaHead = function ({ children, title }) {
       .filter((node) => node)
       .map((node) => renderNode(node))
     if (title && !computed.find((tag) => tag.startsWith('<title'))) {
-      computed.push(`<title inertia>${title}</title>`)
+      computed.unshift(`<title inertia>${title}</title>`)
     }
     return computed
   }

--- a/packages/vue2/src/head.ts
+++ b/packages/vue2/src/head.ts
@@ -93,7 +93,7 @@ const Head: InertiaHead = {
     renderNodes(nodes) {
       const computed = nodes.map((node) => this.renderNode(node)).filter((node) => node)
       if (this.title && !computed.find((tag) => tag.startsWith('<title'))) {
-        computed.push(`<title inertia>${this.title}</title>`)
+        computed.unshift(`<title inertia>${this.title}</title>`)
       }
       return computed
     },

--- a/packages/vue3/src/head.ts
+++ b/packages/vue3/src/head.ts
@@ -95,7 +95,7 @@ const Head: InertiaHead = defineComponent({
     },
     addTitleElement(elements) {
       if (this.title && !elements.find((tag) => tag.startsWith('<title'))) {
-        elements.push(`<title inertia>${this.title}</title>`)
+        elements.unshift(`<title inertia>${this.title}</title>`)
       }
       return elements
     },


### PR DESCRIPTION
Currently when using SSR and the Inertia head component, the title is appended to the meta items.

Taking an example from the docs:
```html
<Head>
  <title>Your page title</title>
  <meta name="description" content="Your page description">
</Head>
```

This would render in the HTML as;
```html
<meta name="description" content="Your page description">
<title inertia>Your page title</title>
```

Since the title is somewhat of a special element the user doesn't have any control over where it's placed in the HTML. Rendering it as the first element would make more sense to me.
(edit: removed the part about SEO, as that's not of a concern)