### PR TITLE
add hidden '_method' field to data if http method is not 'get' or 'post'

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -70,6 +70,14 @@ export default function useForm<TForm extends FormDataType>(
 
   const submit = useCallback(
     (method, url, options = {}) => {
+      const _data = data
+
+      method = method.toLowerCase()
+      if(method != 'get' && method != 'post'){
+        _data['_method'] = method
+        method = 'post'
+      }
+
       const _options = {
         ...options,
         onCancelToken: (token) => {
@@ -158,9 +166,9 @@ export default function useForm<TForm extends FormDataType>(
       }
 
       if (method === 'delete') {
-        router.delete(url, { ..._options, data: transform(data) })
+        router.delete(url, { ..._options, data: transform(_data) })
       } else {
-        router[method](url, transform(data), _options)
+        router[method](url, transform(_data), _options)
       }
     },
     [data, setErrors],

--- a/packages/svelte/src/lib/useForm.ts
+++ b/packages/svelte/src/lib/useForm.ts
@@ -156,7 +156,16 @@ export default function useForm<TForm extends Record<string, unknown>>(
       return this
     },
     submit(method, url, options = {}) {
-      const data = transform(this.data()) as RequestPayload
+      const _data = this.data()
+
+      method = method.toLowerCase()
+      if(method != 'get' && method != 'post'){
+        _data['_method'] = method
+        method = 'post'
+      }
+
+      const data = transform(_data) as RequestPayload
+
       const _options = {
         ...options,
         onCancelToken: (token: { cancel: () => void }) => {

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -123,7 +123,16 @@ export default function useForm<TForm extends FormDataType>(...args): InertiaFor
       return this
     },
     submit(method, url, options: VisitOptions = {}) {
-      const data = transform(this.data())
+      const _data = this.data()
+
+      method = method.toLowerCase()
+      if(method != 'get' && method != 'post'){
+        _data['_method'] = method
+        method = 'post'
+      }
+
+      const data = transform(_data)
+
       const _options = {
         ...options,
         onCancelToken: (token) => {

--- a/packages/vue2/tests/cypress/integration/form-helper.test.js
+++ b/packages/vue2/tests/cypress/integration/form-helper.test.js
@@ -38,10 +38,11 @@ describe('Form Helper', () => {
       cy.window()
         .then((window) => window._inertia_request_dump)
         .then(({ method, form, query }) => {
-          expect(method).to.eq('put')
+          expect(method).to.eq('post')
           expect(query).to.be.empty
           expect(form).to.have.property('name')
           expect(form.name).to.eq('foo')
+          expect(form._method).to.eq('put')
           expect(form).to.have.property('remember')
           expect(form.remember).to.eq(true)
         })
@@ -55,10 +56,11 @@ describe('Form Helper', () => {
       cy.window()
         .then((window) => window._inertia_request_dump)
         .then(({ method, form, query }) => {
-          expect(method).to.eq('patch')
+          expect(method).to.eq('post')
           expect(query).to.be.empty
           expect(form).to.have.property('name')
           expect(form.name).to.eq('foo')
+          expect(form._method).to.eq('patch')
           expect(form).to.have.property('remember')
           expect(form.remember).to.eq(true)
         })
@@ -72,10 +74,11 @@ describe('Form Helper', () => {
       cy.window()
         .then((window) => window._inertia_request_dump)
         .then(({ method, form, query }) => {
-          expect(method).to.eq('delete')
+          expect(method).to.eq('post')
           expect(query).to.be.empty
           expect(form).to.have.property('name')
           expect(form.name).to.eq('foo')
+          expect(form._method).to.eq('delete')
           expect(form).to.have.property('remember')
           expect(form.remember).to.eq(true)
         })
@@ -119,10 +122,11 @@ describe('Form Helper', () => {
       cy.window()
         .then((window) => window._inertia_request_dump)
         .then(({ method, form, query }) => {
-          expect(method).to.eq('put')
+          expect(method).to.eq('post')
           expect(query).to.be.empty
           expect(form).to.have.property('name')
           expect(form.name).to.eq('baz')
+          expect(form._method).to.eq('put')
           expect(form).to.have.property('remember')
           expect(form.remember).to.eq(true)
         })
@@ -136,10 +140,11 @@ describe('Form Helper', () => {
       cy.window()
         .then((window) => window._inertia_request_dump)
         .then(({ method, form, query }) => {
-          expect(method).to.eq('patch')
+          expect(method).to.eq('post')
           expect(query).to.be.empty
           expect(form).to.have.property('name')
           expect(form.name).to.eq('foo')
+          expect(form._method).to.eq('patch')
           expect(form).to.have.property('remember')
           expect(form.remember).to.eq(true)
         })
@@ -153,10 +158,11 @@ describe('Form Helper', () => {
       cy.window()
         .then((window) => window._inertia_request_dump)
         .then(({ method, form, query }) => {
-          expect(method).to.eq('delete')
+          expect(method).to.eq('post')
           expect(query).to.be.empty
           expect(form).to.have.property('name')
           expect(form.name).to.eq('bar')
+          expect(form._method).to.eq('delete')
           expect(form).to.have.property('remember')
           expect(form.remember).to.eq(true)
         })

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -127,7 +127,16 @@ export default function useForm<TForm extends FormDataType>(
       return this
     },
     submit(method, url, options: VisitOptions = {}) {
-      const data = transform(this.data())
+      const _data = this.data()
+
+      method = method.toLowerCase()
+      if(method != 'get' && method != 'post'){
+        _data['_method'] = method
+        method = 'post'
+      }
+
+      const data = transform(_data)
+      
       const _options = {
         ...options,
         onCancelToken: (token) => {


### PR DESCRIPTION
When submitting a form using methods other than GET and POST, browser redirect errors may occur. For example, if you have a secure DELETE route and you are logged out, the browser will redirect you to the authentication page via DELETE method. Having __method_ in _data_ solves this problem. Also, I leave the option to override this property in the transform method.