### PR TITLE
[1.x] useForm wrongly overwrites default values ​​after successful submission

### DIFF
--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -165,7 +165,6 @@ export default function useForm<TForm extends FormDataType>(...args): InertiaFor
           recentlySuccessfulTimeoutId = setTimeout(() => (this.recentlySuccessful = false), 2000)
 
           const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
-          defaults = cloneDeep(this.data())
           this.isDirty = false
           return onSuccess
         },

--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -89,6 +89,7 @@ export default function useForm<TForm extends FormDataType>(...args): InertiaFor
       const resolvedData = typeof data === 'object' ? cloneDeep(defaults) : cloneDeep(data())
       const clonedData = cloneDeep(resolvedData)
       if (fields.length === 0) {
+        this.wasSuccessful = false
         defaults = clonedData
         Object.assign(this, resolvedData)
       } else {
@@ -235,7 +236,7 @@ export default function useForm<TForm extends FormDataType>(...args): InertiaFor
   watch(
     form,
     (newValue) => {
-      form.isDirty = !isEqual(form.data(), defaults)
+      form.isDirty = !form.wasSuccessful && !isEqual(form.data(), defaults)
       if (rememberKey) {
         router.remember(cloneDeep(newValue.__remember()), rememberKey)
       }

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -93,6 +93,7 @@ export default function useForm<TForm extends FormDataType>(
       const resolvedData = typeof data === 'object' ? cloneDeep(defaults) : cloneDeep(data())
       const clonedData = cloneDeep(resolvedData)
       if (fields.length === 0) {
+        this.wasSuccessful = false
         defaults = clonedData
         Object.assign(this, resolvedData)
       } else {
@@ -239,7 +240,7 @@ export default function useForm<TForm extends FormDataType>(
   watch(
     form,
     (newValue) => {
-      form.isDirty = !isEqual(form.data(), defaults)
+      form.isDirty = !form.wasSuccessful && !isEqual(form.data(), defaults)
       if (rememberKey) {
         router.remember(cloneDeep(newValue.__remember()), rememberKey)
       }

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -169,7 +169,7 @@ export default function useForm<TForm extends FormDataType>(
           recentlySuccessfulTimeoutId = setTimeout(() => (this.recentlySuccessful = false), 2000)
 
           const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
-          defaults = cloneDeep(this.data())
+          
           this.isDirty = false
           return onSuccess
         },

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -169,7 +169,6 @@ export default function useForm<TForm extends FormDataType>(
           recentlySuccessfulTimeoutId = setTimeout(() => (this.recentlySuccessful = false), 2000)
 
           const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
-          
           this.isDirty = false
           return onSuccess
         },


### PR DESCRIPTION
**reset** from **useForm** is not functional after a successful submission. This is due to the form's internal onSuccess hook setting defaults to the current form state (line 172).

**The bug happens in any version above 1.0.14 in vue3**

Look at **line  (172).**
https://github.com/inertiajs/inertia/blob/0fc4b1c8b91639ed58b44fafe8833f2108496de6/packages/vue3/src/useForm.ts#L163-L175

Whem we look at the source code of React and Svelte drivers, we dont see this behaviour. Older versions of the Vue codebase also do not have this line of code.

### Steps to reproduce:

#### 1 - Setup a form
```javascript
import { useForm } from '@inertiajs/vue3'

const form = useForm({ email: '' })
```
#### 2 - Change form data
```javascript
form.email = 'test@example.com'
```

#### 3 - Submit form
```javascript
form.post("/endpoint", {
  onSuccess: () => {
    //after some secconds, make reset
    setTimeout(() => {
      form.reset();
    }, 1000);
  },
});
```

**After this we can see the bug, **form.reset** will not work, as the values ​​previously sent in the form will become the new default values, breaking the functioning of form.reset**

### Workaround
As a workaround, it is currently necessary to do a trick
```javascript
function resetForm() {
    form.defaults({email: ""})
    form.reset()
}
```

### Solution

As a solution, the line that causes this unwanted behavior of resetting default values ​​improperly has been removed.





