### PR TITLE
feat: Add isEmpty computed property to useForm

### DIFF
--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -7,6 +7,7 @@ type FormDataType = object
 
 interface InertiaFormProps<TForm extends FormDataType> {
   isDirty: boolean
+  isEmpty: boolean
   errors: Partial<Record<keyof TForm, string>>
   hasErrors: boolean
   processing: boolean
@@ -235,6 +236,11 @@ export default function useForm<TForm extends FormDataType>(
       Object.assign(this, restored.data)
       this.setError(restored.errors)
     },
+    get isEmpty(): boolean {
+      return Object.values(this.data()).every(value =>
+          value === null || value === '' || value === undefined
+      );
+    }
   })
 
   watch(


### PR DESCRIPTION
This PR introduces a new `isEmpty` computed property to the `useForm` hook in Inertia. 
This addition allows developers to easily check if all fields in a form are empty, 
which can be useful for form validation, conditional rendering, or other logic 
that depends on the form's state.