### PR TITLE
[1.x] Fix 'received an unexpected slot "default"' warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ For changes prior to v1.0.0, see the [legacy releases](https://legacy.inertiajs.
 
 ## [Unreleased](https://github.com/inertiajs/inertia/compare/v1.2.0...HEAD)
 
-- Add Svelte TypeScript support ([#1866](https://github.com/inertiajs/inertia/pull/1866))
+- [Svelte] Add Svelte TypeScript support ([#1866](https://github.com/inertiajs/inertia/pull/1866))
 - Fix form helper `transform` return type in React adapter ([#1896](https://github.com/inertiajs/inertia/pull/1896))
 - Use updater function in `setData` in `useForm` hook in React adapter ([#1859](https://github.com/inertiajs/inertia/pull/1859))
 - Skip intercepting non-left button clicks on links ([#1908](https://github.com/inertiajs/inertia/pull/1908), [#1910](https://github.com/inertiajs/inertia/pull/1910))
+- [Svelte] Fix 'received an unexpected slot "default"' warning ([#1941](https://github.com/inertiajs/inertia/pull/1941))
 
 ## [v1.2.0](https://github.com/inertiajs/inertia/compare/v1.1.0...v1.2.0)
 

--- a/packages/svelte/src/lib/components/Render.svelte
+++ b/packages/svelte/src/lib/components/Render.svelte
@@ -34,10 +34,14 @@
 
 {#if $store.component}
   {#key key}
-    <svelte:component this={component} {...props}>
-      {#each children as child, index (component && component.length === index ? $store.key : null)}
-        <svelte:self {...child} />
-      {/each}
-    </svelte:component>
+    {#if children.length > 0}
+      <svelte:component this={component} {...props}>
+        {#each children as child, index (component && component.length === index ? $store.key : null)}
+          <svelte:self {...child} />
+        {/each}
+      </svelte:component>
+    {:else}
+      <svelte:component this={component} {...props} />
+    {/if}
   {/key}
 {/if}


### PR DESCRIPTION
This PR fixes the `<Render />` component by checking for children components before attempting to pass the default slot to the rendered component.

Closes #1785.

## Before


<img width="1379" alt="Screen Shot 2024-08-12 at 21 17 34" src="https://github.com/user-attachments/assets/be3dd17f-739c-4fef-9c5d-120cb51eedef">

## After

<img width="1379" alt="Screen Shot 2024-08-12 at 21 18 08" src="https://github.com/user-attachments/assets/bcf207d0-d487-4816-b05b-f512515876d3">