### PR TITLE
Update Axios to 1.7.4 to mitigate High Vulnerability CVE-2024-39338

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "axios": "^1.6.0",
+    "axios": "^1.7.4",
     "deepmerge": "^4.0.0",
     "nprogress": "^0.2.0",
     "qs": "^6.9.0"


### PR DESCRIPTION
Upgrade Axios to 1.7.4 to mitigate High CVES [CVE-2024-39338](https://github.com/advisories/GHSA-8hc4-vh64-cxmj)

[Axios Release](https://github.com/axios/axios/releases/tag/v1.7.4)
