### PR TITLE
Fix `setNavigationType` for Safari 10

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -70,7 +70,7 @@ export class Router {
 
   protected setNavigationType(): void {
     this.navigationType =
-      window.performance && window.performance.getEntriesByType('navigation').length > 0
+      window.performance && window.performance.getEntriesByType && window.performance.getEntriesByType('navigation').length > 0
         ? (window.performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming).type
         : 'navigate'
   }


### PR DESCRIPTION
Simple fix for Safari 10. 

<img width="556" alt="Screenshot 2024-09-02 at 2 02 34 PM" src="https://github.com/user-attachments/assets/a625c8e5-aae7-4cc7-99c7-29d045fc4e34">

It happens because `this.navigation` is present, but `this.navigation.getEntriesByType` is missing.