### PR TITLE
[1.x] Fix type augmentation for Vue 3

### DIFF
--- a/packages/vue3/src/types.ts
+++ b/packages/vue3/src/types.ts
@@ -12,7 +12,7 @@ declare module '@inertiajs/core' {
   }
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $inertia: typeof router
     $page: Page


### PR DESCRIPTION
This PR changes Vue 3 type augmentation to be placed in `vue` module instead of `@vue/runtime-core` [as it supposed to be](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties).
Many infrastructure packages like [Vue Router](/vuejs/router/pull/2295), [Vue i18n](/intlify/vue-i18n/pull/1919) and [Nuxt](/nuxt/nuxt/pull/28542) already did so.