### PR TITLE
[1.x] Fix "DataCloneError: <Object> could not be cloned"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For changes prior to v1.0.0, see the [legacy releases](https://legacy.inertiajs.
 
 - [Svelte] Add Svelte 5 support ([#1970](https://github.com/inertiajs/inertia/pull/1970))
 - [Svelte] Add Svelte TypeScript support ([#1866](https://github.com/inertiajs/inertia/pull/1866))
+- Fix `DataCloneError: <Object> could not be cloned` ([#1967](https://github.com/inertiajs/inertia/pull/1967))
 - Fix form helper `transform` return type in React adapter ([#1896](https://github.com/inertiajs/inertia/pull/1896))
 - Use updater function in `setData` in `useForm` hook in React adapter ([#1859](https://github.com/inertiajs/inertia/pull/1859))
 - Skip intercepting non-left button clicks on links ([#1908](https://github.com/inertiajs/inertia/pull/1908), [#1910](https://github.com/inertiajs/inertia/pull/1910))

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -32,6 +32,7 @@ import {
 import { hrefToUrl, mergeDataIntoQueryString, urlWithoutHash } from './url'
 
 const isServer = typeof window === 'undefined'
+const cloneSerializable = <T>(obj: T): T => JSON.parse(JSON.stringify(obj))
 
 export class Router {
   protected page!: Page
@@ -482,12 +483,12 @@ export class Router {
 
   protected pushState(page: Page): void {
     this.page = page
-    window.history.pushState(page, '', page.url)
+    window.history.pushState(cloneSerializable(page), '', page.url)
   }
 
   protected replaceState(page: Page): void {
     this.page = page
-    window.history.replaceState(page, '', page.url)
+    window.history.replaceState(cloneSerializable(page), '', page.url)
   }
 
   protected handlePopstateEvent(event: PopStateEvent): void {

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -242,7 +242,7 @@ export default function useForm<TForm extends FormDataType>(
     (newValue) => {
       form.isDirty = !isEqual(form.data(), defaults)
       if (rememberKey) {
-        router.remember(cloneDeep(newValue.__remember()), rememberKey)
+        router.remember(newValue.__remember(), rememberKey)
       }
     },
     { immediate: true, deep: true },

--- a/packages/vue3/src/useRemember.ts
+++ b/packages/vue3/src/useRemember.ts
@@ -1,5 +1,4 @@
 import { router } from '@inertiajs/core'
-import cloneDeep from 'lodash.clonedeep'
 import { isReactive, reactive, ref, Ref, watch } from 'vue'
 
 export default function useRemember<T extends object>(
@@ -18,7 +17,7 @@ export default function useRemember<T extends object>(
   watch(
     remembered,
     (newValue) => {
-      router.remember(cloneDeep(hasCallbacks ? data.__remember() : newValue), key)
+      router.remember(hasCallbacks ? data.__remember() : newValue, key)
     },
     { immediate: true, deep: true },
   )


### PR DESCRIPTION
This bug has been around for a while in Inertia.js _(see timeline below)_, and after digging into it with @jamesst20's help, we figured out the core issue: Inertia is trying to serialize proxy objects when it saves data to the history state. You might run into this using `useForm` _(fixed in 2021)_, `router.remember`, or even just scrolling, as Inertia saves scroll positions in history.

[`history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState#datacloneerror) uses `structuredClone`, which throws [`DataCloneError`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone#datacloneerror) if it hits anything non-serializable.

To fix it, I’m using `JSON.parse(JSON.stringify())`. This is great for simple data structures, and it automatically strips out stuff like functions that can cause issues. It’s lighter and more efficient for this specific case than using `lodash.cloneDeep()`, which keeps things like functions around (and we don’t need that here).

This issue has mostly affected users of the Vue.js adapter since Vue uses proxy objects for its reactivity system. However, it can impact anyone using front-end libraries that rely on proxies, like Svelte 5, which is rolling out its own reactive system based on runes.

## Reproducible

- [Vue 3](https://play.vuejs.org/#eNqVU01vGjEQ/SsjXxYktBxoL4hELSmH5pBEoVIvK1WuGcCJ116NZ/ko2v/e8S7QKEqoclhp7ffmzZsPH9TXqso3NaqxmkRDtmKIyHV1XXhbVoEYDkCoDdsNQgNLCiVkws8KX3gTfGSokGLwcHXm9Q7gdYljyB5wQQGmgVYYswGYUHumvQBT0n+sy6DpJ51l7SVQNAgrpw3+tLyeEQXq9eFQeJBAH4PD3IVVL0sotDCIZpddZAC21i/CNl/byIH2+VFszpqx19EGkEnIkeeC0SlrviZcikDznpVQ82U3Qviwodv5/V1eaYrH38hk/cou90er/f7/zE6G3cBkVHJgLEWdUU4Ak981sxTxxThrnq8K9bqxhWp5AI8dAK0p2A7hm2Z944LHjpfEhp1amydp03X6Tqf3M5369nayV9KT4YsK1EBxlDYv7Sp/kmbIdradL5QJZWUd0n2VuhELNe5mkjDtXNjetndMNQ5O92aN5vmN+6e4S3eFeiCMSBss1BljLTvLHTyb3+FO/s9gGRa1E/YF8BFlRerksaNNa78Q2y94rdvv7RuTwf+Isx2jj6eiktHEbFp+oeTJ3Vwo/Z/dUf6pjZMVkS7+2sgyCVsaOMo/5yPV/AWf0lrU)
- [Svelte 5](https://svelte-5-preview.vercel.app/#H4sIAAAAAAAAE52RUUvDMBDHv8oRhK5Quve6DZz64oOKe_DB-RDT6xbMcuVyddTS7y5pK4ooAx8Sksuf3_24dKqyDoMqnjrl9QFVoS7qWmVK2jpewhs6QZWpQA2bWFkEw7aW1dZvxaFAjRzIwxLOgmjBWQeRU0ByjyUTrIl3GJIMDDVeuC0gWbN-ty6BPj3f-oipGm_EkgfG2mmDj1b218zEsxS6GAAw5AM5zB3tZkl8hyEASTYJpGPuaH1Jx3xvgxC3-QTcDGZjMIMkyT5zjoyOnfM9YzUg-rj9JUWNnPKiRv6hdrO5u81rzWE6BmHrd7ZqJ-k0Pa29mH_9jF-8NCLkgbxx1rwuu5-j7YcPfBirMFjAcQ5XWvSlI49DKEJH0ATlVVynGnyO6Zce34gqUwcqbWWxVIVwg_1z_wGMJCygjwIAAA==)

## Stack trace

```
UnhandledPromiseRejectionWarning: DataCloneError: Proxy object could not be cloned.
```

```
Uncaught (in promise) DOMException: The object could not be cloned. router.ts:397:4
    replaceState router.ts:398
    saveScrollPositions router.ts:73
    resetScrollPositions router.ts:91
    g router.ts:381
    (Async: promise callback)
    g router.ts:379
    (Async: promise callback)
    setPage router.ts:373
    handleInitialPageVisit router.ts:52
    init router.ts:41
    setup app.js:43
```

![179274326-cc3b66c8-852a-4323-9a2f-92092312afdd](https://github.com/user-attachments/assets/8fc712f2-93c8-44ae-addd-d3f4ea7ebce9)

## Timeline

I built this timeline to help me keep track of occurrences relative to the previous attempts to fix this issue.

| Last activity | Issue / PR |  |
| ---: | ---: | :---: |
| Oct 2020 |  #278 |
| Oct 2020 |  #295 |
| Oct 2020 |  #297 | first attempt to fix |
| Mar 2021 |  #552 |
| Mar 2021 |  #582 |
| Mar 2021 |  #587 | last attempt to fix |
| Apr 2021 | #1021 |
| Jun 2021 |  #578 |
| Jul 2021 |  #776 | rejected PR |
| Aug 2021 |  #730 |
| Aug 2021 |  #854 |
| Dec 2021 |  #940 |
| Jul 2022 |  #309 |
| Sep 2022 | #1227 |
| Oct 2022 | #1246 |
| Nov 2022 | #1340 |
| May 2024 |  #775 | 60 comments |

----

Fixes #278, #295, #297, #309, #552, #578, #582, #587, #730, #775, #776, #854, #940, #1021, #1227, #1246, #1340