### PR TITLE
[1.x] Fix `resetScrollPositions` and `restoreScrollPositions` router methods

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -33,6 +33,11 @@ import { hrefToUrl, mergeDataIntoQueryString, urlWithoutHash } from './url'
 
 const isServer = typeof window === 'undefined'
 const cloneSerializable = <T>(obj: T): T => JSON.parse(JSON.stringify(obj))
+const nextFrame = (callback: () => void) => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(callback)
+  })
+}
 
 export class Router {
   protected page!: Page

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -126,21 +126,21 @@ export class Router {
   }
 
   protected resetScrollPositions(): void {
-    nextFrame(() => window.scrollTo(0, 0))
-    this.scrollRegions().forEach((region) => {
-      if (typeof region.scrollTo === 'function') {
-        region.scrollTo(0, 0)
-      } else {
-        region.scrollTop = 0
-        region.scrollLeft = 0
+    nextFrame(() => {
+      window.scrollTo(0, 0)
+      this.scrollRegions().forEach((region) => {
+        if (typeof region.scrollTo === 'function') {
+          region.scrollTo(0, 0)
+        } else {
+          region.scrollTop = 0
+          region.scrollLeft = 0
+        }
+      })
+      this.saveScrollPositions()
+      if (window.location.hash) {
+        document.getElementById(window.location.hash.slice(1))?.scrollIntoView()
       }
     })
-    this.saveScrollPositions()
-    if (window.location.hash) {
-      // We're using a setTimeout() here as a workaround for a bug in the React adapter where the
-      // rendering isn't completing fast enough, causing the anchor link to not be scrolled to.
-      setTimeout(() => document.getElementById(window.location.hash.slice(1))?.scrollIntoView())
-    }
   }
 
   protected restoreScrollPositions(): void {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -92,7 +92,7 @@ export class Router {
     if (!this.page.url.includes(hash)) {
       this.page.url += hash
     }
-    this.setPage(page, { preserveScroll: true ,preserveState: true }).then(() => fireNavigateEvent(page))
+    this.setPage(page, { preserveScroll: true, preserveState: true }).then(() => fireNavigateEvent(page))
   }
 
   protected setupEventListeners(): void {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -144,7 +144,9 @@ export class Router {
   }
 
   protected restoreScrollPositions(): void {
-    if (this.page.scrollRegions) {
+    nextFrame(() => {
+      if (!this.page.scrollRegions) return
+
       this.scrollRegions().forEach((region: Element, index: number) => {
         const scrollPosition = this.page.scrollRegions[index]
         if (!scrollPosition) {
@@ -156,7 +158,7 @@ export class Router {
           region.scrollLeft = scrollPosition.left
         }
       })
-    }
+    })
   }
 
   protected isBackForwardVisit(): boolean {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -126,7 +126,7 @@ export class Router {
   }
 
   protected resetScrollPositions(): void {
-    window.scrollTo(0, 0)
+    nextFrame(() => window.scrollTo(0, 0))
     this.scrollRegions().forEach((region) => {
       if (typeof region.scrollTo === 'function') {
         region.scrollTo(0, 0)


### PR DESCRIPTION
This PR resolves two scroll-related problems in Inertia:

1. **Scroll Reset on Page Navigation**
    - **Issue:** Using Inertia’s `Link` causes the scroll position to reset briefly before loading new content, leading to a flash of the previous page and jank on heavier or mobile pages.
    - **Details:** [#1802](https://github.com/inertiajs/inertia/issues/1802)
    - **Previous Attempt:** [#1803](https://github.com/inertiajs/inertia/pull/1803) tried to fix this but added complexity. This PR provides a simpler solution.

2. **Scroll Position Restoration for `[scroll-region]` Elements**
    - **Issue:** In the React adapter, `[scroll-region]` elements don't restore their scroll positions when navigating back because `restoreScrollPositions` doesn't detect them before the document body updates.
    - **Details:** [#1816](https://github.com/inertiajs/inertia/issues/1816), [#1802](https://github.com/inertiajs/inertia/issues/1802), [#1211](https://github.com/inertiajs/inertia/issues/1211)
    - **Previous Attempt:** [#1796](https://github.com/inertiajs/inertia/pull/1796) used `setTimeout`, but `nextFrame` is a better approach.

### Solution

Used a **double `requestAnimationFrame` (RAF)** method to ensure callbacks run after the next repaint. This approach is used internally by Vue:

- **Double RAF with Callback:** [Vue Transition Component](https://github.com/vuejs/core/blob/dad673809929c084dcb8e42640eb7daa675d4ea4/packages/runtime-dom/src/components/Transition.ts#L326-L330)
- **Double RAF with Promise:** [Vue E2E Utils](https://github.com/vuejs/core/blob/dad673809929c084dcb8e42640eb7daa675d4ea4/packages/vue/__tests__/e2e/e2eUtils.ts#L157-L165)

This fix is implemented in the core, making it safe for React, Vue, and Svelte adapters without needing adapter-specific changes.

----

Fixes #1211, #1459, #1698, #1796, #1802, #1803, #1816, #1922