### PR TITLE
[1.x] Fix history navigation issue on Chrome iOS

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -492,7 +492,7 @@ export class Router {
 
   protected pushState(page: Page): void {
     this.page = page
-    window.history.pushState(cloneSerializable(page), '', page.url)
+    setTimeout(() => window.history.pushState(cloneSerializable(page), '', page.url))
   }
 
   protected replaceState(page: Page): void {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -492,6 +492,8 @@ export class Router {
 
   protected pushState(page: Page): void {
     this.page = page
+    // Defer history.pushState to the next event loop tick to prevent timing conflicts.
+    // Ensure any previous history.replaceState completes before pushState is executed.
     setTimeout(() => window.history.pushState(cloneSerializable(page), '', page.url))
   }
 


### PR DESCRIPTION
On Chrome iOS, calling `this.storeScrollPositions` (which uses `history.replaceState`) right before `this.setPage` in the router `visit` method caused timing issues with `history.pushState`, leading to navigation problems.

Wrapping `window.history.pushState` with `setTimeout` inside `router.pushState` fixes the issue. Using `setTimeout` defers `history.pushState` to the next event loop tick, preventing conflicts between `history.replaceState` and `history.pushState`. This change doesn’t introduce any side effects since `setTimeout` with a delay of 0 just delays the execution without altering functionality.

Fixes #1954.

## Before

https://github.com/user-attachments/assets/f7ad94e9-46fb-4bec-9897-8d54758cd951

## After

https://github.com/user-attachments/assets/2bb29406-ceb8-41ef-b4bd-8a5bff2f75f0

We could enhance this by detecting Chrome on iOS and only applying `setTimeout` there, but the current fix works universally without issues 🤷‍♂️