### PR TITLE
[1.x] Fix isDirty after form.defaults() call in Vue

### DIFF
--- a/packages/vue2/src/useForm.ts
+++ b/packages/vue2/src/useForm.ts
@@ -79,6 +79,7 @@ export default function useForm<TForm extends FormDataType>(...args): InertiaFor
 
       if (typeof key === 'undefined') {
         defaults = this.data()
+        this.isDirty = false
       } else {
         defaults = Object.assign({}, cloneDeep(defaults), value ? { [key]: value } : key)
       }

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -79,6 +79,7 @@ export default function useForm<TForm extends FormDataType>(
 
       if (typeof fieldOrFields === 'undefined') {
         defaults = this.data()
+        this.isDirty = false
       } else {
         defaults = Object.assign(
           {},


### PR DESCRIPTION
When calling `defaults()` on a form, the `isDirty` state does not reset as expected. This occurs because the watcher only monitors changes to the `form` reactive properties, while the `defaults()` method modifies the default properties, which are not part of the watched `form`. As a result, `isDirty` is never recalculated and remains `true`.

This fix ensures that `isDirty` accurately reflects the form's state after resetting to defaults similarly to how the React adapter does it.

Fixes #1862.