### PR TITLE
inject css in head to prevent content shift when using SSR, fixes #1760

### DIFF
--- a/playgrounds/svelte5/vite.config.js
+++ b/playgrounds/svelte5/vite.config.js
@@ -9,6 +9,10 @@ export default defineConfig({
       ssr: 'resources/js/ssr.js',
       refresh: true,
     }),
-    svelte(),
+    svelte({
+      compilerOptions: {
+        css: 'injected'
+      }
+    }),
   ],
 })

--- a/playgrounds/svelte5/vite.config.js
+++ b/playgrounds/svelte5/vite.config.js
@@ -2,7 +2,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 import laravel from 'laravel-vite-plugin'
 import { defineConfig } from 'vite'
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode }) => ({
   plugins: [
     laravel({
       input: ['resources/css/app.css', 'resources/js/app.js'],
@@ -15,4 +15,4 @@ export default defineConfig(({ mode }) => {
       }
     }),
   ],
-})
+}))

--- a/playgrounds/svelte5/vite.config.js
+++ b/playgrounds/svelte5/vite.config.js
@@ -2,7 +2,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 import laravel from 'laravel-vite-plugin'
 import { defineConfig } from 'vite'
 
-export default defineConfig(({ mode ) => {
+export default defineConfig(({ mode }) => {
   plugins: [
     laravel({
       input: ['resources/css/app.css', 'resources/js/app.js'],

--- a/playgrounds/svelte5/vite.config.js
+++ b/playgrounds/svelte5/vite.config.js
@@ -2,7 +2,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 import laravel from 'laravel-vite-plugin'
 import { defineConfig } from 'vite'
 
-export default defineConfig({
+export default defineConfig(({ mode ) => {
   plugins: [
     laravel({
       input: ['resources/css/app.css', 'resources/js/app.js'],
@@ -11,7 +11,7 @@ export default defineConfig({
     }),
     svelte({
       compilerOptions: {
-        css: 'injected'
+        css: mode === "development" ? "external" : "injected",
       }
     }),
   ],


### PR DESCRIPTION
Svelte 4 removed the CSS output from the component's `render` method. However, the `css: 'inject'` compiler option can be used instead to inject that CSS into the `<head>`, as documented [here](https://svelte-5-preview.vercel.app/docs/breaking-changes#components-are-no-longer-classes-server-api-changes). According to Rich Harris, this solution is only for toy projects. So I guess we'll just stay a toy project forever.