### PR TITLE
[1.x] Fix history navigation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ For changes prior to v1.0.0, see the [legacy releases](https://legacy.inertiajs.
 - Use updater function in `setData` in `useForm` hook in React adapter ([#1859](https://github.com/inertiajs/inertia/pull/1859))
 
 ### Fixed
-- Fix history navigation issue on Chrome iOS ([#1984](https://github.com/inertiajs/inertia/pull/1984))
+- Fix history navigation issue on Chrome iOS ([#1984](https://github.com/inertiajs/inertia/pull/1984), [#1992](https://github.com/inertiajs/inertia/pull/1992))
 - Fix `setNavigationType` for Safari 10 ([#1957](https://github.com/inertiajs/inertia/pull/1957))
 - Export `InertiaFormProps` in all adapters ([#1596](https://github.com/inertiajs/inertia/pull/1596), [#1734](https://github.com/inertiajs/inertia/pull/1734))
 - Fix `isDirty` after `form.defaults()` call in Vue 3 ([#1985](https://github.com/inertiajs/inertia/pull/1985))

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -31,8 +31,8 @@ import {
 } from './types'
 import { hrefToUrl, mergeDataIntoQueryString, urlWithoutHash } from './url'
 
-const isChromeIOS = /CriOS/.test(navigator.userAgent)
 const isServer = typeof window === 'undefined'
+const isChromeIOS = !isServer && /CriOS/.test(window.navigator.userAgent)
 const cloneSerializable = <T>(obj: T): T => JSON.parse(JSON.stringify(obj))
 const nextFrame = (callback: () => void) => {
   requestAnimationFrame(() => {


### PR DESCRIPTION
I noticed an issue introduced by #1984 when using the Vue 2/3 and Svelte adapters. On the playgrounds for these adapters, navigating through **Home** → **Users** → **Article** → **Form** and then trying to go back in history skips the **Article** page. 

### Root cause:

After investigating, I found that `router.replaceState` (which remembers the form state) was being called **before** `router.pushState`, effectively replacing the **Article** history state.

<img width="900" alt="before-fix" src="https://github.com/user-attachments/assets/d51f6a33-bbcb-4751-b182-e33b650f4a08">

### Solution:

I tried several approaches but determined that the safest solution is to scope the fix from #1984 specifically to Chrome on iOS, where the initial issue occurs. This avoids any unintended side effects in other browsers.

<img width="900" alt="after-fix" src="https://github.com/user-attachments/assets/38d765b9-1882-45bd-a2be-b71981a61cfe">

----

I’ve tested the fix across all adapters on **Chrome/Safari/Firefox** on macOS and **Chrome/Safari** on iOS, and everything is functioning as expected.