### PR TITLE
Fix history state navigation security issue

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -544,9 +544,7 @@ export class Router {
   private _replaceState(page: Page): void {
     const currentId = window.history.state?._id ?? this.getStateId();
     window.sessionStorage.setItem(currentId, JSON.stringify(page));
-    if (!window.history.state?._id) {
-      window.history.replaceState({_id: currentId}, '', page.url);
-    }
+    window.history.replaceState({_id: currentId}, '', page.url);
   }
 
   protected replaceState(page: Page): void {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -518,7 +518,7 @@ export class Router {
   }
 
   private getStateId() {
-    const newId = `inertia_${crypto.randomUUID()}`;
+    const newId = `inertia_${Date.now() + Math.floor(Math.random() * 1000)}`;
     window.sessionStorage.setItem(allStateIdsSessionStorageKey, JSON.stringify([...this.getAllStates(), newId]));
     return newId;
   }


### PR DESCRIPTION
Implements changes proposed in the following comment https://github.com/inertiajs/inertia/pull/1784#issuecomment-2134173531 back in May, without the server-side header idea (not against it, though I thought it was out of scope for this, and I didn't want to touch more than I needed to.), and using `window.sessionStorage` instead of `window.localStorage`.

To summarise the comment and what this PR does
 * Moves `page` cached history from being stored in `window.history.state` (which cannot be cleared, presenting a potential security issue if private information is stored in page props.), to `window.sessionStorage`, which lives for the lifetime of the tab (though most browsers ignore security concerns by allowing users to restore sessions..) and can be cleared in JS.
 * Added a public method to the router, `router.clearHistory()`, for clearing history state.

_Related tickets/pull-requests:_

https://github.com/inertiajs/inertia/pull/1784
https://github.com/inertiajs/inertia/issues/247
https://github.com/inertiajs/inertia/issues/102