### PR TITLE
Fix Inertia Head rendering error when tags contain dynamic value

### DIFF
--- a/packages/react/src/Head.ts
+++ b/packages/react/src/Head.ts
@@ -62,6 +62,9 @@ const Head: InertiaHead = function ({ children, title }) {
   }
 
   function renderTag(node) {
+    if (typeof node === "string") {
+      return node
+    }
     let html = renderTagStart(node)
     if (node.props.children) {
       html += renderTagChildren(node)

--- a/packages/vue2/src/head.ts
+++ b/packages/vue2/src/head.ts
@@ -61,6 +61,9 @@ const Head: InertiaHead = {
       return node.children.reduce((html, child) => html + this.renderTag(child), '')
     },
     renderTag(node) {
+      if (typeof node === "string") {
+        return node
+      }
       if (!node.tag) {
         return node.text
       }

--- a/packages/vue3/src/head.ts
+++ b/packages/vue3/src/head.ts
@@ -77,6 +77,9 @@ const Head: InertiaHead = defineComponent({
       return /(text|txt)/i.test(node.type.toString())
     },
     renderTag(node) {
+      if (typeof node === "string") {
+        return node
+      }
       if (this.isTextNode(node)) {
         return node.children
       } else if (this.isFragmentNode(node)) {


### PR DESCRIPTION
When putting dynamic value or javascript in a tag's content inside Inertia's Head component, it compiles to a jsx element containing an any[] children. `renderTag` function from Head will recursively render every children, and in this case, trying to access a string node.props will throw an uncatched exception and will break rendering:

Taking as example the React playground from Inertia repository,

<img src="https://github.com/user-attachments/assets/387a0747-05c6-402a-8e92-9f65ed2c6122" width="400px" alt="dynamic values in Head elements" />

Would break rendering and just return the template html to the client:

<img src="https://github.com/user-attachments/assets/e546edb6-157c-4435-aeef-9a0a771b0f58" width="400px" alt="wont render because tried to access props field from a string node" /><br>
Note that nor the tags inside of Head have been rendered.


Making the following change at Head components (in Vue and React packages) avoid trying to access `node.props` from the node if it is a string and fixes the issue:

```ts
// Head.ts (react package) and head.ts (vue packages)
function renderTag(node) {
    if (typeof node === "string") {
        return node
    }
    // ...
}
```

<img src="https://github.com/user-attachments/assets/92113a92-7f8b-41dc-829b-a7c7077f6716" width="600px" alt="started to work after the fix" />
