### PR TITLE
Fix Svelte version import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ For changes prior to v1.0.0, see the [legacy releases](https://legacy.inertiajs.
 
 ## [Unreleased](https://github.com/inertiajs/inertia/compare/v1.3.0-beta.1...HEAD)
 
-- Nothing yet!
+- Fix Svelte version import ([#2002](https://github.com/inertiajs/inertia/pull/2002))
 
 ## [v1.3.0-beta.1](https://github.com/inertiajs/inertia/compare/v1.2.0...v1.3.0-beta.1)
 

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -1,7 +1,7 @@
 import { router, setupProgress, type InertiaAppResponse, type Page } from '@inertiajs/core'
 import escape from 'html-escape'
 import type { ComponentType } from 'svelte'
-import { VERSION } from 'svelte/compiler'
+import { version as SVELTE_VERSION } from 'svelte/package.json'
 import App from './components/App.svelte'
 import store from './store'
 import type { ComponentResolver, ResolvedComponent } from './types'
@@ -52,7 +52,7 @@ export default async function createInertiaApp({
   })
 
   if (isServer) {
-    const isSvelte5 = VERSION.startsWith('5')
+    const isSvelte5 = SVELTE_VERSION.startsWith('5')
     const { html, head, css } = await (async () => {
       if (isSvelte5) {
         const { render } = await dynamicImport('svelte/server')


### PR DESCRIPTION
[Sam reported](https://x.com/saml_dev/status/1843828546051158381) that the new svelte adapter adds ~500 kb to his app bundle size.

After some investigation I found the culprit, it’s the way we import the `VERSION` constant from the Svelte compiler in the `createInertiaApp.ts`. This PR fixes that.

## Before

<img width="750" alt="Screen Shot 2024-10-09 at 03 49 25" src="https://github.com/user-attachments/assets/ff8d257c-cee0-4cbb-8379-601ac442457f">

## After

<img width="750" alt="Screen Shot 2024-10-09 at 03 50 28" src="https://github.com/user-attachments/assets/ef63e694-dde8-48d9-b191-aefad74c1d63">