### PR TITLE
Fix `use:inertia` action event listeners types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ For changes prior to v1.0.0, see the [legacy releases](https://legacy.inertiajs.
 
 ## [Unreleased](https://github.com/inertiajs/inertia/compare/v1.3.0-beta.1...HEAD)
 
-- Nothing yet!
+- Fix `use:inertia` action event listeners types ([#2003](https://github.com/inertiajs/inertia/pull/2003))
 
 ## [v1.3.0-beta.1](https://github.com/inertiajs/inertia/compare/v1.2.0...v1.3.0-beta.1)
 

--- a/packages/svelte/src/link.ts
+++ b/packages/svelte/src/link.ts
@@ -21,9 +21,12 @@ type ActionParameters = Omit<VisitOptions, 'data'> & {
 type SelectedEventKeys = 'start' | 'progress' | 'finish' | 'before' | 'cancel' | 'success' | 'error'
 type SelectedGlobalEventsMap = Pick<GlobalEventsMap, SelectedEventKeys>
 type ActionAttributes = {
-  [K in keyof SelectedGlobalEventsMap as `on:${K}`]?: CustomEvent<SelectedGlobalEventsMap[K]['details']>
+  [K in keyof SelectedGlobalEventsMap as `on:${K}` | `on${K}`]?: (
+    event: CustomEvent<SelectedGlobalEventsMap[K]['details']>,
+  ) => void
 } & {
-  'on:cancel-token'?: CustomEvent<CancelTokenSource>
+  'on:cancel-token'?: (event: CustomEvent<CancelTokenSource>) => void
+  oncanceltoken?: (event: CustomEvent<CancelTokenSource>) => void
 }
 
 function link(node: ActionElement, options: ActionParameters = {}): ActionReturn<ActionParameters, ActionAttributes> {


### PR DESCRIPTION
Commit 69292ef already took care of the type issue reported in #2001. While looking into the type error, I noticed the custom events needed some adjustment for better type safety.

I also realized the action wasn’t supporting the new Svelte 5 event listener syntax (`onbefore`), so I’ve added support for both `on:before` and `onstart` (and all other events) in this PR.

## Before

### Svelte 4 syntax (incorrect)
<img width="1217" alt="Screen Shot 2024-10-09 at 11 19 49" src="https://github.com/user-attachments/assets/70218bef-af12-426c-a3be-1fd5591643c7">

### Svelte 5 syntax (missing)
<img width="1217" alt="Screen Shot 2024-10-09 at 11 20 31" src="https://github.com/user-attachments/assets/f3bc28f2-0afe-4e3e-ad9a-4c583b22e014">


## After

### Svelte 4 syntax
<img width="1217" alt="Screen Shot 2024-10-09 at 11 21 01" src="https://github.com/user-attachments/assets/f5b6009e-7375-4206-8e50-6b9541d3ef0b">

### Svelte 5 syntax
<img width="1217" alt="Screen Shot 2024-10-09 at 11 21 10" src="https://github.com/user-attachments/assets/5091300e-cce8-4a10-88bd-dfb87108e587">

----

Closes #2001