### PR TITLE
[2.x] Fix `onClick` in React adapter

### DIFF
--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -166,6 +166,8 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
 
     const regularEvents = {
       onClick: (event) => {
+        onClick(event)
+
         if (shouldIntercept(event)) {
           event.preventDefault()
 


### PR DESCRIPTION
Right now, `onClick` handlers passed to the React `<Link />` component are only called when the prefetch mode is `click` as reported in #2018. This is PR fixes that.

Closes #2018.