### PR TITLE
[2.x] Fix loading deferred props when re-visiting the same page

### DIFF
--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -3,10 +3,9 @@ import { fireNavigateEvent } from './events'
 import { history } from './history'
 import { page as currentPage } from './page'
 import { Scroll } from './scroll'
-import { GlobalEvent, GlobalEventNames, GlobalEventResult } from './types'
+import { GlobalEvent, GlobalEventNames, GlobalEventResult, InternalEvent } from './types'
 import { hrefToUrl } from './url'
 
-type InternalEvent = 'missingHistoryItem'
 class EventHandler {
   protected internalListeners: {
     event: InternalEvent
@@ -54,7 +53,7 @@ class EventHandler {
     this.fireInternalEvent('missingHistoryItem')
   }
 
-  protected fireInternalEvent(event: InternalEvent): void {
+  public fireInternalEvent(event: InternalEvent): void {
     this.internalListeners.filter((listener) => listener.event === event).forEach((listener) => listener.listener())
   }
 

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -1,3 +1,4 @@
+import { eventHandler } from './eventHandler'
 import { fireNavigateEvent } from './events'
 import { history } from './history'
 import { Scroll } from './scroll'
@@ -81,6 +82,8 @@ class CurrentPage {
         if (!preserveScroll) {
           Scroll.reset(page)
         }
+
+        eventHandler.fireInternalEvent('loadDeferredProps')
 
         if (!replace) {
           fireNavigateEvent(page)

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -59,7 +59,7 @@ export class Router {
       }
     })
 
-    eventHandler.onGlobalEvent('navigate', () => {
+    eventHandler.on('loadDeferredProps', () => {
       this.loadDeferredProps()
     })
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -196,6 +196,8 @@ export type GlobalEventCallback<TEventName extends GlobalEventNames> = (
   ...params: GlobalEventParameters<TEventName>
 ) => GlobalEventResult<TEventName>
 
+export type InternalEvent = 'missingHistoryItem' | 'loadDeferredProps'
+
 export type VisitCallbacks = {
   onCancelToken: { ({ cancel }: { cancel: VoidFunction }): void }
   onBefore: GlobalEventCallback<'before'>

--- a/packages/vue3/test-app/Pages/DeferredProps/Page1.vue
+++ b/packages/vue3/test-app/Pages/DeferredProps/Page1.vue
@@ -22,5 +22,6 @@ defineProps<{
     {{ bar }}
   </Deferred>
 
+  <Link href="/deferred-props/page-1">Page 1</Link>
   <Link href="/deferred-props/page-2">Page 2</Link>
 </template>

--- a/tests/deferred-props.spec.ts
+++ b/tests/deferred-props.spec.ts
@@ -62,3 +62,29 @@ test('we are not caching deferred props after reload', async ({ page }) => {
   await expect(page.getByText('foo value')).toBeVisible()
   await expect(page.getByText('bar value')).toBeVisible()
 })
+
+test('props will re-defer if a link is clicked to go to the same page again', async ({ page }) => {
+  await page.goto('/deferred-props/page-1')
+
+  await expect(page.getByText('Loading foo...')).toBeVisible()
+  await expect(page.getByText('Loading bar...')).toBeVisible()
+
+  await page.waitForResponse(page.url())
+
+  await expect(page.getByText('Loading foo...')).not.toBeVisible()
+  await expect(page.getByText('Loading bar...')).not.toBeVisible()
+  await expect(page.getByText('foo value')).toBeVisible()
+  await expect(page.getByText('bar value')).toBeVisible()
+
+  await clickAndWaitForResponse(page, 'Page 1', '/deferred-props/page-1')
+
+  await expect(page.getByText('Loading foo...')).toBeVisible()
+  await expect(page.getByText('Loading bar...')).toBeVisible()
+
+  await page.waitForResponse(page.url())
+
+  await expect(page.getByText('Loading foo...')).not.toBeVisible()
+  await expect(page.getByText('Loading bar...')).not.toBeVisible()
+  await expect(page.getByText('foo value')).toBeVisible()
+  await expect(page.getByText('bar value')).toBeVisible()
+})


### PR DESCRIPTION
Currently, we only load deferred props on the `navigate` event, but when visiting the same page (e.g. clicking a link to the page you are currently on) that event doesn't get fired and the deferred props go back to their loading state and never load.

We now have a custom `loadDeferredProps` event that fires on every page swap, as it should.

Closes #2013.