### PR TITLE
[2.x] $page url should not include the host

### DIFF
--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -233,7 +233,7 @@ export class Response {
 
     setHashIfSameUrl(this.requestParams.all().url, responseUrl)
 
-    return responseUrl.href
+    return responseUrl.href.split(responseUrl.host).pop()
   }
 
   protected mergeProps(pageResponse: Page): void {


### PR DESCRIPTION
This was an accidental breaking change in 2.x, previously `$page.url` did not include the full URL, now it does. This PR fixes that.

Fixes #2020