### PR TITLE
[2.x] Suppress Svelte accessibility warnings from Playwright logs

### DIFF
--- a/packages/svelte/test-app/svelte.config.js
+++ b/packages/svelte/test-app/svelte.config.js
@@ -1,6 +1,12 @@
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 const config = {
+  onwarn(warning, onwarn) {
+    if (/A11y/.test(warning.message)) return
+
+    onwarn(warning)
+  },
+
   // Consult https://kit.svelte.dev/docs/integrations#preprocessors
   // for more information about preprocessors
   preprocess: vitePreprocess(),


### PR DESCRIPTION
This PR reduces noise when running Playwright tests _(see below)_ to make it easier for us to spot errors when they happen.

<img width="1341" alt="Screen Shot 2024-10-15 at 10 40 39" src="https://github.com/user-attachments/assets/004fbfd7-a392-4d32-bf78-b2ce3efeabc3">
