### PR TITLE
[2.x] Change TypeScript module resolution in the Svelte adapter

### DIFF
--- a/packages/svelte/test-app/tsconfig.json
+++ b/packages/svelte/test-app/tsconfig.json
@@ -9,8 +9,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
+    "module": "ESNext",
+    "moduleResolution": "node"
   },
   "include": ["*.d.ts", "*.ts", "*.js", "**/*.d.ts", "**/*.ts", "**/*.js", "**/*.svelte", "*.config.js", "*.config.cjs"]
 }

--- a/playgrounds/svelte4/resources/js/app.ts
+++ b/playgrounds/svelte4/resources/js/app.ts
@@ -1,5 +1,4 @@
-import { createInertiaApp } from '@inertiajs/svelte'
-import type { ResolvedComponent } from '@inertiajs/svelte'
+import { createInertiaApp, type ResolvedComponent } from '@inertiajs/svelte'
 
 createInertiaApp({
   resolve: (name) => {

--- a/playgrounds/svelte4/resources/js/ssr.ts
+++ b/playgrounds/svelte4/resources/js/ssr.ts
@@ -1,6 +1,5 @@
-import { createInertiaApp } from '@inertiajs/svelte'
+import { createInertiaApp, type ResolvedComponent } from '@inertiajs/svelte'
 import createServer from '@inertiajs/svelte/server'
-import { ResolvedComponent } from '@inertiajs/svelte'
 
 createServer((page) =>
   createInertiaApp({

--- a/playgrounds/svelte4/tsconfig.json
+++ b/playgrounds/svelte4/tsconfig.json
@@ -1,23 +1,26 @@
 {
-	"extends": "@tsconfig/svelte/tsconfig.json",
-	"compilerOptions": {
-		"allowJs": true,
-		"checkJs": true,
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"resolveJsonModule": true,
-		"skipLibCheck": true,
-		"sourceMap": true,
-		"strict": true,
-		"module": "NodeNext",
-		"moduleResolution": "NodeNext"
-	},
-    "include": [
-        "resources/**/*.d.ts",
-        "resources/**/*.ts",
-        "resources/**/*.js",
-        "resources/**/*.svelte",
-        "*.config.js",
-        "*.config.cjs"
-    ]
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "paths": {
+      "@inertiajs/svelte/server": ["../../node_modules/@inertiajs/svelte/dist/server"]
+    }
+  },
+  "include": [
+    "resources/**/*.d.ts",
+    "resources/**/*.ts",
+    "resources/**/*.js",
+    "resources/**/*.svelte",
+    "*.config.js",
+    "*.config.cjs"
+  ]
 }

--- a/playgrounds/svelte5/resources/js/app.ts
+++ b/playgrounds/svelte5/resources/js/app.ts
@@ -1,6 +1,5 @@
-import { createInertiaApp } from '@inertiajs/svelte'
+import { createInertiaApp, type ResolvedComponent } from '@inertiajs/svelte'
 import { hydrate, mount } from 'svelte'
-import type { ResolvedComponent } from '@inertiajs/svelte'
 
 createInertiaApp({
   resolve: (name) => {

--- a/playgrounds/svelte5/resources/js/ssr.ts
+++ b/playgrounds/svelte5/resources/js/ssr.ts
@@ -1,6 +1,5 @@
-import { createInertiaApp } from '@inertiajs/svelte'
+import { createInertiaApp, type ResolvedComponent } from '@inertiajs/svelte'
 import createServer from '@inertiajs/svelte/server'
-import { ResolvedComponent } from '@inertiajs/svelte'
 
 createServer((page) =>
   createInertiaApp({

--- a/playgrounds/svelte5/tsconfig.json
+++ b/playgrounds/svelte5/tsconfig.json
@@ -1,23 +1,26 @@
 {
-	"extends": "@tsconfig/svelte/tsconfig.json",
-	"compilerOptions": {
-		"allowJs": true,
-		"checkJs": true,
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"resolveJsonModule": true,
-		"skipLibCheck": true,
-		"sourceMap": true,
-		"strict": true,
-		"module": "NodeNext",
-		"moduleResolution": "NodeNext"
-	},
-    "include": [
-        "resources/**/*.d.ts",
-        "resources/**/*.ts",
-        "resources/**/*.js",
-        "resources/**/*.svelte",
-        "*.config.js",
-        "*.config.cjs"
-    ]
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "paths": {
+      "@inertiajs/svelte/server": ["../../node_modules/@inertiajs/svelte/dist/server"]
+    }
+  },
+  "include": [
+    "resources/**/*.d.ts",
+    "resources/**/*.ts",
+    "resources/**/*.js",
+    "resources/**/*.svelte",
+    "*.config.js",
+    "*.config.cjs"
+  ]
 }


### PR DESCRIPTION
This PR fixes TypeScript module resolution issues within our monorepo setup that were preventing the detection of type errors during the launch of **v1.3.0-beta.1**. This happened because the `packages/svelte/test-app` and Svelte `playgrounds` projects weren't detecting type definitions from the Svelte adapter. The existing module resolution settings, copied from a fresh SvelteKit installation, were incompatible with our NPM workspace structure.

Changing the TypeScript module resolution to the same values as the other adapters fixes this issue in the Svelte adapter.