### PR TITLE
[2.x] Fix `<Deferred />` in Svelte adapter

### DIFF
--- a/packages/react/test-app/Pages/DeferredProps/Page1.jsx
+++ b/packages/react/test-app/Pages/DeferredProps/Page1.jsx
@@ -3,13 +3,13 @@ import { Deferred, Link, usePage } from '@inertiajs/react'
 const Foo = () => {
   const { foo } = usePage().props
 
-  return foo
+  return foo.text
 }
 
 const Bar = () => {
   const { bar } = usePage().props
 
-  return bar
+  return bar.text
 }
 
 export default () => {

--- a/packages/svelte/src/components/Deferred.svelte
+++ b/packages/svelte/src/components/Deferred.svelte
@@ -1,16 +1,29 @@
 <script lang="ts">
   import { page } from '../index'
+  import { onDestroy } from 'svelte'
 
   export let data: string | string[]
 
   const keys = Array.isArray(data) ? data : [data]
+  let loaded = false
+
+  const unsubscribe = page.subscribe(({ props }) => {
+    // Ensures the deferred slot isn't loaded before page props update
+    window.queueMicrotask(() => {
+      loaded = keys.every((key) => typeof props[key] !== 'undefined')
+    })
+  })
+
+  onDestroy(() => {
+    unsubscribe()
+  })
 
   if (!$$slots.fallback) {
     throw new Error('`<Deferred>` requires a `<svelte:fragment slot="fallback">` slot')
   }
 </script>
 
-{#if keys.every((key) => $page.props[key] !== undefined)}
+{#if loaded}
   <slot />
 {:else}
   <slot name="fallback" />

--- a/packages/svelte/src/components/Deferred.svelte
+++ b/packages/svelte/src/components/Deferred.svelte
@@ -8,7 +8,7 @@
   let loaded = false
 
   const unsubscribe = page.subscribe(({ props }) => {
-    // Ensures the deferred slot isn't loaded before page props update
+    // Ensures the slot isn't loaded before the deferred props are available
     window.queueMicrotask(() => {
       loaded = keys.every((key) => typeof props[key] !== 'undefined')
     })

--- a/packages/svelte/test-app/Pages/DeferredProps/Page1.svelte
+++ b/packages/svelte/test-app/Pages/DeferredProps/Page1.svelte
@@ -9,14 +9,14 @@
   <svelte:fragment slot="fallback">
     <div>Loading foo...</div>
   </svelte:fragment>
-  {foo}
+  {foo.text}
 </Deferred>
 
 <Deferred data="bar">
   <svelte:fragment slot="fallback">
     <div>Loading bar...</div>
   </svelte:fragment>
-  {bar}
+  {bar.text}
 </Deferred>
 
 <a href="/deferred-props/page-2" use:inertia>Page 2</a>

--- a/packages/vue3/test-app/Pages/DeferredProps/Page1.vue
+++ b/packages/vue3/test-app/Pages/DeferredProps/Page1.vue
@@ -2,8 +2,8 @@
 import { Deferred, Link } from '@inertiajs/vue3'
 
 defineProps<{
-  foo?: string
-  bar?: string
+  foo?: {text: string }
+  bar?: {text: string }
 }>()
 </script>
 
@@ -12,14 +12,14 @@ defineProps<{
     <template #fallback>
       <div>Loading foo...</div>
     </template>
-    {{ foo }}
+    {{ foo?.text }}
   </Deferred>
 
   <Deferred data="bar">
     <template #fallback>
       <div>Loading bar...</div>
     </template>
-    {{ bar }}
+    {{ bar?.text }}
   </Deferred>
 
   <Link href="/deferred-props/page-2">Page 2</Link>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -262,8 +262,8 @@ app.get('/deferred-props/page-1', (req, res) => {
       inertia.render(req, res, {
         component: 'DeferredProps/Page1',
         props: {
-          foo: req.headers['x-inertia-partial-data']?.includes('foo') ? 'foo value' : undefined,
-          bar: req.headers['x-inertia-partial-data']?.includes('bar') ? 'bar value' : undefined,
+          foo: req.headers['x-inertia-partial-data']?.includes('foo') ? { text: 'foo value' } : undefined,
+          bar: req.headers['x-inertia-partial-data']?.includes('bar') ? { text: 'bar value' } : undefined,
         },
       }),
     500,


### PR DESCRIPTION
In issue #2012, the `<Deferred />` component was rendering its default slot before the necessary props were updated, leading to errors when accessing properties on undefined objects. To address this, I updated the `<Deferred />` component to subscribe to the `$page` store and use `queueMicrotask` skip a beat and switch `loaded` when the props are expected to be updated.

#2036 improves how `$page` is updated making it more predictable. The approach in this PR resolves the reactivity issue in the `<Deferred />` component without modifying the `$page` store, maintaining compatibility for existing projects.