### PR TITLE
[2.x] Remove `data` option from `useForm` options type

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -6,7 +6,7 @@ import useRemember from './useRemember'
 type setDataByObject<TForm> = (data: TForm) => void
 type setDataByMethod<TForm> = (data: (previousData: TForm) => TForm) => void
 type setDataByKeyValuePair<TForm> = <K extends keyof TForm>(key: K, value: TForm[K]) => void
-type FormDataType = object
+type FormDataType = Record<string, FormDataConvertible>
 type FormOptions = Omit<VisitOptions, 'data'>
 
 export interface InertiaFormProps<TForm extends FormDataType> {

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -26,12 +26,12 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   clearErrors: (...fields: (keyof TForm)[]) => void
   setError(field: keyof TForm, value: string): void
   setError(errors: Record<keyof TForm, string>): void
-  submit: (method: Method, url: string, options?: VisitOptions) => void
-  get: (url: string, options?: VisitOptions) => void
-  patch: (url: string, options?: VisitOptions) => void
-  post: (url: string, options?: VisitOptions) => void
-  put: (url: string, options?: VisitOptions) => void
-  delete: (url: string, options?: VisitOptions) => void
+  submit: (method: Method, url: string, options?: Omit<VisitOptions, 'data'>) => void
+  get: (url: string, options?: Omit<VisitOptions, 'data'>) => void
+  patch: (url: string, options?: Omit<VisitOptions, 'data'>) => void
+  post: (url: string, options?: Omit<VisitOptions, 'data'>) => void
+  put: (url: string, options?: Omit<VisitOptions, 'data'>) => void
+  delete: (url: string, options?: Omit<VisitOptions, 'data'>) => void
   cancel: () => void
 }
 export default function useForm<TForm extends FormDataType>(initialValues?: TForm): InertiaFormProps<TForm>

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -7,6 +7,7 @@ type setDataByObject<TForm> = (data: TForm) => void
 type setDataByMethod<TForm> = (data: (previousData: TForm) => TForm) => void
 type setDataByKeyValuePair<TForm> = <K extends keyof TForm>(key: K, value: TForm[K]) => void
 type FormDataType = object
+type FormOptions = Omit<VisitOptions, 'data'>
 
 export interface InertiaFormProps<TForm extends FormDataType> {
   data: TForm
@@ -26,12 +27,12 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   clearErrors: (...fields: (keyof TForm)[]) => void
   setError(field: keyof TForm, value: string): void
   setError(errors: Record<keyof TForm, string>): void
-  submit: (method: Method, url: string, options?: Omit<VisitOptions, 'data'>) => void
-  get: (url: string, options?: Omit<VisitOptions, 'data'>) => void
-  patch: (url: string, options?: Omit<VisitOptions, 'data'>) => void
-  post: (url: string, options?: Omit<VisitOptions, 'data'>) => void
-  put: (url: string, options?: Omit<VisitOptions, 'data'>) => void
-  delete: (url: string, options?: Omit<VisitOptions, 'data'>) => void
+  submit: (method: Method, url: string, options?: FormOptions) => void
+  get: (url: string, options?: FormOptions) => void
+  patch: (url: string, options?: FormOptions) => void
+  post: (url: string, options?: FormOptions) => void
+  put: (url: string, options?: FormOptions) => void
+  delete: (url: string, options?: FormOptions) => void
   cancel: () => void
 }
 export default function useForm<TForm extends FormDataType>(initialValues?: TForm): InertiaFormProps<TForm>

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -36,12 +36,12 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
   setError(errors: Errors): this
-  submit(method: Method, url: string, options?: Partial<VisitOptions>): void
-  get(url: string, options?: Partial<VisitOptions>): void
-  post(url: string, options?: Partial<VisitOptions>): void
-  put(url: string, options?: Partial<VisitOptions>): void
-  patch(url: string, options?: Partial<VisitOptions>): void
-  delete(url: string, options?: Partial<VisitOptions>): void
+  submit(method: Method, url: string, options?: Omit<VisitOptions, 'data'>): void
+  get(url: string, options?: Omit<VisitOptions, 'data'>): void
+  post(url: string, options?: Omit<VisitOptions, 'data'>): void
+  put(url: string, options?: Omit<VisitOptions, 'data'>): void
+  patch(url: string, options?: Omit<VisitOptions, 'data'>): void
+  delete(url: string, options?: Omit<VisitOptions, 'data'>): void
   cancel(): void
 }
 

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -16,6 +16,7 @@ import isEqual from 'lodash/isEqual'
 import { writable, type Writable } from 'svelte/store'
 
 type FormDataType = Record<string, FormDataConvertible>
+type FormOptions = Omit<VisitOptions, 'data'>
 
 export interface InertiaFormProps<TForm extends FormDataType> {
   isDirty: boolean
@@ -36,12 +37,12 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
   setError(errors: Errors): this
-  submit(method: Method, url: string, options?: Omit<VisitOptions, 'data'>): void
-  get(url: string, options?: Omit<VisitOptions, 'data'>): void
-  post(url: string, options?: Omit<VisitOptions, 'data'>): void
-  put(url: string, options?: Omit<VisitOptions, 'data'>): void
-  patch(url: string, options?: Omit<VisitOptions, 'data'>): void
-  delete(url: string, options?: Omit<VisitOptions, 'data'>): void
+  submit(method: Method, url: string, options?: FormOptions): void
+  get(url: string, options?: FormOptions): void
+  post(url: string, options?: FormOptions): void
+  put(url: string, options?: FormOptions): void
+  patch(url: string, options?: FormOptions): void
+  delete(url: string, options?: FormOptions): void
   cancel(): void
 }
 
@@ -140,7 +141,7 @@ export default function useForm<TForm extends FormDataType>(
       )
       return this
     },
-    submit(method, url, options: Partial<VisitOptions> = {}) {
+    submit(method, url, options: FormOptions = {}) {
       const data = transform(this.data()) as RequestPayload
       const _options: Omit<VisitOptions, 'method'> = {
         ...options,

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -22,12 +22,12 @@ interface InertiaFormProps<TForm extends FormDataType> {
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
   setError(errors: Record<keyof TForm, string>): this
-  submit(method: Method, url: string, options?: Partial<VisitOptions>): void
-  get(url: string, options?: Partial<VisitOptions>): void
-  post(url: string, options?: Partial<VisitOptions>): void
-  put(url: string, options?: Partial<VisitOptions>): void
-  patch(url: string, options?: Partial<VisitOptions>): void
-  delete(url: string, options?: Partial<VisitOptions>): void
+  submit(method: Method, url: string, options?: Omit<VisitOptions, 'data'>): void
+  get(url: string, options?: Omit<VisitOptions, 'data'>): void
+  post(url: string, options?: Omit<VisitOptions, 'data'>): void
+  put(url: string, options?: Omit<VisitOptions, 'data'>): void
+  patch(url: string, options?: Omit<VisitOptions, 'data'>): void
+  delete(url: string, options?: Omit<VisitOptions, 'data'>): void
   cancel(): void
 }
 

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -3,7 +3,7 @@ import cloneDeep from 'lodash.clonedeep'
 import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
 
-type FormDataType = object
+type FormDataType = Record<string, FormDataConvertible>
 type FormOptions = Omit<VisitOptions, 'data'>
 
 interface InertiaFormProps<TForm extends FormDataType> {

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -4,6 +4,7 @@ import isEqual from 'lodash.isequal'
 import { reactive, watch } from 'vue'
 
 type FormDataType = object
+type FormOptions = Omit<VisitOptions, 'data'>
 
 interface InertiaFormProps<TForm extends FormDataType> {
   isDirty: boolean
@@ -22,12 +23,12 @@ interface InertiaFormProps<TForm extends FormDataType> {
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
   setError(errors: Record<keyof TForm, string>): this
-  submit(method: Method, url: string, options?: Omit<VisitOptions, 'data'>): void
-  get(url: string, options?: Omit<VisitOptions, 'data'>): void
-  post(url: string, options?: Omit<VisitOptions, 'data'>): void
-  put(url: string, options?: Omit<VisitOptions, 'data'>): void
-  patch(url: string, options?: Omit<VisitOptions, 'data'>): void
-  delete(url: string, options?: Omit<VisitOptions, 'data'>): void
+  submit(method: Method, url: string, options?: FormOptions): void
+  get(url: string, options?: FormOptions): void
+  post(url: string, options?: FormOptions): void
+  put(url: string, options?: FormOptions): void
+  patch(url: string, options?: FormOptions): void
+  delete(url: string, options?: FormOptions): void
   cancel(): void
 }
 
@@ -126,7 +127,7 @@ export default function useForm<TForm extends FormDataType>(
 
       return this
     },
-    submit(method, url, options: VisitOptions = {}) {
+    submit(method, url, options: FormOptions = {}) {
       const data = transform(this.data())
       const _options = {
         ...options,


### PR DESCRIPTION
The inclusion of `data` in `VisitOptions` can be misleading when using `useForm`. We should update the type definitions to exclude the `data` property in this context to prevent confusion.

Closes #2056.