### PR TITLE
Allow `WhenVisible` Component to Accept `params` Alongside `data` for Enhanced Customization

### DIFF
--- a/packages/react/src/WhenVisible.ts
+++ b/packages/react/src/WhenVisible.ts
@@ -25,9 +25,7 @@ const WhenVisible = ({ children, data, params, buffer, as, always, fallback }: W
     if (data) {
       return {
         only: (Array.isArray(data) ? data : [data]) as string[],
-        data: {
-            ...(params?.data??{})
-        }
+        ...params
       }
     }
 

--- a/packages/react/src/WhenVisible.ts
+++ b/packages/react/src/WhenVisible.ts
@@ -25,6 +25,9 @@ const WhenVisible = ({ children, data, params, buffer, as, always, fallback }: W
     if (data) {
       return {
         only: (Array.isArray(data) ? data : [data]) as string[],
+        data: {
+            ...(params?.data??{})
+        }
       }
     }
 


### PR DESCRIPTION
This PR updates the `getReloadParams` function to allow users to pass both `data` and custom `params` when using the `WhenVisible` component in Inertia v2.

**Old Behavior**:
Previously, if the `data` prop was provided, the `params` prop was ignored. This restricted the user's ability to pass additional parameters when reloading the component, leading to a lack of flexibility.

**New Behavior**:
Now, the `params` prop can be used in combination with the `data` prop. This allows users to extend the request parameters beyond the basic `data` specification.

- Updated code snippet:
  ```javascript
  const getReloadParams = (): Partial<ReloadOptions> => {
      if (data) {
          return {
              only: (Array.isArray(data) ? data : [data]) as string[],
              ...params
          }
      }

      if (!params) {
          throw new Error('You must provide either a `data` or `params` prop.')
      }

      return params
  }
  ```

**Use Case**:
Consider the following example:
```jsx
<WhenVisible
    always
    fallback={(
        <SpinnerWithRetry/>
    )}
    data='rooms'
    params={{
        data: {
            lastRoomId: rooms.data[rooms.data.length - 1].id
        },
        onBefore: async (data) => {
            console.log("onBefore", data);
        }
    }}
    children={null}
/>
```
With this change, both `data` and `params` are processed, ensuring that custom `params.data` like `lastRoomId` are passed correctly, enabling more flexible and complex reload scenarios.

BTW this can resolve my issue here : #2064 

Thanks.