### PR TITLE
[2.x] Add some additional poll helpers

### DIFF
--- a/packages/core/src/poll.ts
+++ b/packages/core/src/poll.ts
@@ -24,6 +24,7 @@ export class Poll {
     if (this.id) {
       //   console.log('clearing interval...')
       clearInterval(this.id)
+      this.id = null
     }
   }
 
@@ -51,5 +52,17 @@ export class Poll {
     if (this.throttle) {
       this.cbCount = 0
     }
+  }
+
+  public toggle(): void {
+    if (this.polling()) {
+      return this.stop()
+    }
+
+    this.start()
+  }
+
+  public polling(): boolean {
+    return !!this.id
   }
 }

--- a/packages/core/src/polls.ts
+++ b/packages/core/src/polls.ts
@@ -12,18 +12,12 @@ class Polls {
     interval: number,
     cb: VoidFunction,
     options: PollOptions,
-  ): {
-    stop: VoidFunction
-    start: VoidFunction
-  } {
+  ): Poll {
     const poll = new Poll(interval, cb, options)
 
     this.polls.push(poll)
 
-    return {
-      stop: () => poll.stop(),
-      start: () => poll.start(),
-    }
+    return poll
   }
 
   public clear() {

--- a/packages/react/src/usePoll.ts
+++ b/packages/react/src/usePoll.ts
@@ -8,7 +8,12 @@ export default function usePoll(
     keepAlive: false,
     autoStart: true,
   },
-) {
+): {
+  stop: VoidFunction
+  start: VoidFunction
+  toggle: VoidFunction
+  polling: () => boolean
+} {
   const pollRef = useRef(
     router.poll(interval, requestOptions, {
       ...options,
@@ -27,5 +32,7 @@ export default function usePoll(
   return {
     stop: pollRef.current.stop,
     start: pollRef.current.start,
+    toggle: pollRef.current.toggle,
+    polling: pollRef.current.polling,
   }
 }

--- a/packages/svelte/src/usePoll.ts
+++ b/packages/svelte/src/usePoll.ts
@@ -8,21 +8,31 @@ export default function usePoll(
     keepAlive: false,
     autoStart: true,
   },
-) {
-  const { stop, start } = router.poll(interval, requestOptions, {
+): {
+  stop: VoidFunction
+  start: VoidFunction
+  toggle: VoidFunction
+  polling: () => boolean
+} {
+  const poll = router.poll(interval, requestOptions, {
     ...options,
     autoStart: false,
   })
 
   onMount(() => {
     if (options.autoStart ?? true) {
-      start()
+      poll.start()
     }
   })
 
   onDestroy(() => {
-    stop()
+    poll.stop()
   })
 
-  return { stop, start }
+  return {
+    stop: () => poll.stop(),
+    start: () => poll.start(),
+    toggle: () => poll.toggle(),
+    polling: () => poll.polling(),
+  }
 }

--- a/packages/vue3/src/usePoll.ts
+++ b/packages/vue3/src/usePoll.ts
@@ -1,5 +1,5 @@
 import { PollOptions, ReloadOptions, router } from '@inertiajs/core'
-import { onMounted, onUnmounted } from 'vue'
+import { computed, ComputedRef, onMounted, onUnmounted, ref } from 'vue'
 
 export default function usePoll(
   interval: number,
@@ -11,24 +11,28 @@ export default function usePoll(
 ): {
   stop: VoidFunction
   start: VoidFunction
+  toggle: VoidFunction
+  polling: ComputedRef<boolean>
 } {
-  const { stop, start } = router.poll(interval, requestOptions, {
+  const poll = ref(router.poll(interval, requestOptions, {
     ...options,
     autoStart: false,
-  })
+  }))
 
   onMounted(() => {
     if (options.autoStart ?? true) {
-      start()
+      poll.value.start()
     }
   })
 
   onUnmounted(() => {
-    stop()
+    poll.value.stop()
   })
 
   return {
-    stop,
-    start,
+    stop: () => poll.value.stop(),
+    start: () => poll.value.start(),
+    toggle: () => poll.value.toggle(),
+    polling: computed(() => poll.value.polling()),
   }
 }


### PR DESCRIPTION
This PR adds `toggle` and `polling()` functions to the poll object.

I think I need a little help with the React and Svelte side. It seems a little more intuitive that there's a `polling` reactive property that gets returned from the `usePoll` hooks.