### PR TITLE
Don't prefetch the current page

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -198,7 +198,10 @@ export class Router {
       prefetch: true,
     })
 
-    if (visit.url.href === window.location.href) {
+    const visitUrl = visit.url.origin + visit.url.pathname + visit.url.search
+    const currentUrl = window.location.origin + window.location.pathname + window.location.search
+
+    if (visitUrl === currentUrl) {
       // Don't prefetch the current page, you're already on it
       return
     }

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -198,6 +198,11 @@ export class Router {
       prefetch: true,
     })
 
+    if (visit.url.href === window.location.href) {
+      // Don't prefetch the current page, you're already on it
+      return
+    }
+
     const events = this.getVisitEvents(options)
 
     // If either of these return false, we don't want to continue

--- a/tests/prefetch.spec.ts
+++ b/tests/prefetch.spec.ts
@@ -18,6 +18,24 @@ const hoverAndClick = async (page: Page, buttonText: string, id: number) => {
   await isPrefetchSwrPage(page, id)
 }
 
+test('will not prefetch current page', async ({ page }) => {
+  // These two prefetch requests should be made on mount
+  const prefetch2 = page.waitForResponse('prefetch/2')
+  const prefetch4 = page.waitForResponse('prefetch/4')
+
+  await page.goto('prefetch/1')
+
+  // These two prefetch requests should be made on mount
+  await prefetch2
+  await prefetch4
+
+  requests.listen(page)
+  await page.getByRole('link', { name: 'On Hover (Default)' }).hover()
+  await page.waitForTimeout(100)
+  // This is the page we're already on, so it shouldn't make a request
+  await expect(requests.requests.length).toBe(0)
+})
+
 test('can prefetch using link props', async ({ page }) => {
   // These two prefetch requests should be made on mount
   const prefetch2 = page.waitForResponse('prefetch/2')


### PR DESCRIPTION
Here's the scenario:

- User is on `/users`
- There is a `Link` to `/users` that prefetches on hover on the page
- If they hover that `Link` it will prefetch page and refresh the data on the current page
- If there is any changed form state, etc it gets reset back to its original state

My solution is: if we are trying to prefetch the current page, just don't. I can't think of a scenario where this is useful, we're already on the page, so we just abort it before it even kicks off.