### PR TITLE
Set the history state before swapping component

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -30,7 +30,7 @@ class History {
     }
   }
 
-  public pushState(page: Page): void {
+  public pushState(page: Page, cb: (() => void) | null = null): void {
     if (isServer || this.preserveUrl) {
       return
     }
@@ -47,6 +47,8 @@ class History {
           '',
           page.url,
         )
+
+        cb && cb()
       })
     })
   }
@@ -93,7 +95,7 @@ class History {
     return pageData instanceof ArrayBuffer ? decryptHistory(pageData) : Promise.resolve(pageData)
   }
 
-  public replaceState(page: Page): void {
+  public replaceState(page: Page, cb: (() => void) | null = null): void {
     currentPage.merge(page)
 
     if (isServer || this.preserveUrl) {
@@ -112,6 +114,8 @@ class History {
           '',
           page.url,
         )
+
+        cb && cb()
       })
     })
   }

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -61,33 +61,35 @@ class CurrentPage {
       const location = typeof window !== 'undefined' ? window.location : new URL(page.url)
       replace = replace || isSameUrlWithoutHash(hrefToUrl(page.url), location)
 
-      replace ? history.replaceState(page) : history.pushState(page)
+      return new Promise((resolve) => {
+        replace ? history.replaceState(page, () => resolve(null)) : history.pushState(page, () => resolve(null))
+      }).then(() => {
+        const isNewComponent = !this.isTheSame(page)
 
-      const isNewComponent = !this.isTheSame(page)
+        this.page = page
+        this.cleared = false
 
-      this.page = page
-      this.cleared = false
-
-      if (isNewComponent) {
-        this.fireEventsFor('newComponent')
-      }
-
-      if (this.isFirstPageLoad) {
-        this.fireEventsFor('firstLoad')
-      }
-
-      this.isFirstPageLoad = false
-
-      return this.swap({ component, page, preserveState }).then(() => {
-        if (!preserveScroll) {
-          Scroll.reset(page)
+        if (isNewComponent) {
+          this.fireEventsFor('newComponent')
         }
 
-        eventHandler.fireInternalEvent('loadDeferredProps')
-
-        if (!replace) {
-          fireNavigateEvent(page)
+        if (this.isFirstPageLoad) {
+          this.fireEventsFor('firstLoad')
         }
+
+        this.isFirstPageLoad = false
+
+        return this.swap({ component, page, preserveState }).then(() => {
+          if (!preserveScroll) {
+            Scroll.reset(page)
+          }
+
+          eventHandler.fireInternalEvent('loadDeferredProps')
+
+          if (!replace) {
+            fireNavigateEvent(page)
+          }
+        })
       })
     })
   }


### PR DESCRIPTION
This PR addresses an issue where the component could technically be mounted before we set the new history state when history encryption is in use, causing `reload` to reload the incorrect URL (typically the previous URL).

Fixes #2093 