### PR TITLE
refactor: augment `vue` instead of `@vue/runtime-core`

### DIFF
--- a/packages/vue3/src/types.ts
+++ b/packages/vue3/src/types.ts
@@ -12,7 +12,7 @@ declare module '@inertiajs/core' {
   }
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $inertia: typeof router
     $page: Page


### PR DESCRIPTION
Hello 👋,

Vue recommends to augment `vue` instead of its sub-dependencies so this PR removes the augmentation of `@vue/runtime-core` and augments `vue` instead.

- https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties
- https://github.com/nuxt/nuxt/pull/28542
- https://github.com/nuxt/nuxt/pull/18505
- https://github.com/inertiajs/inertia/pull/1958