### PR TITLE
Ensure current page is set before prefetching

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -214,13 +214,29 @@ export class Router {
       ...events,
     }
 
-    prefetchedRequests.add(
-      requestParams,
-      (params) => {
-        this.asyncRequestStream.send(Request.create(params, currentPage.get()))
-      },
-      { cacheFor },
-    )
+    const ensureCurrentPageIsSet = (): Promise<void> => {
+      return new Promise((resolve) => {
+        const checkIfPageIsDefined = () => {
+          if (currentPage.get()) {
+            resolve()
+          } else {
+            setTimeout(checkIfPageIsDefined, 50)
+          }
+        }
+
+        checkIfPageIsDefined()
+      })
+    }
+
+    ensureCurrentPageIsSet().then(() => {
+      prefetchedRequests.add(
+        requestParams,
+        (params) => {
+          this.asyncRequestStream.send(Request.create(params, currentPage.get()))
+        },
+        { cacheFor },
+      )
+    })
   }
 
   public clearHistory(): void {


### PR DESCRIPTION
The `prefetch` method needs to know about the current page, but there are scenarios where we may be calling this method prior to the page being set. 

This adjustment ensures the page is set before adding the prefetch to the request queue.

Fixes #2053 