### PR TITLE
docs: fix incorrect SSR server start command

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,7 +56,7 @@ To test the SSR mode, first run the build, and then start the SSR server:
 
 ```sh
 npm run build
-npm run ssr:serve
+php artisan inertia:start-ssr
 ```
 
 ## Publishing


### PR DESCRIPTION
Hi, it seems like the contributing docs mention a non-existing command to start the SSR server.
I've replaced it with the ones mentioned in the Inertia [docs](https://inertiajs.com/server-side-rendering#running-the-ssr-server).