### PR TITLE
ci: fix cache deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 20.15
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ runner.OS }}-npm-cache-${{ hashFiles('package-lock.json') }}
           path: |


### PR DESCRIPTION
Hi, the current build action shows a warning for usage of the deprecated `actions/cache@v2`. This PR should fix that.