### PR TITLE
Support `touchstart`, `focus`, `blur` events in link prefetch

### DIFF
--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -165,7 +165,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
     }, prefetchModes)
 
     const regularEvents = {
-      onClick: (event) => {
+      onClick: (event: Parameters<InertiaLinkProps['onClick']>[0]) => {
         onClick(event)
 
         if (shouldIntercept(event)) {
@@ -174,9 +174,6 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
           router.visit(href, visitParams)
         }
       },
-    }
-
-    const prefetchHoverEvents = {
       onMouseEnter: () => {
         hoverTimeout.current = window.setTimeout(() => {
           doPrefetch()
@@ -185,6 +182,14 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
       onMouseLeave: () => {
         clearTimeout(hoverTimeout.current)
       },
+    }
+
+    const prefetchHoverEvents = {
+      onMouseEnter: regularEvents.onMouseEnter,
+      onMouseLeave: regularEvents.onMouseLeave,
+      onTouchStart: regularEvents.onMouseEnter,
+      onFocus: regularEvents.onMouseEnter,
+      onBlur: regularEvents.onMouseLeave,
       onClick: regularEvents.onClick,
     }
 

--- a/packages/svelte/src/link.ts
+++ b/packages/svelte/src/link.ts
@@ -54,22 +54,31 @@ function link(
   let baseParams: VisitOptions
   let visitParams: VisitOptions
 
-  const regularEvents: ActionEventHandlers = {
+  const regularEvents = {
     click: (event) => {
       if (shouldIntercept(event)) {
         event.preventDefault()
         router.visit(href, visitParams)
       }
     },
-  }
+    mouseenter: () => {
+      hoverTimeout = setTimeout(() => prefetch(), 75)
+    },
+    mouseleave: () => {
+      clearTimeout(hoverTimeout)
+    },
+  } satisfies ActionEventHandlers
 
-  const prefetchHoverEvents: ActionEventHandlers = {
-    mouseenter: () => (hoverTimeout = setTimeout(() => prefetch(), 75)),
-    mouseleave: () => clearTimeout(hoverTimeout),
+  const prefetchHoverEvents = {
+    mouseenter: regularEvents.mouseenter,
+    mouseleave: regularEvents.mouseleave,
+    touchstart: regularEvents.mouseenter,
+    focus: regularEvents.mouseenter,
+    blur: regularEvents.mouseleave,
     click: regularEvents.click,
-  }
+  } satisfies ActionEventHandlers
 
-  const prefetchClickEvents: ActionEventHandlers = {
+  const prefetchClickEvents = {
     mousedown: (event) => {
       if (shouldIntercept(event)) {
         event.preventDefault()
@@ -86,7 +95,7 @@ function link(
         event.preventDefault()
       }
     },
-  }
+  } satisfies ActionEventHandlers
 
   function update({ cacheFor = 0, prefetch = false, ...params }: ActionParameters) {
     prefetchModes = (() => {

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -227,15 +227,12 @@ const Link: InertiaLink = defineComponent({
     }
 
     const regularEvents = {
-      onClick: (event) => {
+      onClick: (event: Parameters<InertiaLinkProps['onClick']>[0]) => {
         if (shouldIntercept(event)) {
           event.preventDefault()
           router.visit(href.value, visitParams)
         }
       },
-    }
-
-    const prefetchHoverEvents = {
       onMouseenter: () => {
         hoverTimeout.value = setTimeout(() => {
           prefetch()
@@ -244,6 +241,14 @@ const Link: InertiaLink = defineComponent({
       onMouseleave: () => {
         clearTimeout(hoverTimeout.value)
       },
+    }
+
+    const prefetchHoverEvents = {
+      onMouseenter: regularEvents.onMouseenter,
+      onMouseleave: regularEvents.onMouseleave,
+      onTouchstart: regularEvents.onMouseenter,
+      onFocus: regularEvents.onMouseenter,
+      onBlur: regularEvents.onMouseleave,
       onClick: regularEvents.onClick,
     }
 


### PR DESCRIPTION
Add support for `touchstart`, `focus`, and `blur` events in link prefetch `hover` behavior.

This is hugely inspired from React Router's [link prefetching code](https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/dom/ssr/components.tsx#L81-L172). Their event handlers composition is pretty neat too but I don't think it's necessary here.