### PR TITLE
Fix: `page.resolve.then` inline promise never resolving

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -62,7 +62,8 @@ class CurrentPage {
       replace = replace || isSameUrlWithoutHash(hrefToUrl(page.url), location)
 
       return new Promise((resolve) => {
-        replace ? history.replaceState(page, () => resolve(null)) : history.pushState(page, () => resolve(null))
+        replace ? history.replaceState(page) : history.pushState(page)
+        resolve(null)
       }).then(() => {
         const isNewComponent = !this.isTheSame(page)
 

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -62,8 +62,12 @@ class CurrentPage {
       replace = replace || isSameUrlWithoutHash(hrefToUrl(page.url), location)
 
       return new Promise((resolve) => {
-        replace ? history.replaceState(page) : history.pushState(page)
-        resolve(null)
+        // resolve the promise in the callback, but if history.preserveUrl is true we need to resolve it immediately
+        // since the callback will never be called
+        replace ? history.replaceState(page, () => resolve(null)) : history.pushState(page, () => resolve(null))
+        if (history.preserveUrl) {
+          resolve(null)
+        }
       }).then(() => {
         const isNewComponent = !this.isTheSame(page)
 


### PR DESCRIPTION
When the `<WhenVisible>` component is used with `preserveUrl: true` the promise in `page.resolve` never actually resolves since history isn't being replaced and the callback is never called.

Example:
```vue
        <WhenVisible
            always
            :params="{
                data: {
                    page: nextPageToLoad,
                },
                only: ['paginatedData'],
                preserveUrl: true,
            }"
        >
            <template #fallback>
                <div>Loading...</div>
            </template>
            <div></div>
        </WhenVisible>
```

This will get stuck forever and never resolve.

This PR adjusts `page.set` when it returns `page.resolve.then` so that the promises it creates resolve without depending on the callback if `preserveUrl` is set to true. The callback is still used if `preserveUrl` is false, since the callback is queued normally in that scenario.