### PR TITLE
Fix prefetch missing cacheFor default value

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -187,7 +187,7 @@ export class Router {
     return prefetchedRequests.findInFlight(this.getPrefetchParams(href, options))
   }
 
-  public prefetch(href: string | URL, options: VisitOptions = {}, { cacheFor = 30 }: PrefetchOptions) {
+  public prefetch(href: string | URL, options: VisitOptions = {}, { cacheFor = 30_000 }: PrefetchOptions) {
     if (options.method !== 'get') {
       throw new Error('Prefetch requests must use the GET method')
     }

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -187,7 +187,7 @@ export class Router {
     return prefetchedRequests.findInFlight(this.getPrefetchParams(href, options))
   }
 
-  public prefetch(href: string | URL, options: VisitOptions = {}, { cacheFor }: PrefetchOptions) {
+  public prefetch(href: string | URL, options: VisitOptions = {}, { cacheFor = 30 }: PrefetchOptions) {
     if (options.method !== 'get') {
       throw new Error('Prefetch requests must use the GET method')
     }


### PR DESCRIPTION
# Fix prefetch method signature to match documentation

## Description
Updates the `prefetch` method signature in `router.ts` to match the [documented](https://inertiajs.com/prefetching#programmatic-prefetching) behavior by providing a default value for the `cacheFor` option. This fixes TS errors when calling `router.prefetch` with two arguments and aligns with the documented API.

## Recreate
Calling `router.prefetch` to programmatically prefetch data like so:
```js
router.prefetch(route('customers.show', row.original.id), { method: 'get' })
```
Results in `TS2554: Expected 3 arguments, but got 2.` and `Uncaught TypeError: Cannot destructure property 'cacheFor' of 'undefined' as it is undefined.` on runtime. This a result of not having a default value on the `prefetch` method on the router.


## Changes
```diff
- public prefetch(href: string | URL, options: VisitOptions = {}, { cacheFor }: PrefetchOptions) {
+ public prefetch(href: string | URL, options: VisitOptions = {}, { cacheFor = 30 }: PrefetchOptions) {
```

## Related Documentation
https://inertiajs.com/prefetching#programmatic-prefetching

Thanks for such a great work on v2 🔥!