### PR TITLE
react useForm: Memoize setData

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -166,9 +166,8 @@ export default function useForm<TForm extends FormDataType>(
     [data, setErrors, transform],
   )
 
-  return {
-    data,
-    setData(keyOrData: keyof TForm | Function | TForm, maybeValue?: TForm[keyof TForm]) {
+  const setDataExpanded = useCallback(
+    (keyOrData: keyof TForm | Function | TForm, maybeValue?: TForm[keyof TForm]) => {
       if (typeof keyOrData === 'string') {
         setData((data) => ({ ...data, [keyOrData]: maybeValue }))
       } else if (typeof keyOrData === 'function') {
@@ -177,6 +176,12 @@ export default function useForm<TForm extends FormDataType>(
         setData(keyOrData as TForm)
       }
     },
+    [setData],
+  )
+
+  return {
+    data,
+    setData: setDataExpanded,
     isDirty: !isEqual(data, defaults),
     errors,
     hasErrors,


### PR DESCRIPTION
Related to this: https://github.com/inertiajs/inertia/issues/1319

Makes `setData` stable to prevent unnecessary component rerenders. It now also works as expected as a dependency for `useEffect`, `useMemo` e.g.

I could not find a test for the react version of `useForm` in the code, so I'm not sure what to do about tests, please let me know :smile: 