### PR TITLE
Ensure callback execution

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -31,8 +31,14 @@ class History {
   }
 
   public pushState(page: Page, cb: (() => void) | null = null): void {
-    if (isServer || this.preserveUrl) {
+    if (isServer) {
       return
+    }
+
+    if (this.preserveUrl) {
+      cb && cb();
+
+      return;
     }
 
     this.current = page
@@ -98,8 +104,14 @@ class History {
   public replaceState(page: Page, cb: (() => void) | null = null): void {
     currentPage.merge(page)
 
-    if (isServer || this.preserveUrl) {
+    if (isServer) {
       return
+    }
+
+    if (this.preserveUrl) {
+      cb && cb();
+
+      return;
     }
 
     this.current = page


### PR DESCRIPTION
Ensure callback execution regardless of `preserveUrl` in `history.pushState` and `history.replaceState` #2162