### PR TITLE
More resilient logic for stripping the origin from page URLs

### DIFF
--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -233,7 +233,7 @@ export class Response {
 
     setHashIfSameUrl(this.requestParams.all().url, responseUrl)
 
-    return responseUrl.href.split(responseUrl.host).pop()
+    return responseUrl.pathname + responseUrl.search + responseUrl.hash
   }
 
   protected mergeProps(pageResponse: Page): void {


### PR DESCRIPTION
The previous method for stripping the origin from absolute page URLs produces malformed output when the `host` string happens to appear multiple times in the URL.

```js
// Old logic
"https://example.com/foo?return_to=https%3A%2F%example.com%2Fbar".split("example.com").pop() === "%2Fbar" 

// New logic
const url = new URL("https://example.com/foo?return_to=https%3A%2F%example.com%2Fbar")
url.pathname + url.search + url.hash === "/foo?return_to=https%3A%2F%example.com%2Fbar"
```

I had some trouble getting an automated test case to work in `response.test.ts` (they all seem to failing for me when I try to run `vitest` 🤔 ), but happy to take another crack at it with some guidance.