### PR TITLE
fix: Add optional chaining to prevent history issue.

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -101,7 +101,7 @@ class History {
       return Promise.resolve().then(() => {
         this.doReplaceState(
           {
-            page: window.history.state.page,
+            page: window.history.state?.page,
             scrollRegions,
           },
           this.current.url!,
@@ -115,7 +115,7 @@ class History {
       return Promise.resolve().then(() => {
         this.doReplaceState(
           {
-            page: window.history.state.page,
+            page: window.history.state?.page,
             documentScrollPosition: scrollRegion,
           },
           this.current.url!,


### PR DESCRIPTION
We've hit a strange bug where this particular line causes an issue after using `Inertia::location()` - it tries to read the `page` parameter of `window.history.state` which i'm assuming is reset during an Inertia::location() call? 

Adding the optional chaining modifier (as already exists in another reference to this variable further up the page) would fix this for us.