### PR TITLE
[2.x] SSR clustering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5368,7 +5368,7 @@
       },
       "devDependencies": {
         "@types/deepmerge": "^2.2.0",
-        "@types/node": "^14.0",
+        "@types/node": "^18.4",
         "@types/nprogress": "^0.2.0",
         "@types/qs": "^6.9.0",
         "esbuild": "^0.16.13",
@@ -5377,11 +5377,14 @@
       }
     },
     "packages/core/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.74",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
+      "integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/core/node_modules/typescript": {
       "version": "4.9.5",
@@ -5396,6 +5399,13 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "packages/core/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/react": {
       "name": "@inertiajs/react",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@types/deepmerge": "^2.2.0",
-    "@types/node": "^14.0",
+    "@types/node": "^18.4",
     "@types/nprogress": "^0.2.0",
     "@types/qs": "^6.9.0",
     "esbuild": "^0.16.13",


### PR DESCRIPTION
Reattempt of #1909 for 2.x

Currently the Inertia SSR server would only run on a single thread, so on high load this might have implications, since the Node process could only take 100% on a single core/thread.

Node has the cluster module [nodejs.org/api/cluster.html](https://nodejs.org/api/cluster.html), which would make it possible to start multiple Node servers on the same port, then each request would be dealt with by each thread in a round-robin way.

With this PR it's possible to enable clustering by using;

```ts
createServer(
  (page) => createInertiaApp( ... ),
  {
    cluster: true,
  }
)
```

Massive thanks to @christianschoenmakers who discovered the issue and asked about it on the Inertia.js Discord server:

> Hi guys! I'm using Laravel Inertia + Vue with SSR. Sometimes the site is becoming really slow. I figured out this is because of the node SSR process is over 100% of CPU usage. However, this is only a single core, there are 7 cores idle. I want to make the node process capable of using multiple CPU cores to spread the load. What is the best way to do it? Should I spawn multiple processes with the inertia:start-ssr command, or should I implement node clustering somehow? Does anyone have a suggestion?
> [discord.com/channels/592327939920494592/758259460920573992/1255111006384820234](https://discord.com/channels/592327939920494592/758259460920573992/1255111006384820234)