### PR TITLE
chore: replace lodash to decrease bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -769,6 +769,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.3.1.tgz",
+      "integrity": "sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw==",
+      "license": "MIT"
+    },
     "node_modules/@inertiajs/core": {
       "resolved": "packages/core",
       "link": true
@@ -1348,13 +1354,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/html-escape/-/html-escape-2.0.2.tgz",
       "integrity": "sha512-fM55cRnV3Uv6sOyUVjHfl3QPRUNf7Fe1am3qUV29zXWHhxQHQtKgi0vF3VQiXqa5kuick9UjZuOc5c7GHKP1zg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2931,6 +2930,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/laravel-vite-plugin": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.1.1.tgz",
@@ -2997,18 +3005,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lower-case": {
@@ -5456,8 +5453,8 @@
       "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
-        "@inertiajs/core": "2.0.5",
-        "lodash.isequal": "^4.5.0"
+        "@gilbarbara/deep-equal": "^0.3.1",
+        "@inertiajs/core": "2.0.5"
       },
       "devDependencies": {
         "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -5489,9 +5486,10 @@
       "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
+        "@gilbarbara/deep-equal": "^0.3.1",
         "@inertiajs/core": "2.0.5",
         "html-escape": "^2.0.0",
-        "lodash": "^4.5.0"
+        "klona": "^2.0.5"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "^3.2.0",
@@ -5499,7 +5497,6 @@
         "@sveltejs/package": "^2.3.4",
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
         "@types/html-escape": "^2.0.2",
-        "@types/lodash": "^4.17.7",
         "axios": "^1.8.2",
         "publint": "^0.2.10",
         "svelte": "^4.2.16",
@@ -5563,9 +5560,9 @@
       "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
+        "@gilbarbara/deep-equal": "^0.3.1",
         "@inertiajs/core": "2.0.5",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
+        "klona": "^2.0.5"
       },
       "devDependencies": {
         "@playwright/test": "^1.46.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,12 +769,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@gilbarbara/deep-equal": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.3.1.tgz",
-      "integrity": "sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw==",
-      "license": "MIT"
-    },
     "node_modules/@inertiajs/core": {
       "resolved": "packages/core",
       "link": true
@@ -2288,6 +2282,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.33.0.tgz",
+      "integrity": "sha512-X13Q/ZSc+vsO1q600bvNK4bxgXMkHcf//RxCmYDaRY5DAcT+eoXjY5hoAPGMdRnWQjvyLEcyauG3b6hz76LNqg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
@@ -2928,15 +2932,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/klona": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/laravel-vite-plugin": {
@@ -5453,8 +5448,8 @@
       "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
-        "@gilbarbara/deep-equal": "^0.3.1",
-        "@inertiajs/core": "2.0.5"
+        "@inertiajs/core": "2.0.5",
+        "es-toolkit": "^1.33.0"
       },
       "devDependencies": {
         "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -5486,10 +5481,9 @@
       "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
-        "@gilbarbara/deep-equal": "^0.3.1",
         "@inertiajs/core": "2.0.5",
-        "html-escape": "^2.0.0",
-        "klona": "^2.0.5"
+        "es-toolkit": "^1.33.0",
+        "html-escape": "^2.0.0"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "^3.2.0",
@@ -5560,9 +5554,8 @@
       "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
-        "@gilbarbara/deep-equal": "^0.3.1",
         "@inertiajs/core": "2.0.5",
-        "klona": "^2.0.5"
+        "es-toolkit": "^1.33.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.46.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -59,7 +59,7 @@
     "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@inertiajs/core": "2.0.5",
-    "lodash.isequal": "^4.5.0"
+    "@gilbarbara/deep-equal": "^0.3.1",
+    "@inertiajs/core": "2.0.5"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -59,7 +59,7 @@
     "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@gilbarbara/deep-equal": "^0.3.1",
-    "@inertiajs/core": "2.0.5"
+    "@inertiajs/core": "2.0.5",
+    "es-toolkit": "^1.33.0"
   }
 }

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -1,5 +1,5 @@
 import { FormDataConvertible, Method, Progress, router, VisitOptions } from '@inertiajs/core'
-import isDeepEqual from '@gilbarbara/deep-equal'
+import { isEqual } from 'es-toolkit'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import useRemember from './useRemember'
 
@@ -270,7 +270,7 @@ export default function useForm<TForm extends FormDataType>(
   return {
     data,
     setData: setDataFunction,
-    isDirty: !isDeepEqual(data, defaults),
+    isDirty: !isEqual(data, defaults),
     errors,
     hasErrors,
     processing,

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -1,5 +1,5 @@
 import { FormDataConvertible, Method, Progress, router, VisitOptions } from '@inertiajs/core'
-import isEqual from 'lodash.isequal'
+import isDeepEqual from '@gilbarbara/deep-equal'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import useRemember from './useRemember'
 
@@ -270,7 +270,7 @@ export default function useForm<TForm extends FormDataType>(
   return {
     data,
     setData: setDataFunction,
-    isDirty: !isEqual(data, defaults),
+    isDirty: !isDeepEqual(data, defaults),
     errors,
     hasErrors,
     processing,

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -15,6 +15,7 @@
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
 
     "noImplicitThis": false,
     "noUnusedLocals": true,

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -43,10 +43,9 @@
     "svelte": "^4.0.0 || ^5.0.0 || ^5.0.0-next.244"
   },
   "dependencies": {
-    "@gilbarbara/deep-equal": "^0.3.1",
     "@inertiajs/core": "2.0.5",
-    "html-escape": "^2.0.0",
-	  "klona": "^2.0.5"
+    "es-toolkit": "^1.33.0",
+    "html-escape": "^2.0.0"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.2.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -43,9 +43,10 @@
     "svelte": "^4.0.0 || ^5.0.0 || ^5.0.0-next.244"
   },
   "dependencies": {
+    "@gilbarbara/deep-equal": "^0.3.1",
     "@inertiajs/core": "2.0.5",
     "html-escape": "^2.0.0",
-    "lodash": "^4.5.0"
+	  "klona": "^2.0.5"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.2.0",
@@ -53,7 +54,6 @@
     "@sveltejs/package": "^2.3.4",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
     "@types/html-escape": "^2.0.2",
-    "@types/lodash": "^4.17.7",
     "axios": "^1.8.2",
     "publint": "^0.2.10",
     "svelte": "^4.2.16",

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -11,8 +11,7 @@ import type {
 } from '@inertiajs/core'
 import { router } from '@inertiajs/core'
 import type { AxiosProgressEvent } from 'axios'
-import { klona } from 'klona/full'
-import isDeepEqual from '@gilbarbara/deep-equal'
+import { cloneDeep, isEqual } from 'es-toolkit'
 import { writable, type Writable } from 'svelte/store'
 
 type FormDataType = Record<string, FormDataConvertible>
@@ -63,7 +62,7 @@ export default function useForm<TForm extends FormDataType>(
   const restored = rememberKey
     ? (router.restore(rememberKey) as { data: TForm; errors: Record<keyof TForm, string> } | null)
     : null
-  let defaults = klona(data)
+  let defaults = cloneDeep(data)
   let cancelToken: { cancel: () => void } | null = null
   let recentlySuccessfulTimeoutId: ReturnType<typeof setTimeout> | null = null
   let transform = (data: TForm) => data as object
@@ -95,16 +94,16 @@ export default function useForm<TForm extends FormDataType>(
     defaults(fieldOrFields?: keyof TForm | Partial<TForm>, maybeValue?: FormDataConvertible) {
       defaults =
         typeof fieldOrFields === 'undefined'
-          ? klona(this.data())
+          ? cloneDeep(this.data())
           : Object.assign(
-              klona(defaults),
+              cloneDeep(defaults),
               typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields,
             )
 
       return this
     },
     reset(...fields) {
-      const clonedData = klona(defaults)
+      const clonedData = cloneDeep(defaults)
       if (fields.length === 0) {
         this.setStore(clonedData)
       } else {
@@ -244,7 +243,7 @@ export default function useForm<TForm extends FormDataType>(
   } as InertiaForm<TForm>)
 
   store.subscribe((form) => {
-    if (form.isDirty === isDeepEqual(form.data(), defaults)) {
+    if (form.isDirty === isEqual(form.data(), defaults)) {
       form.setStore('isDirty', !form.isDirty)
     }
 

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -11,8 +11,8 @@ import type {
 } from '@inertiajs/core'
 import { router } from '@inertiajs/core'
 import type { AxiosProgressEvent } from 'axios'
-import cloneDeep from 'lodash/cloneDeep'
-import isEqual from 'lodash/isEqual'
+import { klona } from 'klona/full'
+import isDeepEqual from '@gilbarbara/deep-equal'
 import { writable, type Writable } from 'svelte/store'
 
 type FormDataType = Record<string, FormDataConvertible>
@@ -63,7 +63,7 @@ export default function useForm<TForm extends FormDataType>(
   const restored = rememberKey
     ? (router.restore(rememberKey) as { data: TForm; errors: Record<keyof TForm, string> } | null)
     : null
-  let defaults = cloneDeep(data)
+  let defaults = klona(data)
   let cancelToken: { cancel: () => void } | null = null
   let recentlySuccessfulTimeoutId: ReturnType<typeof setTimeout> | null = null
   let transform = (data: TForm) => data as object
@@ -95,16 +95,16 @@ export default function useForm<TForm extends FormDataType>(
     defaults(fieldOrFields?: keyof TForm | Partial<TForm>, maybeValue?: FormDataConvertible) {
       defaults =
         typeof fieldOrFields === 'undefined'
-          ? cloneDeep(this.data())
+          ? klona(this.data())
           : Object.assign(
-              cloneDeep(defaults),
+              klona(defaults),
               typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields,
             )
 
       return this
     },
     reset(...fields) {
-      const clonedData = cloneDeep(defaults)
+      const clonedData = klona(defaults)
       if (fields.length === 0) {
         this.setStore(clonedData)
       } else {
@@ -244,7 +244,7 @@ export default function useForm<TForm extends FormDataType>(
   } as InertiaForm<TForm>)
 
   store.subscribe((form) => {
-    if (form.isDirty === isEqual(form.data(), defaults)) {
+    if (form.isDirty === isDeepEqual(form.data(), defaults)) {
       form.setStore('isDirty', !form.isDirty)
     }
 

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -58,8 +58,8 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
+    "@gilbarbara/deep-equal": "^0.3.1",
     "@inertiajs/core": "2.0.5",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.isequal": "^4.5.0"
+	  "klona": "^2.0.5"
   }
 }

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -58,8 +58,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@gilbarbara/deep-equal": "^0.3.1",
     "@inertiajs/core": "2.0.5",
-	  "klona": "^2.0.5"
+    "es-toolkit": "^1.33.0"
   }
 }

--- a/packages/vue3/src/remember.ts
+++ b/packages/vue3/src/remember.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import { klona } from 'klona/full'
+import { cloneDeep } from 'es-toolkit'
 import { ComponentOptions } from 'vue'
 
 const remember: ComponentOptions = {
@@ -52,7 +52,7 @@ const remember: ComponentOptions = {
             rememberable.reduce(
               (data, key) => ({
                 ...data,
-                [key]: klona(hasCallbacks(key) ? this[key].__remember() : this[key]),
+                [key]: cloneDeep(hasCallbacks(key) ? this[key].__remember() : this[key]),
               }),
               {},
             ),

--- a/packages/vue3/src/remember.ts
+++ b/packages/vue3/src/remember.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import cloneDeep from 'lodash.clonedeep'
+import { klona } from 'klona/full'
 import { ComponentOptions } from 'vue'
 
 const remember: ComponentOptions = {
@@ -52,7 +52,7 @@ const remember: ComponentOptions = {
             rememberable.reduce(
               (data, key) => ({
                 ...data,
-                [key]: cloneDeep(hasCallbacks(key) ? this[key].__remember() : this[key]),
+                [key]: klona(hasCallbacks(key) ? this[key].__remember() : this[key]),
               }),
               {},
             ),

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -1,6 +1,6 @@
 import { FormDataConvertible, Method, Progress, router, VisitOptions } from '@inertiajs/core'
-import cloneDeep from 'lodash.clonedeep'
-import isEqual from 'lodash.isequal'
+import { klona } from 'klona/full'
+import isDeepEqual from '@gilbarbara/deep-equal'
 import { reactive, watch } from 'vue'
 
 type FormDataType = Record<string, FormDataConvertible>
@@ -48,13 +48,13 @@ export default function useForm<TForm extends FormDataType>(
   const restored = rememberKey
     ? (router.restore(rememberKey) as { data: TForm; errors: Record<keyof TForm, string> })
     : null
-  let defaults = typeof data === 'function' ? cloneDeep(data()) : cloneDeep(data)
+  let defaults = typeof data === 'function' ? klona(data()) : klona(data)
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = (data) => data
 
   const form = reactive({
-    ...(restored ? restored.data : cloneDeep(defaults)),
+    ...(restored ? restored.data : klona(defaults)),
     isDirty: false,
     errors: restored ? restored.errors : {},
     hasErrors: false,
@@ -84,7 +84,7 @@ export default function useForm<TForm extends FormDataType>(
       } else {
         defaults = Object.assign(
           {},
-          cloneDeep(defaults),
+          klona(defaults),
           typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields,
         )
       }
@@ -92,8 +92,8 @@ export default function useForm<TForm extends FormDataType>(
       return this
     },
     reset(...fields) {
-      const resolvedData = typeof data === 'function' ? cloneDeep(data()) : cloneDeep(defaults)
-      const clonedData = cloneDeep(resolvedData)
+      const resolvedData = typeof data === 'function' ? klona(data()) : klona(defaults)
+      const clonedData = klona(resolvedData)
       if (fields.length === 0) {
         defaults = clonedData
         Object.assign(this, resolvedData)
@@ -171,7 +171,7 @@ export default function useForm<TForm extends FormDataType>(
           recentlySuccessfulTimeoutId = setTimeout(() => (this.recentlySuccessful = false), 2000)
 
           const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
-          defaults = cloneDeep(this.data())
+          defaults = klona(this.data())
           this.isDirty = false
           return onSuccess
         },
@@ -242,9 +242,9 @@ export default function useForm<TForm extends FormDataType>(
   watch(
     form,
     (newValue) => {
-      form.isDirty = !isEqual(form.data(), defaults)
+      form.isDirty = !isDeepEqual(form.data(), defaults)
       if (rememberKey) {
-        router.remember(cloneDeep(newValue.__remember()), rememberKey)
+        router.remember(klona(newValue.__remember()), rememberKey)
       }
     },
     { immediate: true, deep: true },

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -1,6 +1,5 @@
 import { FormDataConvertible, Method, Progress, router, VisitOptions } from '@inertiajs/core'
-import { klona } from 'klona/full'
-import isDeepEqual from '@gilbarbara/deep-equal'
+import { cloneDeep, isEqual } from 'es-toolkit'
 import { reactive, watch } from 'vue'
 
 type FormDataType = Record<string, FormDataConvertible>
@@ -48,13 +47,13 @@ export default function useForm<TForm extends FormDataType>(
   const restored = rememberKey
     ? (router.restore(rememberKey) as { data: TForm; errors: Record<keyof TForm, string> })
     : null
-  let defaults = typeof data === 'function' ? klona(data()) : klona(data)
+  let defaults = typeof data === 'function' ? cloneDeep(data()) : cloneDeep(data)
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = (data) => data
 
   const form = reactive({
-    ...(restored ? restored.data : klona(defaults)),
+    ...(restored ? restored.data : cloneDeep(defaults)),
     isDirty: false,
     errors: restored ? restored.errors : {},
     hasErrors: false,
@@ -84,7 +83,7 @@ export default function useForm<TForm extends FormDataType>(
       } else {
         defaults = Object.assign(
           {},
-          klona(defaults),
+          cloneDeep(defaults),
           typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields,
         )
       }
@@ -92,8 +91,8 @@ export default function useForm<TForm extends FormDataType>(
       return this
     },
     reset(...fields) {
-      const resolvedData = typeof data === 'function' ? klona(data()) : klona(defaults)
-      const clonedData = klona(resolvedData)
+      const resolvedData = typeof data === 'function' ? cloneDeep(data()) : cloneDeep(defaults)
+      const clonedData = cloneDeep(resolvedData)
       if (fields.length === 0) {
         defaults = clonedData
         Object.assign(this, resolvedData)
@@ -171,7 +170,7 @@ export default function useForm<TForm extends FormDataType>(
           recentlySuccessfulTimeoutId = setTimeout(() => (this.recentlySuccessful = false), 2000)
 
           const onSuccess = options.onSuccess ? await options.onSuccess(page) : null
-          defaults = klona(this.data())
+          defaults = cloneDeep(this.data())
           this.isDirty = false
           return onSuccess
         },
@@ -242,9 +241,9 @@ export default function useForm<TForm extends FormDataType>(
   watch(
     form,
     (newValue) => {
-      form.isDirty = !isDeepEqual(form.data(), defaults)
+      form.isDirty = !isEqual(form.data(), defaults)
       if (rememberKey) {
-        router.remember(klona(newValue.__remember()), rememberKey)
+        router.remember(cloneDeep(newValue.__remember()), rememberKey)
       }
     },
     { immediate: true, deep: true },

--- a/packages/vue3/src/useRemember.ts
+++ b/packages/vue3/src/useRemember.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import cloneDeep from 'lodash.clonedeep'
+import { klona } from 'klona/full'
 import { isReactive, reactive, ref, Ref, watch } from 'vue'
 
 export default function useRemember<T extends object>(
@@ -18,7 +18,7 @@ export default function useRemember<T extends object>(
   watch(
     remembered,
     (newValue) => {
-      router.remember(cloneDeep(hasCallbacks ? data.__remember() : newValue), key)
+      router.remember(klona(hasCallbacks ? data.__remember() : newValue), key)
     },
     { immediate: true, deep: true },
   )

--- a/packages/vue3/src/useRemember.ts
+++ b/packages/vue3/src/useRemember.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import { klona } from 'klona/full'
+import { cloneDeep } from 'es-toolkit'
 import { isReactive, reactive, ref, Ref, watch } from 'vue'
 
 export default function useRemember<T extends object>(
@@ -18,7 +18,7 @@ export default function useRemember<T extends object>(
   watch(
     remembered,
     (newValue) => {
-      router.remember(klona(hasCallbacks ? data.__remember() : newValue), key)
+      router.remember(cloneDeep(hasCallbacks ? data.__remember() : newValue), key)
     },
     { immediate: true, deep: true },
   )


### PR DESCRIPTION
This PR replaces `lodash.isequal` by `@gilbarbara/deep-equal` and `lodash.clonedeep` by `klona` to decrease the bundle size in ~6kB (gzip).