### PR TITLE
fix: react `Deferred` component error on partial visits

### DIFF
--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -1,5 +1,6 @@
-import { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useMemo, useState } from 'react'
 import usePage from './usePage'
+import { router } from '.'
 
 interface DeferredProps {
   children: ReactElement | number | string
@@ -14,7 +15,12 @@ const Deferred = ({ children, data, fallback }: DeferredProps) => {
 
   const [loaded, setLoaded] = useState(false)
   const pageProps = usePage().props
-  const keys = Array.isArray(data) ? data : [data]
+  const keys = useMemo(() => Array.isArray(data) ? data : [data], [data])
+
+  useEffect(() => {
+    const removeListener = router.on("start", () => setLoaded(false));
+    return () => { removeListener() }
+  }, [])
 
   useEffect(() => {
     setLoaded(keys.every((key) => pageProps[key] !== undefined))


### PR DESCRIPTION
This PR should fix the error caused by React `Deferred` component during partial visits to (or that causes redirects back to) the same page by listening to the `start` event and bringing back the fallback when a navigation starts.

It also memoizes the `keys` constant. This stops `useEffect` from being triggered more times than expected due to the redefinition of `keys` const on every re-render.

Fixes #2221