### PR TITLE
Fixed TypeError on providing only a partial subset of form fields in setErrors for useForm

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -26,7 +26,7 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   reset: (...fields: (keyof TForm)[]) => void
   clearErrors: (...fields: (keyof TForm)[]) => void
   setError(field: keyof TForm, value: string): void
-  setError(errors: Record<keyof TForm, string>): void
+  setError(errors: Partial<Record<keyof TForm, string>>): void
   submit: (method: Method, url: string, options?: FormOptions) => void
   get: (url: string, options?: FormOptions) => void
   patch: (url: string, options?: FormOptions) => void
@@ -216,13 +216,13 @@ export default function useForm<TForm extends FormDataType>(
   )
 
   const setError = useCallback(
-    (fieldOrFields: keyof TForm | Record<keyof TForm, string>, maybeValue?: string) => {
+    (fieldOrFields: keyof TForm | Partial<Record<keyof TForm, string>>, maybeValue?: string) => {
       setErrors((errors) => {
         const newErrors = {
           ...errors,
           ...(typeof fieldOrFields === 'string'
             ? { [fieldOrFields]: maybeValue }
-            : (fieldOrFields as Record<keyof TForm, string>)),
+            : (fieldOrFields as Partial<Record<keyof TForm, string>>)),
         }
         setHasErrors(Object.keys(newErrors).length > 0)
         return newErrors

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -36,7 +36,7 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
-  setError(errors: Errors): this
+  setError(errors: Partial<Errors>): this
   submit(method: Method, url: string, options?: FormOptions): void
   get(url: string, options?: FormOptions): void
   post(url: string, options?: FormOptions): void
@@ -120,10 +120,10 @@ export default function useForm<TForm extends FormDataType>(
 
       return this
     },
-    setError(fieldOrFields: keyof TForm | Errors, maybeValue?: string) {
+    setError(fieldOrFields: keyof TForm | Partial<Errors>, maybeValue?: string) {
       this.setStore('errors', {
         ...this.errors,
-        ...((typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields) as Errors),
+        ...((typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields) as Partial<Errors>),
       })
 
       return this

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -22,7 +22,7 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   reset(...fields: (keyof TForm)[]): this
   clearErrors(...fields: (keyof TForm)[]): this
   setError(field: keyof TForm, value: string): this
-  setError(errors: Record<keyof TForm, string>): this
+  setError(errors: Partial<Record<keyof TForm, string>>): this
   submit(method: Method, url: string, options?: FormOptions): void
   get(url: string, options?: FormOptions): void
   post(url: string, options?: FormOptions): void
@@ -108,7 +108,7 @@ export default function useForm<TForm extends FormDataType>(
 
       return this
     },
-    setError(fieldOrFields: keyof TForm | Record<keyof TForm, string>, maybeValue?: string) {
+    setError(fieldOrFields: keyof TForm | Partial<Record<keyof TForm, string>>, maybeValue?: string) {
       Object.assign(this.errors, typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields)
 
       this.hasErrors = Object.keys(this.errors).length > 0

--- a/playgrounds/react/resources/js/Pages/Form.tsx
+++ b/playgrounds/react/resources/js/Pages/Form.tsx
@@ -11,6 +11,11 @@ const Form = () => {
   function submit(e) {
     e.preventDefault()
     form.post('/user')
+
+    form.setError({
+      'name': 'Name is required',
+      'company': 'Company is required',
+    })
   }
 
   return (


### PR DESCRIPTION
Fixes #2214 by making the setErrors second signature partial, so not all form fields have to provided at the same time when calling `setErrors` on multiple form fields.

### Error Handling Improvements:

* [`packages/react/src/useForm.ts`](diffhunk://#diff-aff3ba12475ecdb346e7706b8abb04020a1adef9850539a8e9f7c98fcfb702b5L29-R29): Modified the `setError` method in the `InertiaFormProps` interface and the `useForm` function to accept partial records for error types. [[1]](diffhunk://#diff-aff3ba12475ecdb346e7706b8abb04020a1adef9850539a8e9f7c98fcfb702b5L29-R29) [[2]](diffhunk://#diff-aff3ba12475ecdb346e7706b8abb04020a1adef9850539a8e9f7c98fcfb702b5L219-R225)
* [`packages/svelte/src/useForm.ts`](diffhunk://#diff-59e9def88f278d4758846a9ada014927e1836d15714daad8ad9d02705bfe9f8dL39-R39): Updated the `setError` method in the `InertiaFormProps` interface and the `useForm` function to handle partial errors. [[1]](diffhunk://#diff-59e9def88f278d4758846a9ada014927e1836d15714daad8ad9d02705bfe9f8dL39-R39) [[2]](diffhunk://#diff-59e9def88f278d4758846a9ada014927e1836d15714daad8ad9d02705bfe9f8dL123-R126)
* [`packages/vue3/src/useForm.ts`](diffhunk://#diff-6a34bba1f476223d7b1c47c1b1d060324601d770f5d6c9b4a723707bd91dc728L25-R25): Changed the `setError` method in the `InertiaFormProps` interface and the `useForm` function to use partial records for error types. [[1]](diffhunk://#diff-6a34bba1f476223d7b1c47c1b1d060324601d770f5d6c9b4a723707bd91dc728L25-R25) [[2]](diffhunk://#diff-6a34bba1f476223d7b1c47c1b1d060324601d770f5d6c9b4a723707bd91dc728L111-R111)

### Example Usage and Test Update (can be reverted if not needed):

* [`playgrounds/react/resources/js/Pages/Form.tsx`](diffhunk://#diff-35feec69fdac866de37692fc93382e29577823cba800684bc36a98392fa16125R14-R18): Added an example usage of the `setError` method to demonstrate setting multiple errors at once.