### PR TITLE
Add state null checks in history

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -119,6 +119,10 @@ class History {
   public saveDocumentScrollPosition(scrollRegion: ScrollRegion): void {
     queue.add(() => {
       return Promise.resolve().then(() => {
+        if (!window.history.state?.page) {
+          return
+        }
+
         this.doReplaceState(
           {
             page: window.history.state.page,

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -131,11 +131,11 @@ class History {
   }
 
   public getScrollRegions(): ScrollRegion[] {
-    return window.history.state.scrollRegions || []
+    return window.history.state?.scrollRegions || []
   }
 
   public getDocumentScrollPosition(): ScrollRegion {
-    return window.history.state.documentScrollPosition || { top: 0, left: 0 }
+    return window.history.state?.documentScrollPosition || { top: 0, left: 0 }
   }
 
   public replaceState(page: Page, cb: (() => void) | null = null): void {


### PR DESCRIPTION
When switching from a non-inertia handled page to an inertia page in the same application the state object is not set. Thereby the getScrollRegions() and getDocumentScrollPosition() getters would generate the following error;

```
@inertiajs_react.js?v=387df219:3538 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'scrollRegions')
```

This is fixed by adding null checks for history state.

Same goes for `saveScrollPositions` when the page object on state does not exist.

Fixes #2204 