### PR TITLE
Improvements to history  management

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,15 @@ php artisan inertia:start-ssr
 Inertia.js uses [Playwright](https://playwright.dev/) for testing. To run the tests, use the following command:
 
 ```sh
-cd tests && npx playwright test
+npx playwright install # install playwright with system-wide browser dependencies
+
+# install packages for the test app
+cd tests/app
+npm install
+
+# run tests
+cd ..
+npx playwright test
 ```
 
 ## Publishing

--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -3,7 +3,7 @@ import { fireNavigateEvent } from './events'
 import { history } from './history'
 import { page as currentPage } from './page'
 import { Scroll } from './scroll'
-import { GlobalEvent, GlobalEventNames, GlobalEventResult, InternalEvent } from './types'
+import { EventHandlerInitParams, GlobalEvent, GlobalEventNames, GlobalEventResult, InternalEvent } from './types'
 import { hrefToUrl } from './url'
 
 class EventHandler {
@@ -12,13 +12,15 @@ class EventHandler {
     listener: VoidFunction
   }[] = []
 
-  public init() {
+  public init({ handleScroll }: EventHandlerInitParams) {
     if (typeof window !== 'undefined') {
       window.addEventListener('popstate', this.handlePopstateEvent.bind(this))
-      window.addEventListener('scroll', debounce(Scroll.onWindowScroll.bind(Scroll), 100), true)
+      if (handleScroll) {
+        window.addEventListener('scroll', debounce(Scroll.onWindowScroll.bind(Scroll), 100), true)
+      }
     }
 
-    if (typeof document !== 'undefined') {
+    if (typeof document !== 'undefined' && handleScroll) {
       document.addEventListener('scroll', debounce(Scroll.onScroll.bind(Scroll), 100), true)
     }
   }

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -4,12 +4,12 @@ import { history } from './history'
 import { Scroll } from './scroll'
 import {
   Component,
+  CurrentPageInitParams,
   Page,
   PageEvent,
   PageHandler,
   PageResolver,
   PreserveStateOption,
-  RouterInitParams,
   VisitOptions,
 } from './types'
 import { hrefToUrl, isSameUrlWithoutHash } from './url'
@@ -26,7 +26,7 @@ class CurrentPage {
   protected isFirstPageLoad = true
   protected cleared = false
 
-  public init({ initialPage, swapComponent, resolveComponent }: RouterInitParams) {
+  public init({ initialPage, swapComponent, resolveComponent }: CurrentPageInitParams) {
     this.page = initialPage
     this.swapComponent = swapComponent
     this.resolveComponent = resolveComponent

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -43,7 +43,7 @@ export class Router {
     interruptible: false,
   })
 
-  public init({ initialPage, resolveComponent, swapComponent }: RouterInitParams): void {
+  public init({ initialPage, resolveComponent, swapComponent, handleScroll }: RouterInitParams): void {
     currentPage.init({
       initialPage,
       resolveComponent,
@@ -52,7 +52,7 @@ export class Router {
 
     InitialVisit.handle()
 
-    eventHandler.init()
+    eventHandler.init({ handleScroll })
 
     eventHandler.on('missingHistoryItem', () => {
       if (typeof window !== 'undefined') {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -239,6 +239,13 @@ export type RouterInitParams = {
   initialPage: Page
   resolveComponent: PageResolver
   swapComponent: PageHandler
+  handleScroll: boolean
+}
+
+export type CurrentPageInitParams = Omit<RouterInitParams, 'handleScroll'>
+
+export type EventHandlerInitParams = {
+  handleScroll: boolean
 }
 
 export type PendingVisitOptions = {

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -10,6 +10,7 @@ export default function App({
   resolveComponent,
   titleCallback,
   onHeadUpdate,
+  handleScroll,
 }) {
   const [current, setCurrent] = useState({
     component: initialComponent || null,
@@ -29,6 +30,7 @@ export default function App({
     router.init({
       initialPage,
       resolveComponent,
+      handleScroll,
       swapComponent: async ({ component, page, preserveState }) => {
         setCurrent((current) => ({
           component,

--- a/packages/svelte/src/components/App.svelte
+++ b/packages/svelte/src/components/App.svelte
@@ -5,6 +5,7 @@
   export interface InertiaAppProps {
     initialComponent: ResolvedComponent
     initialPage: Page
+    handleScroll: boolean
     resolveComponent: ComponentResolver
   }
 </script>
@@ -18,6 +19,7 @@
   export let initialComponent: InertiaAppProps['initialComponent']
   export let initialPage: InertiaAppProps['initialPage']
   export let resolveComponent: InertiaAppProps['resolveComponent']
+  export let handleScroll: InertiaAppProps['handleScroll']
 
   let component = initialComponent
   let key: number | null = null
@@ -32,6 +34,7 @@
     router.init({
       initialPage,
       resolveComponent,
+      handleScroll,
       swapComponent: async (args) => {
         component = args.component as ResolvedComponent
         page = args.page

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -18,6 +18,7 @@ import useForm from './useForm'
 export interface InertiaAppProps {
   initialPage: Page
   initialComponent?: object
+  handleScroll?: boolean
   resolveComponent?: (name: string) => DefineComponent | Promise<DefineComponent>
   titleCallback?: (title: string) => string
   onHeadUpdate?: (elements: string[]) => void
@@ -57,7 +58,7 @@ const App: InertiaApp = defineComponent({
       default: () => () => {},
     },
   },
-  setup({ initialPage, initialComponent, resolveComponent, titleCallback, onHeadUpdate }) {
+  setup({ initialPage, initialComponent, resolveComponent, titleCallback, onHeadUpdate, handleScroll }) {
     component.value = initialComponent ? markRaw(initialComponent) : null
     page.value = initialPage
     key.value = null
@@ -69,6 +70,7 @@ const App: InertiaApp = defineComponent({
       router.init({
         initialPage,
         resolveComponent,
+        handleScroll,
         swapComponent: async (args: VuePageHandlerArgs) => {
           component.value = markRaw(args.component)
           page.value = args.page


### PR DESCRIPTION
Before I start going deep down the rabbithole making sure this is all cleaned up and tested etc, I'd like to get some feedback on if you're likely to accept this PR.

I've had some issues with inertia's history handling during a migration to inertia with a legacy app.

The problem is that inertia assumes that _all_ history manipulation is handled with inertia's router.push / router.replace methods, which is not the case.

There are two ways this causes issues:

1. When handling popstate, it assumes that the current history state should be handled by inertia. However it the state was not pushed by inertia, history.state will not contain a valid page object and should be ignored to prevent errors
2. When preserving scroll positions, the event handler assum
es that the url stored in currentPage is the correct current url, which it might not be if some other code has pushed a new state onto the stack in the meantime.

This causes a bug that means that if you are currently on and inertia page http://example.com/foo, and run `pushState({}, "", "http://example.com/foo?bar=123")`, you end up in a situation that inertia can't handle well
	a. If you scroll the page, the scroll handler will pushState with the latest inertia it knows about, and the query param will disappear
	b. If you hit the back button, inertia will try to handle the pop state event with the empty state with no inertia page in it, and will error out trying to render a component.

I would like to fix these issues to make inertia more interoperable especially during stack migrations, so please let me know if going down this path is likely to align with the project goals and if so I'll improve the handling here to make things a little smoother

