### PR TITLE
Avoiding the exception 'Uncaught (in promise) TypeError: Cannot read …

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -134,8 +134,8 @@ export class Request {
       'X-Inertia': true,
     }
 
-    if (currentPage.get().version) {
-      headers['X-Inertia-Version'] = currentPage.get().version
+    if (currentPage.get()?.version) {
+      headers['X-Inertia-Version'] = currentPage.get()?.version
     }
 
     return headers


### PR DESCRIPTION
…properties of undefined (reading 'version')' when submitting a form. The currentPage.get() function is returning undefined unpredictably.

The exception below is happening when submitting a simple form.

```sh
index.esm-DaZQPhBF.js:4 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'version')
    at Yr.getHeaders (index.esm-DaZQPhBF.js:4:57092)
    at Yr.send (index.esm-DaZQPhBF.js:4:55877)
    at da.send (index.esm-DaZQPhBF.js:4:57294)
    at $o.visit (index.esm-DaZQPhBF.js:4:59501)
    at $o.post (index.esm-DaZQPhBF.js:4:58281)
    at index.esm-DaZQPhBF.js:69:13670
```

Here is a laracasts post with some more details about the this issue.

https://laracasts.com/discuss/channels/inertia/cannot-read-properties-of-undefined-reading-version