### PR TITLE
fix: typehinting react useForm with interface (#2188)

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -6,7 +6,7 @@ import useRemember from './useRemember'
 type setDataByObject<TForm> = (data: TForm) => void
 type setDataByMethod<TForm> = (data: (previousData: TForm) => TForm) => void
 type setDataByKeyValuePair<TForm> = <K extends keyof TForm>(key: K, value: TForm[K]) => void
-type FormDataType = Record<string, FormDataConvertible>
+type FormDataType = Partial<Record<string, FormDataConvertible>>
 type FormOptions = Omit<VisitOptions, 'data'>
 
 export interface InertiaFormProps<TForm extends FormDataType> {


### PR DESCRIPTION
Hello! Really love all of the great work you are doing with Inertia, by far my favorite way to build web apps 🥳

This PR fixes https://github.com/inertiajs/inertia/issues/2188

A previous PR (https://github.com/inertiajs/inertia/pull/2060) introduced stricter typing for the useForm hook.

However, this unfortunately breaks typehinting the hook, since the hook now requires and index signature for the generic. This also causes in the new Laravel starter kit, see https://github.com/laravel/react-starter-kit/pull/31 for more info.