### PR TITLE
Fix anchor links on initial visits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ For changes prior to v1.0.0, see the [legacy releases](https://legacy.inertiajs.
 
 ## [Unreleased](https://github.com/inertiajs/inertia/compare/v2.0.3...HEAD)
 
-- Nothing yet
+- Fix anchor links on initial visits ([#2258](https://github.com/inertiajs/inertia/pull/2258))
 
 ## [v2.0.3](https://github.com/inertiajs/inertia/compare/v2.0.2...v2.0.3)
 

--- a/packages/core/src/initialVisit.ts
+++ b/packages/core/src/initialVisit.ts
@@ -93,7 +93,9 @@ export class InitialVisit {
     }
 
     currentPage.set(currentPage.get(), { preserveScroll: true, preserveState: true }).then(() => {
-      Scroll.restore(history.getScrollRegions())
+      if (navigationType.isReload()) {
+        Scroll.restore(history.getScrollRegions())
+      }
       fireNavigateEvent(currentPage.get())
     })
   }


### PR DESCRIPTION
This PR fixes a bug where full page visits with anchor links (ie. `/page#someid`) don't work because the scroll restoration interferes with it.

The reason we do scroll restoration on initial page visits is to maintain the scroll position when reloading a page (see #1360). However, we don't want to do this when it's just a standard "navigate" type.

This PR adds a navigation type to see if it's a "reload" visit, and only then does scroll restoration.