### PR TITLE
Fix history state errors

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -135,11 +135,11 @@ class History {
   }
 
   public getScrollRegions(): ScrollRegion[] {
-    return window.history.state.scrollRegions || []
+    return window.history.state?.scrollRegions || []
   }
 
   public getDocumentScrollPosition(): ScrollRegion {
-    return window.history.state.documentScrollPosition || { top: 0, left: 0 }
+    return window.history.state?.documentScrollPosition || { top: 0, left: 0 }
   }
 
   public replaceState(page: Page, cb: (() => void) | null = null): void {

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -119,6 +119,10 @@ class History {
   public saveDocumentScrollPosition(scrollRegion: ScrollRegion): void {
     queue.add(() => {
       return Promise.resolve().then(() => {
+        if (!window.history.state?.page) {
+          return
+        }
+
         this.doReplaceState(
           {
             page: window.history.state.page,


### PR DESCRIPTION
This fixes https://github.com/inertiajs/inertia/issues/2204 

We have experienced the same error from one of our apps, although it's still unclear exactly what's going on. I decided to push this PR because it may help people out there until someone smarter figures out the source of this.

To expand on what I know so far: client-side navigation is broken after performing a full page load through InertiaJS' 409 Conflict protocol ([a location visit](https://github.com/inertiajs/inertia/blob/37f9180faa17a86b714c9ce22f0a2f9866c8c47f/packages/core/src/response.ts#L79)). It doesn't occur for every route/component though. The error experienced is:
```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'page')
```
The error points to:
```javascript
this.doReplaceState({
  page: window.history.state.page,
  documentScrollPosition: e
}, this.current.url)
```
`window.history.state` is `null` above. 

Worth mentioning that ~1 month ago @joetannenbaum pushed a similar fix to a few lines of code above this one: https://github.com/inertiajs/inertia/pull/2200