### PR TITLE
do not pass url when storing scroll state to history

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -109,8 +109,7 @@ class History {
           {
             page: window.history.state.page,
             scrollRegions,
-          },
-          this.current.url!,
+          }
         )
       })
     })
@@ -123,8 +122,7 @@ class History {
           {
             page: window.history.state.page,
             documentScrollPosition: scrollRegion,
-          },
-          this.current.url!,
+          }
         )
       })
     })
@@ -176,7 +174,7 @@ class History {
       scrollRegions?: ScrollRegion[]
       documentScrollPosition?: ScrollRegion
     },
-    url: string,
+    url?: string,
   ): void {
     window.history.replaceState(
       {


### PR DESCRIPTION
If there was a change to the url that interia was not aware of, such as the modification of a query parameter, this would cause the current url to be overwritten and reset to a previous value.

Since passing the url is optional, we can simply not pass it to avoid overriding the url in any case.

Closes https://github.com/inertiajs/inertia/issues/2233