### PR TITLE
Fix location return history decryption throwing error

### DIFF
--- a/packages/core/src/initialVisit.ts
+++ b/packages/core/src/initialVisit.ts
@@ -61,7 +61,7 @@ export class InitialVisit {
     }
 
     history
-      .decrypt()
+      .decrypt(currentPage.get())
       .then(() => {
         const rememberedState = history.getState<Page['rememberedState']>(history.rememberedState, {})
         const scrollRegions = history.getScrollRegions()

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -21,6 +21,22 @@ test('can make a location visit', async ({ page }) => {
   await expect(dump['x-inertia']).toBeUndefined()
 })
 
+test('will avoid an extra reload after a location visit', async ({ page }) => {
+  pageLoads.watch(page, 2)
+
+  await page.goto('/links/location')
+  requests.listen(page)
+
+  await expect(requests.requests.length).toBe(0)
+  await page.getByRole('link', { name: 'Location visit' }).click()
+  const dump = await shouldBeDumpPage(page, 'get')
+  await expect(dump['x-inertia']).toBeUndefined()
+  // /location',
+  // /dump/get',
+  // /assets/index-*.js',
+  await expect(requests.requests.length).toBe(3)
+})
+
 test('will automatically cancel a pending visits when a new request is made', async ({ page }) => {
   pageLoads.watch(page)
 


### PR DESCRIPTION
### Issue this fixes

When performing a location redirect and the user is returned to the Inertia application, the location handler tries to decrypt the history of the page, but at this point, the state hasn't been set yet, so it returns `undefined` when attempting to access the page state through `window.history.state?.page`, this scenario is further explained by the issue [#2262](https://github.com/inertiajs/inertia/issues/2262)

### Analysis

I'm not sure why the `decrypt` function is being called at this stage in the `InitialVisit.handle()` as the router is being initialized and the history state hasn't been set yet, so trying to decrypt the history state at this point will always return `undefined`.

