### PR TITLE
Deferred: More descriptive Deferred data prop error

### DIFF
--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -9,7 +9,7 @@ interface DeferredProps {
 
 const Deferred = ({ children, data, fallback }: DeferredProps) => {
   if (!data) {
-    throw new Error('`<Deferred>` requires a `data` prop')
+    throw new Error('`<Deferred>` requires a `data` prop to be a string or array of strings')
   }
 
   const [loaded, setLoaded] = useState(false)


### PR DESCRIPTION
This one just tripped me up for a bit

I passed in an object instead of a string for the `data` prop and the error wasn't descriptive enough to help me.

- ❌ Error before: '`<Deferred>` requires a `data` prop'
- ✅ Error now: '`<Deferred>` requires a `data` prop to be a string or array of strings'