### PR TITLE
Allow better missed root handling

### DIFF
--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -45,7 +45,7 @@ type InertiaAppOptionsForCSR<SharedProps extends PageProps> = BaseInertiaAppOpti
         includeCSS?: boolean
         showSpinner?: boolean
       }
-  setup(options: SetupOptions<HTMLElement, SharedProps>): CreateInertiaAppSetupReturnType
+  setup(options: SetupOptions<HTMLElement | null, SharedProps>): CreateInertiaAppSetupReturnType
 }
 
 type CreateInertiaAppSSRContent = { head: string[]; body: string }
@@ -76,7 +76,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 > {
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
-  const initialPage = page || JSON.parse(el.dataset.page)
+  const initialPage = page || JSON.parse(el?.dataset.page || '{}')
   // @ts-expect-error
   const resolveComponent = (name) => Promise.resolve(resolve(name)).then((module) => module.default || module)
 

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -5,7 +5,7 @@ import App, { InertiaApp, InertiaAppProps, plugin } from './app'
 interface CreateInertiaAppProps {
   id?: string
   resolve: (name: string) => DefineComponent | Promise<DefineComponent> | { default: DefineComponent }
-  setup: (props: { el: Element; App: InertiaApp; props: InertiaAppProps; plugin: Plugin }) => void | VueApp
+  setup: (props: { el: HTMLElement | null; App: InertiaApp; props: InertiaAppProps; plugin: Plugin }) => void | VueApp
   title?: (title: string) => string
   progress?:
     | false
@@ -30,7 +30,7 @@ export default async function createInertiaApp({
 }: CreateInertiaAppProps): Promise<{ head: string[]; body: string }> {
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
-  const initialPage = page || JSON.parse(el.dataset.page)
+  const initialPage = page || JSON.parse(el?.dataset.page || '{}')
   const resolveComponent = (name) => Promise.resolve(resolve(name)).then((module) => module.default || module)
 
   let head = []


### PR DESCRIPTION
This PR ports existing logic from svelte adapter to the react and vue adapter to allow graceful handling for non-inertia pages:

before:
```js
const rootId = 'app'

if (document.getElementById(rootId)) {
  void createInertiaApp({
    id: rootId,
   //...
  })
}
```

after:
```js
void createInertiaApp({
  setup({ el, App, props }) {
    if (el) {...}
  }
})
```