### PR TITLE
Allow Object type for href prop

### DIFF
--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -53,7 +53,7 @@ const Link: InertiaLink = defineComponent({
       default: () => ({}),
     },
     href: {
-      type: String,
+      type: [String, Object],
       required: true,
     },
     method: {

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -53,7 +53,7 @@ const Link: InertiaLink = defineComponent({
       default: () => ({}),
     },
     href: {
-      type: [String, Object],
+      type: [String, Object] as PropType<InertiaLinkProps['href']>,
       required: true,
     },
     method: {


### PR DESCRIPTION
The Link component has support for the href prop to be an object. However, Object type is missing from the allowed types for the href prop. Resulting in route objects not being allowed to be passed to the href prop.

For example, with wayfinder a controller action or route can not be passed directly to the href prop of Link:

```vue
<script setup lang="ts">
import { about } from "@/routes/about";
</script>

<template>
    <div>
        <Link :href="about()"> About </Link>
    </div>
</template>
```

But this does not currently work as the only allowed type for href is String. The typescript definition allows the Object type so the IDE doesn't throw an error. The error is thrown in the browser:
<img width="723" alt="Screenshot 2025-04-04 at 10 04 31" src="https://github.com/user-attachments/assets/bb5e09de-cf24-448d-b718-871b4afe88dd" />
