### PR TITLE
Improve type checking of request data

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -65,27 +65,46 @@ export class Router {
     })
   }
 
-  public get(url: URL | string, data: RequestPayload = {}, options: VisitHelperOptions = {}): void {
+  public get<T extends RequestPayload = RequestPayload>(
+    url: URL | string,
+    data: T = {} as T,
+    options: VisitHelperOptions<T> = {},
+  ): void {
     return this.visit(url, { ...options, method: 'get', data })
   }
 
-  public post(url: URL | string, data: RequestPayload = {}, options: VisitHelperOptions = {}): void {
+  public post<T extends RequestPayload = RequestPayload>(
+    url: URL | string,
+    data: T = {} as T,
+    options: VisitHelperOptions<T> = {},
+  ): void {
     return this.visit(url, { preserveState: true, ...options, method: 'post', data })
   }
 
-  public put(url: URL | string, data: RequestPayload = {}, options: VisitHelperOptions = {}): void {
+  public put<T extends RequestPayload = RequestPayload>(
+    url: URL | string,
+    data: T = {} as T,
+    options: VisitHelperOptions<T> = {},
+  ): void {
     return this.visit(url, { preserveState: true, ...options, method: 'put', data })
   }
 
-  public patch(url: URL | string, data: RequestPayload = {}, options: VisitHelperOptions = {}): void {
+  public patch<T extends RequestPayload = RequestPayload>(
+    url: URL | string,
+    data: T = {} as T,
+    options: VisitHelperOptions<T> = {},
+  ): void {
     return this.visit(url, { preserveState: true, ...options, method: 'patch', data })
   }
 
-  public delete(url: URL | string, options: Omit<VisitOptions, 'method'> = {}): void {
+  public delete<T extends RequestPayload = RequestPayload>(
+    url: URL | string,
+    options: Omit<VisitOptions<T>, 'method'> = {},
+  ): void {
     return this.visit(url, { preserveState: true, ...options, method: 'delete' })
   }
 
-  public reload(options: ReloadOptions = {}): void {
+  public reload<T extends RequestPayload = RequestPayload>(options: ReloadOptions<T> = {}): void {
     if (typeof window === 'undefined') {
       return
     }
@@ -137,7 +156,7 @@ export class Router {
     })
   }
 
-  public visit(href: string | URL, options: VisitOptions = {}): void {
+  public visit<T extends RequestPayload = RequestPayload>(href: string | URL, options: VisitOptions<T> = {}): void {
     const visit: PendingVisit = this.getPendingVisit(href, {
       ...options,
       showProgress: options.showProgress ?? !options.async,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -103,9 +103,9 @@ export type LocationVisit = {
   preserveScroll: boolean
 }
 
-export type Visit = {
+export type Visit<T extends RequestPayload = RequestPayload> = {
   method: Method
-  data: RequestPayload
+  data: T
   replace: boolean
   preserveScroll: PreserveStateOption
   preserveState: PreserveStateOption
@@ -245,16 +245,19 @@ export type VisitCallbacks = {
   onPrefetching: GlobalEventCallback<'prefetching'>
 }
 
-export type VisitOptions = Partial<Visit & VisitCallbacks>
+export type VisitOptions<T extends RequestPayload = RequestPayload> = Partial<Visit<T> & VisitCallbacks>
 
-export type ReloadOptions = Omit<VisitOptions, 'preserveScroll' | 'preserveState'>
+export type ReloadOptions<T extends RequestPayload = RequestPayload> = Omit<
+  VisitOptions<T>,
+  'preserveScroll' | 'preserveState'
+>
 
 export type PollOptions = {
   keepAlive?: boolean
   autoStart?: boolean
 }
 
-export type VisitHelperOptions = Omit<VisitOptions, 'method' | 'data'>
+export type VisitHelperOptions<T extends RequestPayload = RequestPayload> = Omit<VisitOptions<T>, 'method' | 'data'>
 
 export type RouterInitParams = {
   initialPage: Page


### PR DESCRIPTION
All credit to @7nohe from https://github.com/inertiajs/inertia/pull/1537

```ts
import { router } from '@inertiajs/vue3'

type RequestData = { message: string }

router.post<RequestData>(url, { title: 'hello' }, options) // <- TypeScript Error
router.post<RequestData>(url, { message: 'hello' }, options) // <- OK
```