### PR TITLE
Remove empty payload from GET requests

### DIFF
--- a/packages/core/src/requestParams.ts
+++ b/packages/core/src/requestParams.ts
@@ -42,7 +42,7 @@ export class RequestParams {
   }
 
   public data() {
-    return this.params.method === 'get' ? {} : this.params.data
+    return this.params.method === 'get' ? null : this.params.data
   }
 
   public queryParams() {

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -108,7 +108,7 @@ test.describe('data', () => {
         await expect(dump.query).toEqual({ a: ['b', 'c'] })
         await expect(dump.method).toBe('get')
         await expect(dump.form).toEqual({})
-        await expect(dump.headers['content-type']).toBe('application/json')
+        await expect(dump.headers['content-type']).not.toBe('application/json')
       })
     })
   })
@@ -132,7 +132,7 @@ test.describe('data', () => {
       await expect(dump.query).toEqual({ foo: 'get' })
       await expect(dump.method).toBe('get')
       await expect(dump.form).toEqual({})
-      await expect(dump.headers['content-type']).toBe('application/json')
+      await expect(dump.headers['content-type']).not.toBe('application/json')
     })
 
     const data = [

--- a/tests/manual-visits.spec.ts
+++ b/tests/manual-visits.spec.ts
@@ -115,7 +115,7 @@ test.describe('Data', () => {
       await expect(dump.query).toEqual({ foo: 'visit' })
       await expect(dump.form).toEqual({})
       await expect(dump.files).toEqual({})
-      await expect(dump.headers['content-type']).toBe('application/json')
+      await expect(dump.headers['content-type']).not.toBe('application/json')
     })
 
     test.describe('GET method', () => {
@@ -128,7 +128,7 @@ test.describe('Data', () => {
         await expect(dump.query).toEqual({ bar: 'get' })
         await expect(dump.form).toEqual({})
         await expect(dump.files).toEqual({})
-        await expect(dump.headers['content-type']).toBe('application/json')
+        await expect(dump.headers['content-type']).not.toBe('application/json')
       })
 
       const data = [
@@ -148,7 +148,7 @@ test.describe('Data', () => {
           await expect(dump.query).toEqual({ a: ['b', 'c'] })
           await expect(dump.method).toBe('get')
           await expect(dump.form).toEqual({})
-          await expect(dump.headers['content-type']).toBe('application/json')
+          await expect(dump.headers['content-type']).not.toBe('application/json')
         })
       })
     })


### PR DESCRIPTION
All credit to @edgars-vasiljevs in https://github.com/inertiajs/inertia/pull/1651

Previously, all Inertia GET requests had `Content-Type: application/json` header applied because empty object is passed as a payload. Axios sees an object and sets content type to `application/json` even though request body is empty.

This led to odd behavior on Laravel's side as the request was interpreted as JSON.

The payload now defaults to `null`, thereby removing the `Content-Type: application/json` header from the request.