### PR TITLE
Progress: Make hide and reveal CSP-compatible

### DIFF
--- a/packages/core/src/progress-component.ts
+++ b/packages/core/src/progress-component.ts
@@ -338,27 +338,17 @@ const injectCSS = (color: string): void => {
   document.head.appendChild(element)
 }
 
-const hiddenStyles = (() => {
-  if (typeof document === 'undefined') {
-    return null
-  }
-
-  const el = document.createElement('style')
-
-  el.innerHTML = `#${baseComponentSelector} { display: none; }`
-
-  return el
-})()
-
 const show = () => {
-  if (hiddenStyles && document.head.contains(hiddenStyles)) {
-    return document.head.removeChild(hiddenStyles)
+  const element = document.getElementById(baseComponentSelector);
+  if (element) {
+    element.style.display = 'block';
   }
 }
 
 const hide = () => {
-  if (hiddenStyles && !document.head.contains(hiddenStyles)) {
-    document.head.appendChild(hiddenStyles)
+  const element = document.getElementById(baseComponentSelector);
+  if (element) {
+    element.style.display = 'none';
   }
 }
 


### PR DESCRIPTION
Removes the use of dynamically injected <style> tags to hide and reveal the progress bar. Instead, it toggles visibility by directly modifying the display property on the element.

This avoids triggering CSP violations in environments with a strict style-src policy that disallows 'unsafe-inline'. It also slightly simplifies the code.

Related issue: https://github.com/inertiajs/inertia/issues/2261