### PR TITLE
Corrects url search parameter merge logic to match behavior prior to v2.0.8

### DIFF
--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -1,4 +1,4 @@
-import { merge } from 'es-toolkit'
+import { mergeWith } from 'es-toolkit'
 import * as qs from 'qs'
 import { hasFiles } from './files'
 import { isFormData, objectToFormData } from './formData'
@@ -45,10 +45,15 @@ export function mergeDataIntoQueryString(
   const url = new URL(href.toString(), 'http://localhost')
 
   if (method === 'get' && Object.keys(data).length) {
-    url.search = qs.stringify(merge(qs.parse(url.search, { ignoreQueryPrefix: true }), data), {
-      encodeValuesOnly: true,
-      arrayFormat: qsArrayFormat,
-    })
+    url.search = qs.stringify(
+      mergeWith(qs.parse(url.search, { ignoreQueryPrefix: true }), data, (_, sourceValue, key, target) => {
+        if (sourceValue === undefined) delete target[key]
+      }),
+      {
+        encodeValuesOnly: true,
+        arrayFormat: qsArrayFormat,
+      },
+    )
     data = {}
   }
 


### PR DESCRIPTION
In versions prior to `v2.0.8`, `deepmerge` treated `undefined` values as a signal to remove keys from url search parameters.

So:
```js
router.reload({ data: { foo: undefined } });
```
would remove `?foo=...` from the URL entirely.

In [this commit](https://github.com/inertiajs/inertia/commit/2ed6671cd7288a8a0987a51a6f4bfc198241fc78), `deepmerge` was removed and replaced with an `es-toolkit` method of `merge` in [packages/core/src/url.ts](https://github.com/inertiajs/inertia/commit/2ed6671cd7288a8a0987a51a6f4bfc198241fc78#diff-5ccc166b9dbc7c5cb9816b15b8296bed6bc3363ff434a96da345e2e99d02779e). This new method **does not omit** `undefined` values and instead serializes them as empty strings.

So:
```js
{ foo: undefined } 
```
becomes

```js
?foo=
```

This is a subtle but breaking change in behavior and arguably a regression. 

Fixes issue #2310 