### PR TITLE
Fix for deferred props + prefetch links

### DIFF
--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -2,6 +2,17 @@ import { ReactElement, useEffect, useMemo, useState } from 'react'
 import { router } from '.'
 import usePage from './usePage'
 
+const urlWithoutHash = (url: URL | Location): URL => {
+  url = new URL(url.href)
+  url.hash = ''
+
+  return url
+}
+
+const isSameUrlWithoutHash = (url1: URL | Location, url2: URL | Location): boolean => {
+  return urlWithoutHash(url1).href === urlWithoutHash(url2).href
+}
+
 interface DeferredProps {
   children: ReactElement | number | string
   fallback: ReactElement | number | string
@@ -19,10 +30,10 @@ const Deferred = ({ children, data, fallback }: DeferredProps) => {
 
   useEffect(() => {
     const removeListener = router.on('start', (e) => {
-      if (
-        (e.detail.visit.only.length === 0 && e.detail.visit.except.length === 0) ||
-        e.detail.visit.only.find((key) => keys.includes(key))
-      ) {
+      const isPartialVisit = e.detail.visit.only.length > 0 || e.detail.visit.except.length > 0
+      const isReloadingKey = e.detail.visit.only.find((key) => keys.includes(key))
+
+      if (isSameUrlWithoutHash(e.detail.visit.url, window.location) && (!isPartialVisit || isReloadingKey)) {
         setLoaded(false)
       }
     })

--- a/packages/react/test-app/Pages/DeferredProps/WithPartialReload.jsx
+++ b/packages/react/test-app/Pages/DeferredProps/WithPartialReload.jsx
@@ -1,4 +1,4 @@
-import { Deferred, router, usePage } from '@inertiajs/react'
+import { Deferred, Link, router, usePage } from '@inertiajs/react'
 
 const WithPartialReload = ({ withOnly, withExcept }) => {
   const handleTriggerPartialReload = () => {
@@ -14,6 +14,9 @@ const WithPartialReload = ({ withOnly, withExcept }) => {
         <DeferredUsers />
       </Deferred>
       <button onClick={handleTriggerPartialReload}>Trigger a partial reload</button>
+      <Link href="/deferred-props/page-1" prefetch="hover">
+        Prefetch
+      </Link>
     </div>
   )
 }

--- a/tests/deferred-props.spec.ts
+++ b/tests/deferred-props.spec.ts
@@ -139,3 +139,28 @@ noReload.forEach((type) => {
     await expect(page.getByText('John Doe')).toBeVisible()
   })
 })
+
+test('it will not revert to fallback when fetching a url that is different than the current page', async ({ page }) => {
+  test.skip(process.env.PACKAGE !== 'react', 'React only test')
+
+  await page.goto(`/deferred-props/with-partial-reload/only`)
+
+  await expect(page.getByText('Loading...')).toBeVisible()
+
+  await page.waitForResponse(page.url())
+
+  await expect(page.getByText('Loading...')).not.toBeVisible()
+  await expect(page.getByText('John Doe')).toBeVisible()
+
+  const responsePromise = page.waitForResponse('/deferred-props/page-1')
+
+  await page.getByRole('link', { name: 'Prefetch' }).hover()
+
+  await page.waitForTimeout(100)
+
+  await expect(page.getByText('Loading...')).not.toBeVisible()
+
+  await responsePromise
+
+  await expect(page.getByText('John Doe')).toBeVisible()
+})


### PR DESCRIPTION
A bug surfaced when https://github.com/inertiajs/inertia/pull/2223 was merged where deferred props were reverting to their fallback state when prefetch links were hovered.

This PR fixes this behavior to only revert to fallback state if we are fetching the same URL.