### PR TITLE
Allow custom URL protocols

### DIFF
--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -36,7 +36,7 @@ export function mergeDataIntoQueryString(
   data: Record<string, FormDataConvertible>,
   qsArrayFormat: 'indices' | 'brackets' = 'brackets',
 ): [string, Record<string, FormDataConvertible>] {
-  const hasHost = /^[a-zA-Z]+:\/\//.test(href.toString())
+  const hasHost = /^[a-z][a-z0-9+.-]*:\/\//i.test(href.toString())
   const hasAbsolutePath = hasHost || href.toString().startsWith('/')
   const hasRelativePath = !hasAbsolutePath && !href.toString().startsWith('#') && !href.toString().startsWith('?')
   const hasSearch = href.toString().includes('?') || (method === 'get' && Object.keys(data).length)

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -36,7 +36,7 @@ export function mergeDataIntoQueryString(
   data: Record<string, FormDataConvertible>,
   qsArrayFormat: 'indices' | 'brackets' = 'brackets',
 ): [string, Record<string, FormDataConvertible>] {
-  const hasHost = /^https?:\/\//.test(href.toString())
+  const hasHost = /^[a-zA-Z]+:\/\//.test(href.toString())
   const hasAbsolutePath = hasHost || href.toString().startsWith('/')
   const hasRelativePath = !hasAbsolutePath && !href.toString().startsWith('#') && !href.toString().startsWith('?')
   const hasSearch = href.toString().includes('?') || (method === 'get' && Object.keys(data).length)


### PR DESCRIPTION
This PR slightly changes the host detection for URLs in order to properly support URLs that have a custom protocol.

**Why a custom protocol?**  ...you might ask.

Great question!

This will allow us to make use of Inertia within a NativePHP iOS application, where the internal URL protocol is `php://`.

With the current hardcoded check for `https?`, the URL generation ends up to become wrong when using a custom protocol.

As the regular expression still checks for the beginning of the string, I don't really see an issue with this.