### PR TITLE
Revamp useForm's generic types across adaptors

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,16 +10,21 @@ declare module 'axios' {
 export type Errors = Record<string, string>
 export type ErrorBag = Record<string, Errors>
 
+export type FormDataConvertibleValue = Blob | FormDataEntryValue | Date | boolean | number | null | undefined
 export type FormDataConvertible =
   | Array<FormDataConvertible>
   | { [key: string]: FormDataConvertible }
-  | Blob
-  | FormDataEntryValue
-  | Date
-  | boolean
-  | number
-  | null
-  | undefined
+  | FormDataConvertibleValue
+
+export type FormDataType<T extends object> = {
+  [K in keyof T]: T[K] extends FormDataConvertibleValue
+    ? T[K]
+    : T[K] extends (...args: unknown[]) => unknown
+      ? never
+      : T[K] extends object | Array<unknown>
+        ? FormDataType<T[K]>
+        : never
+}
 
 export type FormDataKeys<T extends Record<any, any>> = T extends T
   ? keyof T extends infer Key extends Extract<keyof T, string>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,6 +60,8 @@ export type FormDataValues<T, K extends FormDataKeys<T>> = K extends `${infer P}
       ? T[K & number]
       : never
 
+export type FormDataError<T> = Partial<Record<FormDataKeys<T>, string>>
+
 export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete'
 
 export type RequestPayload = Record<string, FormDataConvertible> | FormData

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,7 +7,30 @@ declare module 'axios' {
   }
 }
 
-export type Errors = Record<string, string>
+export type DefaultInertiaConfig = {
+  errorValueType: string
+}
+/** 
+ * Designed to allow overriding of some core types using TypeScript
+ * interface declaration merging.
+ * 
+ * @see {@link DefaultInertiaConfig} for keys to override
+ * @example
+ * ```ts
+ * declare module '@inertiajs/core' {
+ *   export interface InertiaConfig {
+ *     errorValueType: string[]
+ *   }
+ * }
+ * ```
+ */
+export interface InertiaConfig {}
+export type InertiaConfigFor<Key extends keyof DefaultInertiaConfig> = Key extends keyof InertiaConfig
+  ? InertiaConfig[Key]
+  : DefaultInertiaConfig[Key]
+export type ErrorValue = InertiaConfigFor<'errorValueType'>
+
+export type Errors = Record<string, ErrorValue>
 export type ErrorBag = Record<string, Errors>
 
 export type FormDataConvertibleValue = Blob | FormDataEntryValue | Date | boolean | number | null | undefined
@@ -60,7 +83,7 @@ export type FormDataValues<T, K extends FormDataKeys<T>> = K extends `${infer P}
       ? T[K & number]
       : never
 
-export type FormDataError<T> = Partial<Record<FormDataKeys<T>, string>>
+export type FormDataError<T> = Partial<Record<FormDataKeys<T>, ErrorValue>>
 
 export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete'
 

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -1,4 +1,5 @@
 import {
+  ErrorValue,
   FormDataError,
   FormDataKeys,
   FormDataType,
@@ -34,7 +35,7 @@ export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   setDefaults(fields: Partial<TForm>): void
   reset: (...fields: FormDataKeys<TForm>[]) => void
   clearErrors: (...fields: FormDataKeys<TForm>[]) => void
-  setError(field: FormDataKeys<TForm>, value: string): void
+  setError(field: FormDataKeys<TForm>, value: ErrorValue): void
   setError(errors: FormDataError<TForm>): void
   submit: (...args: [Method, string, FormOptions?] | [{ url: string; method: Method }, FormOptions?]) => void
   get: (url: string, options?: FormOptions) => void

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -1,5 +1,4 @@
 import {
-  FormDataConvertible,
   FormDataKeys,
   FormDataType,
   FormDataValues,
@@ -30,7 +29,7 @@ export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   setData: SetDataByObject<TForm> & SetDataByMethod<TForm> & SetDataByKeyValuePair<TForm>
   transform: (callback: (data: TForm) => object) => void
   setDefaults(): void
-  setDefaults(field: FormDataKeys<TForm>, value: FormDataConvertible): void
+  setDefaults<T extends FormDataKeys<TForm>>(field: T, value: FormDataValues<TForm, T>): void
   setDefaults(fields: Partial<TForm>): void
   reset: (...fields: FormDataKeys<TForm>[]) => void
   clearErrors: (...fields: FormDataKeys<TForm>[]) => void
@@ -197,7 +196,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
   )
 
   const setDefaultsFunction = useCallback(
-    (fieldOrFields?: FormDataKeys<TForm> | Partial<TForm>, maybeValue?: FormDataConvertible) => {
+    (fieldOrFields?: FormDataKeys<TForm> | Partial<TForm>, maybeValue?: unknown) => {
       if (typeof fieldOrFields === 'undefined') {
         setDefaults(() => data)
       } else {

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -1,6 +1,7 @@
 import {
   FormDataConvertible,
   FormDataKeys,
+  FormDataType,
   FormDataValues,
   Method,
   Progress,
@@ -14,11 +15,10 @@ import useRemember from './useRemember'
 
 type SetDataByObject<TForm> = (data: TForm) => void
 type SetDataByMethod<TForm> = (data: (previousData: TForm) => TForm) => void
-type SetDataByKeyValuePair<TForm extends Record<any, any>> = <K extends FormDataKeys<TForm>>(key: K, value: FormDataValues<TForm, K>) => void
-type FormDataType = Record<string, FormDataConvertible>
+type SetDataByKeyValuePair<TForm> = <K extends FormDataKeys<TForm>>(key: K, value: FormDataValues<TForm, K>) => void
 type FormOptions = Omit<VisitOptions, 'data'>
 
-export interface InertiaFormProps<TForm extends FormDataType> {
+export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   data: TForm
   isDirty: boolean
   errors: Partial<Record<FormDataKeys<TForm>, string>>
@@ -44,12 +44,12 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   delete: (url: string, options?: FormOptions) => void
   cancel: () => void
 }
-export default function useForm<TForm extends FormDataType>(initialValues?: TForm): InertiaFormProps<TForm>
-export default function useForm<TForm extends FormDataType>(
+export default function useForm<TForm extends FormDataType<TForm>>(initialValues?: TForm): InertiaFormProps<TForm>
+export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKey: string,
   initialValues?: TForm,
 ): InertiaFormProps<TForm>
-export default function useForm<TForm extends FormDataType>(
+export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKeyOrInitialValues?: string | TForm,
   maybeInitialValues?: TForm,
 ): InertiaFormProps<TForm> {

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -3,6 +3,7 @@ import type {
   Errors,
   FormDataConvertible,
   FormDataKeys,
+  FormDataType,
   Method,
   Page,
   PendingVisit,
@@ -16,10 +17,9 @@ import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
 import { writable, type Writable } from 'svelte/store'
 
-type FormDataType = Record<string, FormDataConvertible>
 type FormOptions = Omit<VisitOptions, 'data'>
 
-export interface InertiaFormProps<TForm extends FormDataType> {
+export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   isDirty: boolean
   errors: Partial<Record<FormDataKeys<TForm>, string>>
   hasErrors: boolean
@@ -47,14 +47,16 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   cancel(): void
 }
 
-export type InertiaForm<TForm extends FormDataType> = InertiaFormProps<TForm> & TForm
+export type InertiaForm<TForm extends FormDataType<TForm>> = InertiaFormProps<TForm> & TForm
 
-export default function useForm<TForm extends FormDataType>(data: TForm | (() => TForm)): Writable<InertiaForm<TForm>>
-export default function useForm<TForm extends FormDataType>(
+export default function useForm<TForm extends FormDataType<TForm>>(
+  data: TForm | (() => TForm),
+): Writable<InertiaForm<TForm>>
+export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKey: string,
   data: TForm | (() => TForm),
 ): Writable<InertiaForm<TForm>>
-export default function useForm<TForm extends FormDataType>(
+export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKeyOrData: string | TForm | (() => TForm),
   maybeData?: TForm | (() => TForm),
 ): Writable<InertiaForm<TForm>> {
@@ -86,7 +88,7 @@ export default function useForm<TForm extends FormDataType>(
     data() {
       return Object.keys(data).reduce((carry, key) => {
         return set(carry, key, get(this, key))
-      }, {} as FormDataType) as TForm
+      }, {} as TForm)
     },
     transform(callback) {
       transform = callback
@@ -114,7 +116,7 @@ export default function useForm<TForm extends FormDataType>(
             .filter((key) => has(clonedData, key))
             .reduce((carry, key) => {
               return set(carry, key, get(clonedData, key))
-            }, {} as FormDataType) as TForm,
+            }, {} as TForm),
         )
       }
 

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -1,6 +1,7 @@
 import type {
   ActiveVisit,
   Errors,
+  ErrorValue,
   FormDataError,
   FormDataKeys,
   FormDataType,
@@ -37,7 +38,7 @@ export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   defaults<T extends FormDataKeys<TForm>>(field: T, value: FormDataValues<TForm, T>): this
   reset(...fields: FormDataKeys<TForm>[]): this
   clearErrors(...fields: FormDataKeys<TForm>[]): this
-  setError(field: FormDataKeys<TForm>, value: string): this
+  setError(field: FormDataKeys<TForm>, value: ErrorValue): this
   setError(errors: FormDataError<TForm>): this
   submit: (...args: [Method, string, FormOptions?] | [{ url: string; method: Method }, FormOptions?]) => void
   get(url: string, options?: FormOptions): void
@@ -123,7 +124,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
 
       return this
     },
-    setError(fieldOrFields: FormDataKeys<TForm> | FormDataError<TForm>, maybeValue?: string) {
+    setError(fieldOrFields: FormDataKeys<TForm> | FormDataError<TForm>, maybeValue?: ErrorValue) {
       this.setStore('errors', {
         ...this.errors,
         ...((typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields) as Errors),

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -1,9 +1,9 @@
 import type {
   ActiveVisit,
   Errors,
-  FormDataConvertible,
   FormDataKeys,
   FormDataType,
+  FormDataValues,
   Method,
   Page,
   PendingVisit,
@@ -28,12 +28,12 @@ export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   recentlySuccessful: boolean
   processing: boolean
   setStore(data: TForm): void
-  setStore(key: FormDataKeys<TForm>, value?: FormDataConvertible): void
+  setStore<T extends FormDataKeys<TForm>>(key: T, value: FormDataValues<TForm, T>): void
   data(): TForm
   transform(callback: (data: TForm) => object): this
   defaults(): this
   defaults(fields: Partial<TForm>): this
-  defaults(field?: FormDataKeys<TForm>, value?: FormDataConvertible): this
+  defaults<T extends FormDataKeys<TForm>>(field: T, value: FormDataValues<TForm, T>): this
   reset(...fields: FormDataKeys<TForm>[]): this
   clearErrors(...fields: FormDataKeys<TForm>[]): this
   setError(field: FormDataKeys<TForm>, value: string): this
@@ -80,7 +80,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
     wasSuccessful: false,
     recentlySuccessful: false,
     processing: false,
-    setStore(keyOrData, maybeValue = undefined) {
+    setStore(keyOrData: keyof InertiaFormProps<TForm> | FormDataKeys<TForm> | TForm, maybeValue = undefined) {
       store.update((store) => {
         return typeof keyOrData === 'string' ? set(store, keyOrData, maybeValue) : Object.assign(store, keyOrData)
       })
@@ -94,7 +94,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
       transform = callback
       return this
     },
-    defaults(fieldOrFields?: FormDataKeys<TForm> | Partial<TForm>, maybeValue?: FormDataConvertible) {
+    defaults(fieldOrFields?: FormDataKeys<TForm> | Partial<TForm>, maybeValue?: unknown) {
       if (typeof fieldOrFields === 'undefined') {
         defaults = cloneDeep(this.data())
       } else {

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -1,6 +1,7 @@
 import type {
   ActiveVisit,
   Errors,
+  FormDataError,
   FormDataKeys,
   FormDataType,
   FormDataValues,
@@ -21,7 +22,7 @@ type FormOptions = Omit<VisitOptions, 'data'>
 
 export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   isDirty: boolean
-  errors: Partial<Record<FormDataKeys<TForm>, string>>
+  errors: FormDataError<TForm>
   hasErrors: boolean
   progress: Progress | null
   wasSuccessful: boolean
@@ -37,7 +38,7 @@ export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   reset(...fields: FormDataKeys<TForm>[]): this
   clearErrors(...fields: FormDataKeys<TForm>[]): this
   setError(field: FormDataKeys<TForm>, value: string): this
-  setError(errors: Errors): this
+  setError(errors: FormDataError<TForm>): this
   submit: (...args: [Method, string, FormOptions?] | [{ url: string; method: Method }, FormOptions?]) => void
   get(url: string, options?: FormOptions): void
   post(url: string, options?: FormOptions): void
@@ -122,7 +123,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
 
       return this
     },
-    setError(fieldOrFields: FormDataKeys<TForm> | Errors, maybeValue?: string) {
+    setError(fieldOrFields: FormDataKeys<TForm> | FormDataError<TForm>, maybeValue?: string) {
       this.setStore('errors', {
         ...this.errors,
         ...((typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields) as Errors),

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -1,4 +1,4 @@
-import { FormDataKeys, FormDataType, Method, Progress, router, VisitOptions } from '@inertiajs/core'
+import { FormDataKeys, FormDataType, FormDataValues, Method, Progress, router, VisitOptions } from '@inertiajs/core'
 import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
 import { reactive, watch } from 'vue'
@@ -16,7 +16,7 @@ export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   data(): TForm
   transform(callback: (data: TForm) => object): this
   defaults(): this
-  defaults(field: FormDataKeys<TForm>, value: FormDataConvertible): this
+  defaults<T extends FormDataKeys<TForm>>(field: T, value: FormDataValues<TForm, T>): this
   defaults(fields: Partial<TForm>): this
   reset(...fields: FormDataKeys<TForm>[]): this
   clearErrors(...fields: FormDataKeys<TForm>[]): this
@@ -71,7 +71,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
 
       return this
     },
-    defaults(fieldOrFields?: FormDataKeys<TForm> | Partial<TForm>, maybeValue?: FormDataConvertible) {
+    defaults(fieldOrFields?: FormDataKeys<TForm> | Partial<TForm>, maybeValue?: unknown) {
       if (typeof data === 'function') {
         throw new Error('You cannot call `defaults()` when using a function to define your form data.')
       }

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -1,12 +1,11 @@
-import { FormDataConvertible, FormDataKeys, Method, Progress, router, VisitOptions } from '@inertiajs/core'
+import { FormDataKeys, FormDataType, Method, Progress, router, VisitOptions } from '@inertiajs/core'
 import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
 import { reactive, watch } from 'vue'
 
-type FormDataType = Record<string, FormDataConvertible>
 type FormOptions = Omit<VisitOptions, 'data'>
 
-export interface InertiaFormProps<TForm extends FormDataType> {
+export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   isDirty: boolean
   errors: Partial<Record<FormDataKeys<TForm>, string>>
   hasErrors: boolean
@@ -32,14 +31,14 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   cancel(): void
 }
 
-export type InertiaForm<TForm extends FormDataType> = TForm & InertiaFormProps<TForm>
+export type InertiaForm<TForm extends FormDataType<TForm>> = TForm & InertiaFormProps<TForm>
 
-export default function useForm<TForm extends FormDataType>(data: TForm | (() => TForm)): InertiaForm<TForm>
-export default function useForm<TForm extends FormDataType>(
+export default function useForm<TForm extends FormDataType<TForm>>(data: TForm | (() => TForm)): InertiaForm<TForm>
+export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKey: string,
   data: TForm | (() => TForm),
 ): InertiaForm<TForm>
-export default function useForm<TForm extends FormDataType>(
+export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKeyOrData: string | TForm | (() => TForm),
   maybeData?: TForm | (() => TForm),
 ): InertiaForm<TForm> {

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -1,4 +1,5 @@
 import {
+  ErrorValue,
   FormDataError,
   FormDataKeys,
   FormDataType,
@@ -29,8 +30,8 @@ export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   defaults(fields: Partial<TForm>): this
   reset(...fields: FormDataKeys<TForm>[]): this
   clearErrors(...fields: FormDataKeys<TForm>[]): this
-  setError(field: FormDataKeys<TForm>, value: string): this
-  setError(errors: Record<FormDataKeys<TForm>, string>): this
+  setError(field: FormDataKeys<TForm>, value: ErrorValue): this
+  setError(errors: Record<FormDataKeys<TForm>, ErrorValue>): this
   submit: (...args: [Method, string, FormOptions?] | [{ url: string; method: Method }, FormOptions?]) => void
   get(url: string, options?: FormOptions): void
   post(url: string, options?: FormOptions): void
@@ -114,7 +115,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
 
       return this
     },
-    setError(fieldOrFields: FormDataKeys<TForm> | FormDataError<TForm>, maybeValue?: string) {
+    setError(fieldOrFields: FormDataKeys<TForm> | FormDataError<TForm>, maybeValue?: ErrorValue) {
       Object.assign(this.errors, typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields)
 
       this.hasErrors = Object.keys(this.errors).length > 0

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -1,4 +1,13 @@
-import { FormDataKeys, FormDataType, FormDataValues, Method, Progress, router, VisitOptions } from '@inertiajs/core'
+import {
+  FormDataError,
+  FormDataKeys,
+  FormDataType,
+  FormDataValues,
+  Method,
+  Progress,
+  router,
+  VisitOptions,
+} from '@inertiajs/core'
 import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
 import { reactive, watch } from 'vue'
@@ -7,7 +16,7 @@ type FormOptions = Omit<VisitOptions, 'data'>
 
 export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   isDirty: boolean
-  errors: Partial<Record<FormDataKeys<TForm>, string>>
+  errors: FormDataError<TForm>
   hasErrors: boolean
   processing: boolean
   progress: Progress | null
@@ -105,7 +114,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
 
       return this
     },
-    setError(fieldOrFields: FormDataKeys<TForm> | Record<FormDataKeys<TForm>, string>, maybeValue?: string) {
+    setError(fieldOrFields: FormDataKeys<TForm> | FormDataError<TForm>, maybeValue?: string) {
       Object.assign(this.errors, typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields)
 
       this.hasErrors = Object.keys(this.errors).length > 0


### PR DESCRIPTION
What started as a rework to solve allowing otherwise valid interfaces being provided directly via `useForm<SomeInterface>({...})` (fixing #2188), ended up as a total rework of the generic types they use and their uses and expanding on the work I did in #1649. Hell of a nerd snipe on myself thinking it could be solved.

All adaptors no longer have their own bespoke but functionally identical `FormDataType`, and now use one that I added to core. It should reject things that are invalid to be in the form (Functions come to mind on the typings, but anything that's not basic JSON data), which might cause some type issues for end users if they were doing something invalid to start with. If this is too tight, it can be made more permissive if that's something people want later.

Updated FormDataValues and FormDataKeys to dive down into arrays and TypeScript tuples correctly. I did quickly test all the playgrounds to make sure the adaptors use it for things like `defaults`/`setDefault`, `setData`/`setStore`, or `reset`. All of them work correctly even with arrays, with the *one* rub being that `reset` has a footgun with keys nested inside an array (if a default for the index on the array does not have a value set, it's behaviour is not well defined, ranging from setting the index to undefined or not resetting a value at all).

A type for form errors was extracted to core as `Partial<Record<FormDataKeys<TForm>, string>>` everywhere was verbose.

Relevant types have been exported on the core package for any third party client adaptors to use.

<details>
<summary>Demo of types</summary>

```ts
import { useForm } from '@inertiajs/vue3'

interface NestedType {
  id: number
  name: string
}
interface TestType {
  string: string
  number: number
  nested: NestedType
  array: NestedType[]
  tuple: [string, number, NestedType]
  typeObject: { union: 'foo' | 'bar' }
}
const form = useForm<TestType>({[...]})

form.string
//   ^? (property) TestType.string: string
form.number
//   ^? (property) TestType.number: number
form.nested
//   ^? (property) TestType.nested: NestedType
form.nested.id
//          ^? (property) NestedType.id: number
form.array[1].name
//            ^? (property) NestedType.name: string
form.tuple[0]
//         ^? (property) 0: string
form.tuple[1]
//         ^? (property) 1: number
form.tuple[2]
//         ^? (property) 2: NestedType
form.typeObject.union
//              ^? (property) union: "foo" | "bar"
form.errors['nested.name']
//           ^? (property) "nested.name"?: string
form.errors['tuple.2.name']
//          ^? (property) "tuple.2.name"?: string
form.errors['typeObject']
//          ^? (property) "typeObject"?: string
form.errors['typeObject.union']
//          ^? (property) "typeObject.union"?: string
form.reset('tuple.2.name')
form.defaults('tuple.0', 'newString')
form.defaults('tuple.1', 2)
form.defaults('tuple.2', { id: 1, name: 'Types!' })
form.defaults('typeObject.union', 'foo')
```
</details>

I expect this is not a breaking type change for either users or third party client adaptors, unless they were technically invalid to start with. I could be wrong though. The form error type might be wrong if a server side adaptor does not follow what Laravel's error bag does for nested data structures (IE: `array.0.key`), but it's not like it was being handled correctly before anyway. This is about two days of head bashing and checking done, but open to people poking holes where they can.