### PR TITLE
On back button, fetch from server if version hash is not current

### DIFF
--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -84,6 +84,11 @@ class EventHandler {
     history
       .decrypt(state.page)
       .then((data) => {
+        if (currentPage.get().version !== data.version) {
+          this.onMissingHistoryItem()
+          return
+        }
+
         currentPage.setQuietly(data, { preserveState: false }).then(() => {
           Scroll.restore(history.getScrollRegions())
           fireNavigateEvent(currentPage.get())

--- a/packages/react/test-app/Pages/History/Version.jsx
+++ b/packages/react/test-app/Pages/History/Version.jsx
@@ -1,0 +1,10 @@
+import { Link } from '@inertiajs/react'
+
+export default () => {
+  return (
+    <>
+      <Link href="/history/version/1">Page 1</Link>
+      <Link href="/history/version/2">Page 2</Link>
+    </>
+  )
+}

--- a/packages/svelte/test-app/Pages/History/Page.svelte
+++ b/packages/svelte/test-app/Pages/History/Page.svelte
@@ -1,17 +1,7 @@
 <script>
-  import { inertia, router } from '@inertiajs/svelte'
+  import { inertia } from '@inertiajs/svelte'
 
-  export let pageNumber
-    export let multiByte
 </script>
 
-<a href="/history/1" use:inertia>Page 1</a>
-<a href="/history/2" use:inertia>Page 2</a>
-<a href="/history/3" use:inertia>Page 3</a>
-<a href="/history/4" use:inertia>Page 4</a>
-<a href="/history/5" use:inertia>Page 5</a>
-
-<button on:click={() => router.clearHistory()}>Clear History</button>
-
-<div>This is page {pageNumber}.</div>
-<div>Multi byte character: { multiByte }</div>
+<a href="/history/version/1" use:inertia>Page 1</a>
+<a href="/history/version/2" use:inertia>Page 2</a>

--- a/packages/svelte/test-app/Pages/History/Page.svelte
+++ b/packages/svelte/test-app/Pages/History/Page.svelte
@@ -1,7 +1,17 @@
 <script>
-  import { inertia } from '@inertiajs/svelte'
+  import { inertia, router } from '@inertiajs/svelte'
 
+  export let pageNumber
+    export let multiByte
 </script>
 
-<a href="/history/version/1" use:inertia>Page 1</a>
-<a href="/history/version/2" use:inertia>Page 2</a>
+<a href="/history/1" use:inertia>Page 1</a>
+<a href="/history/2" use:inertia>Page 2</a>
+<a href="/history/3" use:inertia>Page 3</a>
+<a href="/history/4" use:inertia>Page 4</a>
+<a href="/history/5" use:inertia>Page 5</a>
+
+<button on:click={() => router.clearHistory()}>Clear History</button>
+
+<div>This is page {pageNumber}.</div>
+<div>Multi byte character: { multiByte }</div>

--- a/packages/svelte/test-app/Pages/History/Version.svelte
+++ b/packages/svelte/test-app/Pages/History/Version.svelte
@@ -1,0 +1,7 @@
+<script>
+  import { inertia } from '@inertiajs/svelte'
+
+</script>
+
+<a href="/history/version/1" use:inertia>Page 1</a>
+<a href="/history/version/2" use:inertia>Page 2</a>

--- a/packages/vue3/test-app/Pages/History/Version.vue
+++ b/packages/vue3/test-app/Pages/History/Version.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+
+defineProps<{ pageNumber: number }>()
+</script>
+
+<template>
+  <Link href="/history/version/1">Page 1</Link>
+  <Link href="/history/version/2">Page 2</Link>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -259,6 +259,16 @@ app.get('/history/:pageNumber', (req, res) => {
   })
 })
 
+app.get('/history/version/:pageNumber', (req, res) => {
+  inertia.render(req, res, {
+    component: 'History/Version',
+    props: {
+      pageNumber: req.params.pageNumber,
+    },
+    version: req.params.pageNumber === '1' ? 'version-1' : 'version-2',
+  })
+})
+
 app.get('/when-visible', (req, res) => {
   const page = () =>
     inertia.render(req, res, {

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -138,3 +138,17 @@ test('url will update after scrolling and pressing back', async ({ page }) => {
   await page.waitForTimeout(200)
   await page.waitForURL('/history/1')
 })
+
+test('will pull from server if history version is different than current version when pressing back', async ({
+  page,
+}) => {
+  await page.goto('/history/version/1')
+  await page.waitForURL('/history/version/1')
+  await clickAndWaitForResponse(page, 'Page 2', '/history/version/2')
+
+  requests.listen(page)
+
+  await page.goBack()
+  await page.waitForURL('/history/version/1')
+  await expect(requests.requests).toHaveLength(1)
+})

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -150,5 +150,6 @@ test('will pull from server if history version is different than current version
 
   await page.goBack()
   await page.waitForURL('/history/version/1')
+  await page.waitForTimeout(200)
   await expect(requests.requests).toHaveLength(1)
 })


### PR DESCRIPTION
This PR adds a check to the pop state listener that checks if the version hash in the history state is the current version hash, if it isn't, it will fetch the response fresh from the server.