### PR TITLE
Prevent duplicate render of the initial page in React

### DIFF
--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -11,6 +11,8 @@ export default function App({
   titleCallback,
   onHeadUpdate,
 }) {
+  let currentIsInitialPage = true
+
   const [current, setCurrent] = useState({
     component: initialComponent || null,
     page: initialPage,
@@ -30,6 +32,11 @@ export default function App({
       initialPage,
       resolveComponent,
       swapComponent: async ({ component, page, preserveState }) => {
+        if (currentIsInitialPage) {
+          currentIsInitialPage = false
+          return
+        }
+
         setCurrent((current) => ({
           component,
           page,


### PR DESCRIPTION
This took some serious debugging, but I found the reason why the React package renders the initial page twice!

If you follow in the core package: `router.init()` => `InitialVisit.handle()` => `InitialVisit.handleDefault()`, then `handleDefault` will call `set()` on the `currentPage` page instance. At the end of that method, it will call `this.swap` which essentially calls the `swapComponent` callback from the packages.

So, in the React package we have:

```ts
const [current, setCurrent] = useState({
  component: initialComponent || null,
  page: initialPage,
  key: null,
})

useEffect(() => {
  router.init({
    // ...
    swapComponent: async ({ component, page, preserveState }) => {
      setCurrent((current) => ({
        component,
        page,
        key: preserveState ? current.key : Date.now(),
      }))
    },
  })

  // ...
}, [])
```

This would call `setCurrent` but with the same object as that was initially set in `useState()`, which then leads to a rerender. I've introduced a `currentIsInitialPage` variable to prevent this from happening, just once on the initial page.
