### PR TITLE
Initialize router before components in React

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -34,6 +34,10 @@ class CurrentPage {
     return this
   }
 
+  public setSwapComponent(swapComponent: PageHandler): void {
+    this.swapComponent = swapComponent
+  }
+
   public set(
     page: Page,
     {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -17,6 +17,7 @@ import {
   GlobalEventResult,
   InFlightPrefetch,
   Page,
+  PageHandler,
   PendingVisit,
   PendingVisitOptions,
   PollOptions,
@@ -63,6 +64,10 @@ export class Router {
     eventHandler.on('loadDeferredProps', () => {
       this.loadDeferredProps()
     })
+  }
+
+  public setSwapComponent(swapComponent: PageHandler): void {
+    currentPage.setSwapComponent(swapComponent)
   }
 
   public get<T extends RequestPayload = RequestPayload>(

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -1,5 +1,5 @@
 import { createHeadManager, router } from '@inertiajs/core'
-import { createElement, useMemo, useState } from 'react'
+import { createElement, useEffect, useMemo, useState } from 'react'
 import HeadContext from './HeadContext'
 import PageContext from './PageContext'
 
@@ -31,18 +31,22 @@ export default function App({
     router.init({
       initialPage,
       resolveComponent,
-      swapComponent: async ({ component, page, preserveState }) => {
-        setCurrent((current) => ({
-          component,
-          page,
-          key: preserveState ? current.key : Date.now(),
-        }))
-      },
+      swapComponent: async () => {},
     })
 
     router.on('navigate', () => headManager.forceUpdate())
     isRouterInitialized = true
   }
+
+  useEffect(() => {
+    router.setSwapComponent(async ({ component, page, preserveState }) => {
+      setCurrent((current) => ({
+        component,
+        page,
+        key: preserveState ? current.key : Date.now(),
+      }))
+    })
+  }, [])
 
   if (!current.component) {
     return createElement(

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -1,7 +1,9 @@
 import { createHeadManager, router } from '@inertiajs/core'
-import { createElement, useEffect, useMemo, useState } from 'react'
+import { createElement, useMemo, useState } from 'react'
 import HeadContext from './HeadContext'
 import PageContext from './PageContext'
+
+let isRouterInitialized = false
 
 export default function App({
   children,
@@ -25,7 +27,7 @@ export default function App({
     )
   }, [])
 
-  useEffect(() => {
+  if (!isRouterInitialized) {
     router.init({
       initialPage,
       resolveComponent,
@@ -39,7 +41,8 @@ export default function App({
     })
 
     router.on('navigate', () => headManager.forceUpdate())
-  }, [])
+    isRouterInitialized = true
+  }
 
   if (!current.component) {
     return createElement(

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -33,8 +33,6 @@ export default function App({
       resolveComponent,
       swapComponent: async () => {},
     })
-
-    router.on('navigate', () => headManager.forceUpdate())
     isRouterInitialized = true
   }
 
@@ -46,6 +44,8 @@ export default function App({
         key: preserveState ? current.key : Date.now(),
       }))
     })
+
+    router.on('navigate', () => headManager.forceUpdate())
   }, [])
 
   if (!current.component) {


### PR DESCRIPTION
As reported in #2366 if we try to run make a request with router inside a useEffect() and the page is the first page loaded it will fail because router is not initialized yet because of how react executes the order of useEffects (bottom to top).

To fix it I splitted the router init, adding a setter for the swapComponent handler to set it inside an useEffect (mandatory).