### PR TITLE
Remove `setSwapComponent` method and cleanup after PR #2379

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -34,10 +34,6 @@ class CurrentPage {
     return this
   }
 
-  public setSwapComponent(swapComponent: PageHandler): void {
-    this.swapComponent = swapComponent
-  }
-
   public set(
     page: Page,
     {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -18,7 +18,6 @@ import {
   GlobalEventResult,
   InFlightPrefetch,
   Page,
-  PageHandler,
   PendingVisit,
   PendingVisitOptions,
   PollOptions,
@@ -65,10 +64,6 @@ export class Router {
     eventHandler.on('loadDeferredProps', () => {
       this.loadDeferredProps()
     })
-  }
-
-  public setSwapComponent(swapComponent: PageHandler): void {
-    currentPage.setSwapComponent(swapComponent)
   }
 
   public get<T extends RequestPayload = RequestPayload>(

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -3,7 +3,7 @@ import { createElement, useEffect, useMemo, useState } from 'react'
 import HeadContext from './HeadContext'
 import PageContext from './PageContext'
 
-let isRouterInitialized = false
+let routerIsInitialized = false
 let currentIsInitialPage = true
 
 export default function App({
@@ -28,31 +28,27 @@ export default function App({
     )
   }, [])
 
-  if (!isRouterInitialized) {
+  if (!routerIsInitialized) {
     router.init({
       initialPage,
       resolveComponent,
-      swapComponent: async () => {
-        currentIsInitialPage = false
+      swapComponent: async ({ component, page, preserveState }) => {
+        if (currentIsInitialPage) {
+          currentIsInitialPage = false
+          return
+        }
+
+        setCurrent((current) => ({
+          component,
+          page,
+          key: preserveState ? current.key : Date.now(),
+        }))
       },
     })
-    isRouterInitialized = true
+    routerIsInitialized = true
   }
 
   useEffect(() => {
-    router.setSwapComponent(async ({ component, page, preserveState }) => {
-      if (currentIsInitialPage) {
-        currentIsInitialPage = false
-        return
-      }
-
-      setCurrent((current) => ({
-        component,
-        page,
-        key: preserveState ? current.key : Date.now(),
-      }))
-    })
-
     router.on('navigate', () => headManager.forceUpdate())
   }, [])
 

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -29,9 +29,10 @@ export default function App({
   const routerIsInitialized = useRef(false)
 
   const swapComponentRef = useRef<PageHandler>(async () => {
-    // Dummy function so that we can initialize the router outside of the
-    // useEffect hook, so that router.reload() can be called on mount.
-    // We set the real swapComponent function in the useEffect below.
+    // Dummy function so we can init the router synchronously. This is needed
+    // so `router.reload()` works right away on mount in any component.
+    // We swap in the real function with the useEffect hook below.
+    currentIsInitialPage.current = false
   })
 
   if (!routerIsInitialized.current) {

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -1,4 +1,4 @@
-import { createHeadManager, router } from '@inertiajs/core'
+import { createHeadManager, PageHandler, router } from '@inertiajs/core'
 import { createElement, useEffect, useMemo, useRef, useState } from 'react'
 import HeadContext from './HeadContext'
 import PageContext from './PageContext'
@@ -28,7 +28,7 @@ export default function App({
   const currentIsInitialPage = useRef(true)
   const routerIsInitialized = useRef(false)
 
-  const swapComponentRef = useRef(async (params) => {
+  const swapComponentRef = useRef<PageHandler>(async () => {
     // Dummy function so that we can initialize the router outside of the
     // useEffect hook, so that router.reload() can be called on mount.
     // We set the real swapComponent function in the useEffect below.
@@ -38,7 +38,7 @@ export default function App({
     router.init({
       initialPage,
       resolveComponent,
-      swapComponent: (params) => swapComponentRef.current(params),
+      swapComponent: (args) => swapComponentRef.current(args),
     })
 
     routerIsInitialized.current = true

--- a/packages/react/test-app/Pages/Visits/ReloadOnMount.jsx
+++ b/packages/react/test-app/Pages/Visits/ReloadOnMount.jsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react'
 export default (props) => {
   useEffect(() => {
     router.reload({ only: ['name'] })
-  })
+  }, [])
 
   return <div>Name is {props.name}</div>
 }

--- a/packages/react/test-app/Pages/Visits/ReloadOnMount.jsx
+++ b/packages/react/test-app/Pages/Visits/ReloadOnMount.jsx
@@ -3,9 +3,7 @@ import { useEffect } from 'react'
 
 export default (props) => {
   useEffect(() => {
-    setTimeout(() => {
-      router.reload({ only: ['name'] })
-    })
+    router.reload({ only: ['name'] })
   })
 
   return <div>Name is {props.name}</div>


### PR DESCRIPTION
This is a cleanup of PR #2379.

* `isRouterInitialized` has been renamed to `routerIsInitialized`.
* ~~The `routerIsInitialized` bool was enough to fix the problem. The additional `setSwapComponent` logic doesn't seem to provide any benefits. Perhaps this was needed before `currentIsInitialPage` [was introduced](https://github.com/inertiajs/inertia/pull/2377), but I can't reproduce it.~~
* The `setSwapComponent` has been removed to prevent introducing another public method on the core router. The swapping of the `swapComponent` method is now handled internally in `App.ts`. `swapComponent` is now simply a variable that gets replaced in the `useEffect` hook.
* There was already a test for this (*can reload on mount* in `manual-visits.spec.ts`) but in the React implementation it was using a `setTimeout` to overcome the [initial problem](https://github.com/inertiajs/inertia/issues/2340). The `setTimeout` is removed now.