### PR TITLE
Use ReactNode type for children props

### DIFF
--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useMemo, useState } from 'react'
+import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { router } from '.'
 import usePage from './usePage'
 
@@ -14,8 +14,8 @@ const isSameUrlWithoutHash = (url1: URL | Location, url2: URL | Location): boole
 }
 
 interface DeferredProps {
-  children: ReactElement | number | string
-  fallback: ReactElement | number | string
+  children: ReactNode
+  fallback: ReactNode
   data: string | string[]
 }
 

--- a/packages/react/src/WhenVisible.ts
+++ b/packages/react/src/WhenVisible.ts
@@ -1,9 +1,9 @@
 import { ReloadOptions, router } from '@inertiajs/core'
-import { createElement, ReactElement, useCallback, useEffect, useRef, useState } from 'react'
+import { createElement, ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
 interface WhenVisibleProps {
-  children: ReactElement | number | string
-  fallback: ReactElement | number | string
+  children: ReactNode
+  fallback: ReactNode
   data?: string | string[]
   params?: ReloadOptions
   buffer?: number


### PR DESCRIPTION
ReactNode includes all the possible renderable types. The current definitions misses some types, this will throw type error for example:

```
<Deferred data="options" fallback={<span>Fallback</span>}
<div>first line</div>
<div>second line</div>
</Deferred>
```