### PR TITLE
Make Svelte's <Deferred> not crash in an SSR environment

### DIFF
--- a/packages/svelte/src/components/Deferred.svelte
+++ b/packages/svelte/src/components/Deferred.svelte
@@ -7,16 +7,20 @@
   const keys = Array.isArray(data) ? data : [data]
   let loaded = false
 
-  const unsubscribe = page.subscribe(({ props }) => {
-    // Ensures the slot isn't loaded before the deferred props are available
-    window.queueMicrotask(() => {
-      loaded = keys.every((key) => typeof props[key] !== 'undefined')
-    })
-  })
+  const isServer = typeof window === 'undefined'
 
-  onDestroy(() => {
-    unsubscribe()
-  })
+  if (!isServer) {
+    const unsubscribe = page.subscribe(({ props }) => {
+      // Ensures the slot isn't loaded before the deferred props are available
+      window.queueMicrotask(() => {
+        loaded = keys.every((key) => typeof props[key] !== 'undefined')
+      })
+    })
+  
+    onDestroy(() => {
+      unsubscribe()
+    })
+  }
 
   if (!$$slots.fallback) {
     throw new Error('`<Deferred>` requires a `<svelte:fragment slot="fallback">` slot')


### PR DESCRIPTION
The Deferred Svelte component calls `window.queueMicrotask`. In SSR, `window` is unavailable, leading to SSR throwing: 

```
ReferenceError: window is not defined
```

In SSR, `<Deferred>` props don't need to be rendered at all by definition, so the component should check if `window` is available before scheduling the microtask.