### PR TITLE
Call `provider.update` outside useEffect block to support SSR

### DIFF
--- a/packages/react/src/Head.ts
+++ b/packages/react/src/Head.ts
@@ -11,6 +11,7 @@ type InertiaHead = FunctionComponent<InertiaHeadProps>
 const Head: InertiaHead = function ({ children, title }) {
   const headManager = useContext(HeadContext)
   const provider = useMemo(() => headManager.createProvider(), [headManager])
+  const isServer = typeof window === 'undefined'
 
   useEffect(() => {
     provider.reconnect()
@@ -97,7 +98,9 @@ const Head: InertiaHead = function ({ children, title }) {
     return computed
   }
 
-  provider.update(renderNodes(children))
+  if (isServer) {
+    provider.update(renderNodes(children))
+  }
 
   return null
 }


### PR DESCRIPTION
This restores the call to `provider.update` that was moved to a useEffect block in #2328.

It's no problem to call the method both inside and outside the useEffect block as the update method is debounced, so it's only executed once.

Fixes #2394 