### PR TITLE
Introduce `skipNullsInQueryString` option

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -340,6 +340,7 @@ export class Router {
       errorBag: '',
       forceFormData: false,
       queryStringArrayFormat: 'brackets',
+      skipNullsInQueryString: false,
       async: false,
       showProgress: true,
       fresh: false,
@@ -355,6 +356,7 @@ export class Router {
       mergedOptions.method,
       mergedOptions.forceFormData,
       mergedOptions.queryStringArrayFormat,
+      mergedOptions.skipNullsInQueryString,
     )
 
     const visit = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -116,6 +116,7 @@ export type Visit<T extends RequestPayload = RequestPayload> = {
   errorBag: string | null
   forceFormData: boolean
   queryStringArrayFormat: 'indices' | 'brackets'
+  skipNullsInQueryString: boolean
   async: boolean
   showProgress: boolean
   prefetch: boolean

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -14,6 +14,7 @@ export const transformUrlAndData = (
   method: Method,
   forceFormData: VisitOptions['forceFormData'],
   queryStringArrayFormat: VisitOptions['queryStringArrayFormat'],
+  skipNullsInQueryString: VisitOptions['skipNullsInQueryString'] = false,
 ): [URL, RequestPayload] => {
   let url = typeof href === 'string' ? hrefToUrl(href) : href
 
@@ -25,7 +26,7 @@ export const transformUrlAndData = (
     return [url, data]
   }
 
-  const [_href, _data] = mergeDataIntoQueryString(method, url, data, queryStringArrayFormat)
+  const [_href, _data] = mergeDataIntoQueryString(method, url, data, queryStringArrayFormat, skipNullsInQueryString)
 
   return [hrefToUrl(_href), _data]
 }
@@ -35,6 +36,7 @@ export function mergeDataIntoQueryString(
   href: URL | string,
   data: Record<string, FormDataConvertible>,
   qsArrayFormat: 'indices' | 'brackets' = 'brackets',
+  skipNullsInQueryString: boolean = false,
 ): [string, Record<string, FormDataConvertible>] {
   const hasHost = /^[a-z][a-z0-9+.-]*:\/\//i.test(href.toString())
   const hasAbsolutePath = hasHost || href.toString().startsWith('/')
@@ -54,6 +56,7 @@ export function mergeDataIntoQueryString(
       {
         encodeValuesOnly: true,
         arrayFormat: qsArrayFormat,
+        skipNulls: skipNullsInQueryString,
       },
     )
     data = {}

--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -34,6 +34,7 @@ interface BaseInertiaLinkProps {
   onSuccess?: () => void
   onError?: () => void
   queryStringArrayFormat?: 'indices' | 'brackets'
+  skipNullsInQueryString?: boolean
   async?: boolean
   cacheFor?: number | string
   prefetch?: boolean | LinkPrefetchOption | LinkPrefetchOption[]
@@ -58,6 +59,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
       except = [],
       headers = {},
       queryStringArrayFormat = 'brackets',
+      skipNullsInQueryString = false,
       async = false,
       onClick = noop,
       onCancelToken = noop,
@@ -84,6 +86,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
       typeof href === 'object' ? href.url : href || '',
       data,
       queryStringArrayFormat,
+      skipNullsInQueryString,
     )
     const url = _href
     data = _data

--- a/packages/svelte/src/components/Link.svelte
+++ b/packages/svelte/src/components/Link.svelte
@@ -19,6 +19,7 @@
   export let except: string[] = []
   export let headers: Record<string, string> = {}
   export let queryStringArrayFormat: 'brackets' | 'indices' = 'brackets'
+  export let skipNullsInQueryString: boolean = false
   export let async: boolean = false
   export let prefetch: boolean | LinkPrefetchOption | LinkPrefetchOption[] = false
   export let cacheFor: CacheForOption | CacheForOption[] = 0
@@ -48,6 +49,7 @@
     except,
     headers,
     queryStringArrayFormat,
+    skipNullsInQueryString,
     async,
     prefetch,
     cacheFor,

--- a/packages/svelte/src/link.ts
+++ b/packages/svelte/src/link.ts
@@ -169,6 +169,7 @@ function link(
       typeof params.href === 'object' ? params.href.url : node.href || params.href || '',
       params.data || {},
       params.queryStringArrayFormat || 'brackets',
+      params.skipNullsInQueryString || false,
     )
   }
 

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -33,6 +33,7 @@ export interface InertiaLinkProps {
   onSuccess?: () => void
   onError?: () => void
   queryStringArrayFormat?: 'brackets' | 'indices'
+  skipNullsInQueryString?: boolean
   async?: boolean
   prefetch?: boolean | LinkPrefetchOption | LinkPrefetchOption[]
   cacheFor?: CacheForOption | CacheForOption[]
@@ -87,6 +88,10 @@ const Link: InertiaLink = defineComponent({
     queryStringArrayFormat: {
       type: String as PropType<'brackets' | 'indices'>,
       default: 'brackets',
+    },
+    skipNullsInQueryString: {
+      type: Boolean,
+      default: false,
     },
     async: {
       type: Boolean,
@@ -187,6 +192,7 @@ const Link: InertiaLink = defineComponent({
         typeof props.href === 'object' ? props.href.url : props.href || '',
         props.data,
         props.queryStringArrayFormat,
+        props.skipNullsInQueryString,
       ),
     )
     const href = computed(() => mergeDataArray.value[0])


### PR DESCRIPTION
This PR introduces a `skipNullsInQueryString` visit option to exclude `null` values from the query string:

```js
import { router } from '@inertiajs/react'

router.reload({ data: { foo: null } })
```

With the new option, it would make a request to `/` instead of `/?foo`. Still WIP because it misses tests, and I want to investigate if we could introduce a way to set this globally (same for `queryStringArrayFormat`).