### PR TITLE
Fix for `useRemember` in React

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -28,7 +28,9 @@ class History {
 
   public restore(key: string): unknown {
     if (!isServer) {
-      return this.initialState?.[this.rememberedState]?.[key]
+      return this.current[this.rememberedState]
+        ? this.current[this.rememberedState]?.[key]
+        : this.initialState?.[this.rememberedState]?.[key]
     }
   }
 

--- a/tests/remember.spec.ts
+++ b/tests/remember.spec.ts
@@ -73,6 +73,18 @@ test.describe('Remember (local state caching)', () => {
     await expect(page.locator('.b-name')).toHaveValue('B1')
     await expect(page.locator('.b-remember')).toBeChecked()
     await expect(page.locator('.b-untracked')).toHaveValue('')
+
+    // try again with updated values
+    await page.fill('#name', 'E')
+    await page.uncheck('#remember')
+
+    await page.getByRole('link', { name: 'Navigate away' }).click()
+    await shouldBeDumpPage(page, 'get')
+    await page.goBack()
+
+    await expect(page).toHaveURL('remember/multiple-components')
+    await expect(page.locator('#name')).toHaveValue('E')
+    await expect(page.locator('#remember')).not.toBeChecked()
   })
 
   test('restores remembered data when pressing the back button from another website', async ({ page }) => {


### PR DESCRIPTION
This PR aims to fix `useRemember` in React. The following scenario is currently broken:

1. Navigate to a page which has `const [form, setForm] = useRemember({ name: '', remember: false })`
2. Call `setForm({ ...form, name: 'change-1' })` to remember some data
3. Navigate to another page with the Inertia Router and hit the browser's back button
4. The form data is successfully restored, `form.name` is still `change-1` ✅
5. Now change the data again with `setForm({ ...form, name: 'change-2' })`
6. Navigate again to another page with the Inertia Router and hit the browser's back button
7. Now `form.name` is still `change-1` instead of `change-2` ❌

Draft because I want to make sure I understand the original intention of `initialState` correctly.

Fixes #2226.