### PR TITLE
Escape the attribute values that are passed into the `Head` component

### DIFF
--- a/packages/react/src/Head.ts
+++ b/packages/react/src/Head.ts
@@ -1,3 +1,4 @@
+import { escape } from 'es-toolkit'
 import React, { FunctionComponent, useContext, useEffect, useMemo } from 'react'
 import HeadContext from './HeadContext'
 
@@ -52,7 +53,7 @@ const Head: InertiaHead = function ({ children, title }) {
       if (value === '') {
         return carry + ` ${name}`
       } else {
-        return carry + ` ${name}="${value}"`
+        return carry + ` ${name}="${escape(value)}"`
       }
     }, '')
     return `<${node.type}${attrs}>`

--- a/packages/react/test-app/Pages/Head.jsx
+++ b/packages/react/test-app/Pages/Head.jsx
@@ -1,0 +1,14 @@
+import { Head } from '@inertiajs/react'
+
+export default () => {
+  return (
+    <>
+      <Head title="Test Head Component">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content='This is an "escape" example' />
+      </Head>
+
+      <h1 style={{ fontSize: '40px' }}>Head Component</h1>
+    </>
+  )
+}

--- a/packages/vue3/src/head.ts
+++ b/packages/vue3/src/head.ts
@@ -1,3 +1,4 @@
+import { escape } from 'es-toolkit'
 import { defineComponent, DefineComponent } from 'vue'
 
 export type InertiaHead = DefineComponent<{
@@ -51,7 +52,7 @@ const Head: InertiaHead = defineComponent({
         } else if (value === '') {
           return carry + ` ${name}`
         } else {
-          return carry + ` ${name}="${value}"`
+          return carry + ` ${name}="${escape(value)}"`
         }
       }, '')
       return `<${node.type}${attrs}>`

--- a/packages/vue3/test-app/Pages/Head.vue
+++ b/packages/vue3/test-app/Pages/Head.vue
@@ -1,0 +1,12 @@
+<script setup>
+import { Head } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <Head title="Test Head Component">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content='This is an "escape" example' />
+  </Head>
+
+  <h1 :style="{ fontSize: '40px' }">Head Component</h1>
+</template>

--- a/tests/head.spec.ts
+++ b/tests/head.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test'
+
+test('renders the title tag and children', async ({ page }) => {
+  test.skip(process.env.PACKAGE === 'svelte', 'Svelte adapter has no Head component')
+
+  await page.goto('/head')
+
+  const inertiaTitle = await page.evaluate(() => document.querySelector('title[inertia]')?.textContent)
+
+  await expect(inertiaTitle).toBe('Test Head Component')
+  await expect(page.locator('meta[name="viewport"]')).toHaveAttribute('content', 'width=device-width, initial-scale=1')
+  await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', 'This is an "escape" example')
+})


### PR DESCRIPTION
This PR fixes #2362 by escaping the attribute values on tags that are passing into the `Head` component. Currently, passing this line of valid HTML will break:

```html
<meta name="description" content='This is the "best" example' />
```

The imported `escape` method is really small, but since we're already relying on `es-toolkit`, I think it's fine to leverage it. Still draft because it misses tests.