### PR TITLE
Add event callbacks to `ClientSideVisitOptions`

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -82,6 +82,9 @@ export interface ClientSideVisitOptions {
   encryptHistory?: Page['encryptHistory']
   preserveScroll?: VisitOptions['preserveScroll']
   preserveState?: VisitOptions['preserveState']
+  errorBag: string | null
+  onError?: (errors: Errors) => void
+  onFinish?: () => void
   onSuccess?: () => void
 }
 

--- a/packages/react/test-app/Pages/ClientSideVisit/Page1.jsx
+++ b/packages/react/test-app/Pages/ClientSideVisit/Page1.jsx
@@ -2,13 +2,41 @@ import { router } from '@inertiajs/react'
 import { useState } from 'react'
 
 export default ({ foo, bar }) => {
-  const [replaced, setReplaced] = useState(0)
+  const [errors, setErrors] = useState(0)
+  const [finished, setFinished] = useState(0)
+  const [success, setSuccess] = useState(0)
+
+  const bagErrors = () => {
+    router.replace({
+      preserveState: true,
+      props: (props) => ({ ...props, errors: { bag: { foo: 'bar' } } }),
+      errorBag: 'bag',
+      onError: (err) => {
+        setErrors(Object.keys(err).length)
+      },
+      onFinish: () => setFinished(finished + 1),
+      onSuccess: () => setSuccess(success + 1),
+    })
+  }
+
+  const defaultErrors = () => {
+    router.replace({
+      preserveState: true,
+      props: (props) => ({ ...props, errors: { foo: 'bar', baz: 'qux' } }),
+      onError: (err) => {
+        setErrors(Object.keys(err).length)
+      },
+      onFinish: () => setFinished(finished + 1),
+      onSuccess: () => setSuccess(success + 1),
+    })
+  }
 
   const replace = () => {
     router.replace({
       preserveState: true,
       props: (props) => ({ ...props, foo: 'foo from client' }),
-      onSuccess: () => setReplaced(replaced + 1),
+      onFinish: () => setFinished(finished + 1),
+      onSuccess: () => setSuccess(success + 1),
     })
   }
 
@@ -26,7 +54,11 @@ export default ({ foo, bar }) => {
       <div>{bar}</div>
       <button onClick={replace}>Replace</button>
       <button onClick={push}>Push</button>
-      <div>Replaced: {replaced}</div>
+      <button onClick={defaultErrors}>Errors (default)</button>
+      <button onClick={bagErrors}>Errors (bag)</button>
+      <div>Errors: {errors}</div>
+      <div>Finished: {finished}</div>
+      <div>Success: {success}</div>
     </div>
   )
 }

--- a/packages/svelte/test-app/Pages/ClientSideVisit/Page1.svelte
+++ b/packages/svelte/test-app/Pages/ClientSideVisit/Page1.svelte
@@ -4,13 +4,41 @@
   export let foo;
   export let bar;
 
-  let replaced = 0;
+  let errors = 0;
+  let finished = 0;
+  let success = 0;
+
+  const bagErrors = () => {
+    router.replace({
+      preserveState: true,
+      props: (props) => ({ ...props, errors: { bag: { foo: 'bar' } } }),
+      errorBag: 'bag',
+      onError: (err) => {
+        errors = Object.keys(err).length
+      },
+      onFinish: () => finished++,
+      onSuccess: () => success++,
+    })
+  }
+
+  const defaultErrors = () => {
+    router.replace({
+      preserveState: true,
+      props: (props) => ({ ...props, errors: { foo: 'bar', baz: 'qux' } }),
+      onError: (err) => {
+        errors = Object.keys(err).length
+      },
+      onFinish: () => finished++,
+      onSuccess: () => success++,
+    })
+  }
 
   const replace = () => {
     router.replace({
       preserveState: true,
       props: (props) => ({ ...props, foo: 'foo from client' }),
-      onSuccess: () => replaced++,
+      onFinish: () => finished++,
+      onSuccess: () => success++,
     });
   };
 
@@ -28,5 +56,9 @@
   <div>{bar}</div>
   <button on:click={replace}>Replace</button>
   <button on:click={push}>Push</button>
-  <div>Replaced: {replaced}</div>
+  <button on:click="{defaultErrors}">Errors (default)</button>
+  <button on:click="{bagErrors}">Errors (bag)</button>
+  <div>Errors: {errors}</div>
+  <div>Finished: {finished}</div>
+  <div>Success: {success}</div>
 </div>

--- a/packages/vue3/test-app/Pages/ClientSideVisit/Page1.vue
+++ b/packages/vue3/test-app/Pages/ClientSideVisit/Page1.vue
@@ -7,13 +7,41 @@ defineProps<{
   bar: string
 }>()
 
-const replaced = ref(0)
+const errors = ref(0)
+const finished = ref(0)
+const success = ref(0)
+
+const bagErrors = () => {
+  router.replace({
+    preserveState: true,
+    props: (props) => ({ ...props, errors: { bag: { foo: 'bar' } } }),
+    errorBag: 'bag',
+    onError: (err) => {
+      errors.value = Object.keys(err).length
+    },
+    onFinish: () => finished.value++,
+    onSuccess: () => success.value++,
+  })
+}
+
+const defaultErrors = () => {
+  router.replace({
+    preserveState: true,
+    props: (props) => ({ ...props, errors: { foo: 'bar', baz: 'qux' } }),
+    onError: (err) => {
+      errors.value = Object.keys(err).length
+    },
+    onFinish: () => finished.value++,
+    onSuccess: () => success.value++,
+  })
+}
 
 const replace = () => {
   router.replace({
     preserveState: true,
     props: (props) => ({ ...props, foo: 'foo from client' }),
-    onSuccess: () => replaced.value++,
+    onFinish: () => finished.value++,
+    onSuccess: () => success.value++,
   })
 }
 
@@ -33,5 +61,9 @@ const push = () => {
   <div>{{ bar }}</div>
   <button @click="replace">Replace</button>
   <button @click="push">Push</button>
-  <div>Replaced: {{ replaced }}</div>
+  <button @click="defaultErrors">Errors (default)</button>
+  <button @click="bagErrors">Errors (bag)</button>
+  <div>Errors: {{ errors }}</div>
+  <div>Finished: {{ finished }}</div>
+  <div>Success: {{ success }}</div>
 </template>

--- a/tests/client-side-visits.spec.ts
+++ b/tests/client-side-visits.spec.ts
@@ -11,7 +11,8 @@ test('replaces the page client side', async ({ page }) => {
   await expect(page.getByText('foo from server')).toBeVisible()
   await expect(page.getByText('bar from server')).toBeVisible()
   await expect(page.getByText('foo from client')).not.toBeVisible()
-  await expect(page.getByText('Replaced: 0')).toBeVisible()
+  await expect(page.getByText('Finished: 0')).toBeVisible()
+  await expect(page.getByText('Success: 0')).toBeVisible()
 
   await page.getByRole('button', { name: 'Replace' }).click()
 
@@ -19,13 +20,53 @@ test('replaces the page client side', async ({ page }) => {
   await expect(page.getByText('foo from server')).not.toBeVisible()
   await expect(page.getByText('foo from client')).toBeVisible()
   await expect(page.getByText('bar from server')).toBeVisible()
-  await expect(page.getByText('Replaced: 1')).toBeVisible()
+  await expect(page.getByText('Finished: 1')).toBeVisible()
+  await expect(page.getByText('Success: 1')).toBeVisible()
 
   await expect(requests.requests.length).toBe(0)
 
   const historyLength = await page.evaluate(() => window.history.length)
 
   await expect(historyLength).toBe(2)
+})
+
+test('fires an onError callback when the props has errors', async ({ page }) => {
+  pageLoads.watch(page)
+
+  await page.goto('/client-side-visit')
+
+  requests.listen(page)
+
+  await expect(page.getByText('Errors: 0')).toBeVisible()
+  await expect(page.getByText('Finished: 0')).toBeVisible()
+  await expect(page.getByText('Success: 0')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Errors (default)' }).click()
+
+  await expect(page.getByText('Finished: 1')).toBeVisible()
+  await expect(page.getByText('Errors: 2')).toBeVisible()
+  await expect(page.getByText('Success: 0')).toBeVisible()
+
+  await expect(requests.requests.length).toBe(0)
+})
+
+test('fires an onError callback when the props has errors in a custom bag', async ({ page }) => {
+  pageLoads.watch(page)
+
+  await page.goto('/client-side-visit')
+
+  requests.listen(page)
+
+  await expect(page.getByText('Errors: 0')).toBeVisible()
+  await expect(page.getByText('Finished: 0')).toBeVisible()
+  await expect(page.getByText('Success: 0')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Errors (bag)' }).click()
+
+  await expect(page.getByText('Finished: 1')).toBeVisible()
+  await expect(page.getByText('Errors: 1')).toBeVisible()
+  await expect(page.getByText('Success: 0')).toBeVisible()
+  await expect(requests.requests.length).toBe(0)
 })
 
 test('pushes the page client side', async ({ page }) => {


### PR DESCRIPTION
This PR introduces the ability to pass an `onError`, `onFinish`, and `onSuccess` callback when making client-side visits:

```js
router.replace({
  props: (props) => ({ ...props, foo: 'bar' }),
  onError: (errors) => {
    // ...
  },
  onFinish: () => {
    // ...
  },
  onSuccess: () => {
    // ...
  }
});
```

Fixes #2325. 