### PR TITLE
Allow to reset the form after successful submit and sync the defaults afterwards

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -129,7 +129,6 @@ export default function useForm<TForm extends FormDataType>(
             setHasErrors(false)
             setWasSuccessful(true)
             setRecentlySuccessful(true)
-            setDefaults(cloneDeep(data))
             recentlySuccessfulTimeoutId.current = setTimeout(() => {
               if (isMounted.current) {
                 setRecentlySuccessful(false)
@@ -137,9 +136,13 @@ export default function useForm<TForm extends FormDataType>(
             }, 2000)
           }
 
-          if (options.onSuccess) {
-            return options.onSuccess(page)
+          const onSuccess = options.onSuccess ? options.onSuccess(page) : null;
+          
+          if (isMounted.current) {
+            setDefaults(cloneDeep(data))
           }
+
+          return onSuccess;
         },
         onError: (errors) => {
           if (isMounted.current) {


### PR DESCRIPTION
Provide a Fix to #2411.

After digging into issues and code i found the following [comment from Jess Archer](https://github.com/inertiajs/inertia/issues/553#issuecomment-1700217765) which describe the steps to reproduce, but for the vue form.
Which leads me to the form helper of vue and i found different behavior vue vs react.

The critical `setDefaults(data)` in `onSuccess` was introduce by https://github.com/inertiajs/inertia/pull/2236 to fix an issue with reactivity of the isDirty prop.


### Solution:
To bring vue and react in sync an solve this bug, we have to move the `setDefaults` after running the `onSuccess` hook, which bring the reset data and the defaults in sync.
