### PR TITLE
Introduce single method to reset form state and clear errors

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -36,6 +36,7 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   setDefaults(fields: Partial<TForm>): void
   reset: (...fields: FormDataKeys<TForm>[]) => void
   clearErrors: (...fields: FormDataKeys<TForm>[]) => void
+  resetAll: (...fields: FormDataKeys<TForm>[]) => void
   setError(field: FormDataKeys<TForm>, value: string): void
   setError(errors: Record<FormDataKeys<TForm>, string>): void
   submit: (...args: [Method, string, FormOptions?] | [{ url: string; method: Method }, FormOptions?]) => void
@@ -219,7 +220,7 @@ export default function useForm<TForm extends FormDataType>(
     },
     [data, setDefaults],
   )
-  
+
   useLayoutEffect(() => {
     if (!dataAsDefaults) {
       return
@@ -287,6 +288,14 @@ export default function useForm<TForm extends FormDataType>(
     [setErrors, setHasErrors],
   )
 
+  const resetAll = useCallback(
+    (...fields) => {
+      reset(...fields)
+      clearErrors(...fields)
+    },
+    [reset, clearErrors],
+  )
+
   const createSubmitMethod = (method) => (url, options) => {
     submit(method, url, options)
   }
@@ -321,6 +330,7 @@ export default function useForm<TForm extends FormDataType>(
     reset,
     setError,
     clearErrors,
+    resetAll,
     submit,
     get: getMethod,
     post,

--- a/packages/react/test-app/Pages/FormHelper/Errors.jsx
+++ b/packages/react/test-app/Pages/FormHelper/Errors.jsx
@@ -26,6 +26,14 @@ export default (props) => {
     form.setError('handle', 'Manually set Handle error')
   }
 
+  const resetAll = () => {
+    form.resetAll()
+  }
+
+  const resetHandle = () => {
+    form.resetAll('handle')
+  }
+
   return (
     <div>
       <label>
@@ -77,6 +85,12 @@ export default (props) => {
       </button>
       <button onClick={setError} className="set-one">
         Set one error
+      </button>
+      <button onClick={resetAll} className="reset-all">
+        Reset all
+      </button>
+      <button onClick={resetHandle} className="reset-handle">
+        Reset handle
       </button>
 
       <span className="errors-status">Form has {form.hasErrors ? '' : 'no '}errors</span>

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -36,6 +36,7 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   defaults(field?: FormDataKeys<TForm>, value?: FormDataConvertible): this
   reset(...fields: FormDataKeys<TForm>[]): this
   clearErrors(...fields: FormDataKeys<TForm>[]): this
+  resetAll(...fields: FormDataKeys<TForm>[]): this
   setError(field: FormDataKeys<TForm>, value: string): this
   setError(errors: Errors): this
   submit: (...args: [Method, string, FormOptions?] | [{ url: string; method: Method }, FormOptions?]) => void
@@ -139,6 +140,11 @@ export default function useForm<TForm extends FormDataType>(
           {},
         ) as Errors,
       )
+      return this
+    },
+    resetAll(...fields) {
+      this.reset(...fields)
+      this.clearErrors(...fields)
       return this
     },
     submit(...args) {

--- a/packages/svelte/test-app/Pages/FormHelper/Errors.svelte
+++ b/packages/svelte/test-app/Pages/FormHelper/Errors.svelte
@@ -29,6 +29,14 @@
   const setError = () => {
     $form.setError('handle', 'Manually set Handle error')
   }
+
+  const resetAll = () => {
+    $form.resetAll()
+  }
+
+  const resetHandle = () => {
+    $form.resetAll('handle')
+  }
 </script>
 
 <div>
@@ -60,6 +68,8 @@
   <button on:click={clearError} class="clear-one">Clear one error</button>
   <button on:click={setErrors} class="set">Set errors</button>
   <button on:click={setError} class="set-one">Set one error</button>
+  <button on:click={resetAll} class="reset-all">Reset all</button>
+  <button on:click={resetHandle} class="reset-handle">Reset handle</button>
 
   <span class="errors-status">Form has {$form.hasErrors ? '' : 'no '}errors</span>
 </div>

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -21,6 +21,7 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   defaults(fields: Partial<TForm>): this
   reset(...fields: FormDataKeys<TForm>[]): this
   clearErrors(...fields: FormDataKeys<TForm>[]): this
+  resetAll(...fields: FormDataKeys<TForm>[]): this
   setError(field: FormDataKeys<TForm>, value: string): this
   setError(errors: Record<FormDataKeys<TForm>, string>): this
   submit: (...args: [Method, string, FormOptions?] | [{ url: string; method: Method }, FormOptions?]) => void
@@ -124,6 +125,11 @@ export default function useForm<TForm extends FormDataType>(
 
       this.hasErrors = Object.keys(this.errors).length > 0
 
+      return this
+    },
+    resetAll(...fields) {
+      this.reset(...fields)
+      this.clearErrors(...fields)
       return this
     },
     submit(...args) {

--- a/packages/vue3/test-app/Pages/FormHelper/Errors.vue
+++ b/packages/vue3/test-app/Pages/FormHelper/Errors.vue
@@ -28,6 +28,14 @@ const setErrors = () => {
 const setError = () => {
   form.setError('handle', 'Manually set Handle error')
 }
+
+const resetAll = () => {
+  form.resetAll()
+}
+
+const resetHandle = () => {
+  form.resetAll('handle')
+}
 </script>
 
 <template>
@@ -54,6 +62,8 @@ const setError = () => {
     <button @click="clearError" class="clear-one">Clear one error</button>
     <button @click="setErrors" class="set">Set errors</button>
     <button @click="setError" class="set-one">Set one error</button>
+    <button @click="resetAll" class="reset-all">Reset all</button>
+    <button @click="resetHandle" class="reset-handle">Reset handle</button>
 
     <span class="errors-status">Form has {{ form.hasErrors ? '' : 'no ' }}errors</span>
   </div>

--- a/tests/form-helper.spec.ts
+++ b/tests/form-helper.spec.ts
@@ -235,6 +235,61 @@ test.describe('Form Helper', () => {
       await expect(await handleError.textContent()).toEqual('Manually set Handle error')
       await expect(await nameError.textContent()).toEqual('Manually set Name error')
     })
+
+    test('can reset all errors and reset all fields to their initial values', async ({ page }) => {
+      await page.getByRole('button', { name: 'Submit form' }).click()
+
+      await expect(page).toHaveURL('form-helper/errors')
+
+      await page.waitForSelector('.remember_error', { state: 'detached' })
+
+      const errorsStatus = await page.locator('.errors-status')
+      const nameError = await page.locator('.name_error')
+      const handleError = await page.locator('.handle_error')
+
+      await expect(await errorsStatus.textContent()).toEqual('Form has errors')
+      await expect(await nameError.textContent()).toEqual('Some name error')
+      await expect(await handleError.textContent()).toEqual('The Handle was invalid')
+
+      await page.getByRole('button', { name: 'Reset all' }).click()
+
+      await expect(page.locator('#name')).toHaveValue('foo')
+      await expect(page.locator('#handle')).toHaveValue('example')
+      await expect(page.locator('#remember')).not.toBeChecked()
+
+      await page.waitForSelector('.name_error', { state: 'detached' })
+      await page.waitForSelector('.handle_error', { state: 'detached' })
+      await page.waitForSelector('.remember_error', { state: 'detached' })
+
+      await expect(await errorsStatus.textContent()).toEqual('Form has no errors')
+    })
+
+    test('can reset a single error and reset a single field to its initial value', async ({ page }) => {
+      await page.getByRole('button', { name: 'Submit form' }).click()
+
+      await expect(page).toHaveURL('form-helper/errors')
+
+      await page.waitForSelector('.remember_error', { state: 'detached' })
+
+      const errorsStatus = await page.locator('.errors-status')
+      const nameError = await page.locator('.name_error')
+      const handleError = await page.locator('.handle_error')
+
+      await expect(await errorsStatus.textContent()).toEqual('Form has errors')
+      await expect(await nameError.textContent()).toEqual('Some name error')
+      await expect(await handleError.textContent()).toEqual('The Handle was invalid')
+
+      await page.getByRole('button', { name: 'Reset handle' }).click()
+
+      await expect(page.locator('#name')).toHaveValue('A')
+      await expect(page.locator('#handle')).toHaveValue('example')
+      await expect(page.locator('#remember')).toBeChecked()
+
+      await expect(await nameError.textContent()).toEqual('Some name error')
+      await page.waitForSelector('.handle_error', { state: 'detached' })
+      await page.waitForSelector('.remember_error', { state: 'detached' })
+      await expect(await errorsStatus.textContent()).toEqual('Form has errors')
+    })
   })
 
   test.describe('Dirty', () => {


### PR DESCRIPTION
Instead of:

```js
form.reset()
form.clearErrors()
```

You can now do:  

```js
form.resetAll()
```

Still draft because the `resetAll()` name is a bit ambiguous, and it feels wrong when you pass in fields like `resetAll('name')`.