### PR TITLE
Ability to configure defaults in `createInertiaApp()`

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -351,14 +351,16 @@ export class Router {
       prefetch: false,
     }
 
-    const options: Visit = this.defaultVisitOptionsCallback
-      ? {
-          ...defaultOptions,
-          ...this.defaultVisitOptionsCallback(href, defaultOptions),
-        }
-      : defaultOptions
+    if (!this.defaultVisitOptionsCallback) {
+      return { ...defaultOptions, ...mergeOptions }
+    }
 
-    return mergeWith(options, mergeOptions, (originalValue, mergeValue, key) => {
+    const options = {
+      ...defaultOptions,
+      ...this.defaultVisitOptionsCallback(href, defaultOptions),
+    }
+
+    return mergeWith(options, mergeOptions, (originalValue, mergeValue) => {
       if (Array.isArray(mergeValue) && Array.isArray(originalValue)) {
         return [...originalValue, ...mergeValue]
       }

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -1,4 +1,4 @@
-import { createHeadManager, Page, PageProps, router } from '@inertiajs/core'
+import { createHeadManager, Page, PageProps, router, Visit } from '@inertiajs/core'
 import {
   computed,
   DefineComponent,
@@ -21,6 +21,9 @@ export interface InertiaAppProps {
   resolveComponent?: (name: string) => DefineComponent | Promise<DefineComponent>
   titleCallback?: (title: string) => string
   onHeadUpdate?: (elements: string[]) => void
+  defaults?: {
+    visitOptions?: (href: string | URL, options: Visit) => Partial<Visit>
+  }
 }
 
 export type InertiaApp = DefineComponent<InertiaAppProps>
@@ -56,8 +59,15 @@ const App: InertiaApp = defineComponent({
       required: false,
       default: () => () => {},
     },
+    defaults: {
+      type: Object as PropType<{
+        visitOptions?: (href: string | URL, options: Visit) => Partial<Visit>
+      }>,
+      required: false,
+      default: () => ({}),
+    },
   },
-  setup({ initialPage, initialComponent, resolveComponent, titleCallback, onHeadUpdate }) {
+  setup({ initialPage, initialComponent, resolveComponent, titleCallback, onHeadUpdate, defaults }) {
     component.value = initialComponent ? markRaw(initialComponent) : null
     page.value = initialPage
     key.value = null
@@ -75,6 +85,10 @@ const App: InertiaApp = defineComponent({
           key.value = args.preserveState ? key.value : Date.now()
         },
       })
+
+      if (defaults?.visitOptions) {
+        router.withDefaultVisitOptions(defaults.visitOptions)
+      }
 
       router.on('navigate', () => headManager.forceUpdate())
     }

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -1,4 +1,4 @@
-import { Page, router, setupProgress } from '@inertiajs/core'
+import { Page, router, setupProgress, Visit } from '@inertiajs/core'
 import { DefineComponent, Plugin, App as VueApp, createSSRApp, h } from 'vue'
 import App, { InertiaApp, InertiaAppProps, plugin } from './app'
 
@@ -17,6 +17,9 @@ interface CreateInertiaAppProps {
       }
   page?: Page
   render?: (app: VueApp) => Promise<string>
+  defaults?: {
+    visitOptions?: (href: string | URL, options: Visit) => Partial<Visit>
+  }
 }
 
 export default async function createInertiaApp({
@@ -27,6 +30,7 @@ export default async function createInertiaApp({
   progress = {},
   page,
   render,
+  defaults,
 }: CreateInertiaAppProps): Promise<{ head: string[]; body: string }> {
   const isServer = typeof window === 'undefined'
   const el = isServer ? null : document.getElementById(id)
@@ -48,6 +52,7 @@ export default async function createInertiaApp({
         resolveComponent,
         titleCallback: title,
         onHeadUpdate: isServer ? (elements) => (head = elements) : null,
+        defaults,
       },
       plugin,
     })

--- a/playgrounds/vue3/resources/js/app.ts
+++ b/playgrounds/vue3/resources/js/app.ts
@@ -14,4 +14,14 @@ createInertiaApp({
       .use(plugin)
       .mount(el)
   },
+  defaults: {
+    visitOptions: (href, options) => {
+      return {
+        // queryStringArrayFormat: 'indices',
+        // headers: {
+        //   'X-Foo': 'bar',
+        // },
+      }
+    },
+  },
 })


### PR DESCRIPTION
*Definitely WIP, but I'm already opening this to gather feedback/input.*

This PR introduces a new `defaults` key to the `CreateInertiaAppProps` interface, allowing you to define application-wide defaults.

For example, you can use it to change the default `queryStringArrayFormat` from brackets to indices, or to attach default headers to every request:

```js
createInertiaApp({
  title: (title) => `${title} - ${appName}`,

  // ...resolve, setup, progress, etc...

  defaults: {
    visitOptions: (href, options) => {
      return {
        queryStringArrayFormat: 'indices',
        headers: {
          'X-Foo': 'bar',
        },
      }
    },
  },
})
```

I've chosen to nest `visitOptions` under `defaults` so we don't bloat `CreateInertiaAppProps` if we end up adding more of these callbacks later on.