### PR TITLE
Prevent JS builds and test apps from being minified

### DIFF
--- a/packages/core/build.js
+++ b/packages/core/build.js
@@ -6,7 +6,7 @@ const watch = process.argv.slice(1).includes('--watch')
 
 const config = {
   bundle: true,
-  minify: true,
+  minify: false,
   sourcemap: true,
   target: 'es2020',
   plugins: [

--- a/packages/react/build.js
+++ b/packages/react/build.js
@@ -6,7 +6,7 @@ const watch = process.argv.slice(1).includes('--watch')
 
 const config = {
   bundle: true,
-  minify: true,
+  minify: false,
   sourcemap: true,
   target: 'es2020',
   plugins: [

--- a/packages/react/test-app/vite.config.js
+++ b/packages/react/test-app/vite.config.js
@@ -2,6 +2,9 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  build: {
+    minify: false,
+  },
   resolve: {
     alias: {
       '@': __dirname,

--- a/packages/svelte/vite.config.ts
+++ b/packages/svelte/vite.config.ts
@@ -2,5 +2,8 @@ import { sveltekit } from '@sveltejs/kit/vite'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  build: {
+    minify: false,
+  },
   plugins: [sveltekit()],
 })

--- a/packages/vue3/build.js
+++ b/packages/vue3/build.js
@@ -6,7 +6,7 @@ const watch = process.argv.slice(1).includes('--watch')
 
 const config = {
   bundle: true,
-  minify: true,
+  minify: false,
   sourcemap: true,
   target: 'es2020',
   plugins: [

--- a/packages/vue3/test-app/vite.config.js
+++ b/packages/vue3/test-app/vite.config.js
@@ -2,6 +2,9 @@ import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  build: {
+    minify: false,
+  },
   resolve: {
     alias: {
       '@': __dirname,


### PR DESCRIPTION
Fixes #2186.

I think it makes sense to stop minifying the builds, as you'd always use Vite or another bundler with Inertia. I looked around, and here are some other libraries that are also not minified: Lodash, Tanstack packages, es-toolkit, Laravel Echo.

Also included the test apps in the PR. Minifying those builds only makes debugging harder.