### PR TITLE
Use `CacheForOption` type in React `Link` component

### DIFF
--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -1,4 +1,5 @@
 import {
+  CacheForOption,
   FormDataConvertible,
   LinkPrefetchOption,
   mergeDataIntoQueryString,
@@ -35,7 +36,7 @@ interface BaseInertiaLinkProps {
   onError?: () => void
   queryStringArrayFormat?: 'indices' | 'brackets'
   async?: boolean
-  cacheFor?: number | string
+  cacheFor?: CacheForOption | CacheForOption[]
   prefetch?: boolean | LinkPrefetchOption | LinkPrefetchOption[]
 }
 


### PR DESCRIPTION
Fixes #2143 