### PR TITLE
Cancel sync request on popstate event

### DIFF
--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -1,6 +1,7 @@
 import debounce from './debounce'
 import { fireNavigateEvent } from './events'
 import { history } from './history'
+import { router } from './index'
 import { page as currentPage } from './page'
 import { Scroll } from './scroll'
 import { GlobalEvent, GlobalEventNames, GlobalEventResult, InternalEvent } from './types'
@@ -65,6 +66,9 @@ class EventHandler {
   }
 
   protected handlePopstateEvent(event: PopStateEvent): void {
+    // Cancel ongoing synchronous requests
+    router.cancel()
+
     const state = event.state || null
 
     if (state === null) {

--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -90,8 +90,8 @@ class EventHandler {
           return
         }
 
-        // Cancel ongoing synchronous requests
-        router.cancel()
+        // Cancel ongoing requests
+        router.cancelAll()
 
         currentPage.setQuietly(data, { preserveState: false }).then(() => {
           window.requestAnimationFrame(() => {

--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -66,9 +66,6 @@ class EventHandler {
   }
 
   protected handlePopstateEvent(event: PopStateEvent): void {
-    // Cancel ongoing synchronous requests
-    router.cancel()
-
     const state = event.state || null
 
     if (state === null) {
@@ -84,6 +81,9 @@ class EventHandler {
     if (!history.isValidState(state)) {
       return this.onMissingHistoryItem()
     }
+
+    // Cancel ongoing synchronous requests
+    router.cancel()
 
     history
       .decrypt(state.page)

--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -82,9 +82,6 @@ class EventHandler {
       return this.onMissingHistoryItem()
     }
 
-    // Cancel ongoing synchronous requests
-    router.cancel()
-
     history
       .decrypt(state.page)
       .then((data) => {
@@ -92,6 +89,9 @@ class EventHandler {
           this.onMissingHistoryItem()
           return
         }
+
+        // Cancel ongoing synchronous requests
+        router.cancel()
 
         currentPage.setQuietly(data, { preserveState: false }).then(() => {
           window.requestAnimationFrame(() => {

--- a/packages/react/test-app/Pages/Links/CancelSyncRequest.jsx
+++ b/packages/react/test-app/Pages/Links/CancelSyncRequest.jsx
@@ -1,0 +1,19 @@
+import { Link } from '@inertiajs/react'
+
+export default ({ page }) => {
+  return (
+    <>
+      <h1 style={{ 'fontSize': '40px', }}>Page {page}</h1>
+
+      <Link href="/links/cancel-sync-request/1">
+        Go to Page 1
+      </Link>
+      <Link href="/links/cancel-sync-request/2">
+        Go to Page 2
+      </Link>
+      <Link href="/links/cancel-sync-request/3">
+        Go to Page 3
+      </Link>
+    </>
+  )
+}

--- a/packages/svelte/test-app/Pages/Links/CancelSyncRequest.svelte
+++ b/packages/svelte/test-app/Pages/Links/CancelSyncRequest.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Link } from '@inertiajs/svelte'
+
+  export let page: number
+</script>
+
+<h1 style="font-size: 40px;">
+  Page {page}
+</h1>
+
+<Link href="/links/cancel-sync-request/1">
+  Go to Page 1
+</Link>
+<Link href="/links/cancel-sync-request/2">
+  Go to Page 2
+</Link>
+<Link href="/links/cancel-sync-request/3">
+  Go to Page 3
+</Link>

--- a/packages/vue3/test-app/Pages/Links/CancelSyncRequest.vue
+++ b/packages/vue3/test-app/Pages/Links/CancelSyncRequest.vue
@@ -1,0 +1,17 @@
+<script setup>
+import { Link } from '@inertiajs/vue3'
+
+defineProps({
+  page: Number,
+})
+</script>
+
+<template>
+  <div>
+    <h1 style="font-size: 40px">Page {{ page }}</h1>
+
+    <Link href="/links/cancel-sync-request/1"> Go to Page 1 </Link>
+    <Link href="/links/cancel-sync-request/2"> Go to Page 2 </Link>
+    <Link href="/links/cancel-sync-request/3"> Go to Page 3 </Link>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -82,6 +82,14 @@ app.get('/links/headers/version', (req, res) =>
 app.get('/links/data-loading', (req, res) => inertia.render(req, res, { component: 'Links/DataLoading' }))
 app.get('/links/prop-update', (req, res) => inertia.render(req, res, { component: 'Links/PropUpdate' }))
 
+app.get('/links/cancel-sync-request/:page', (req, res) => {
+  const page = req.params.page
+  setTimeout(
+    () => inertia.render(req, res, { component: 'Links/CancelSyncRequest', props: { page } }),
+    page == 3 ? 500 : 0,
+  )
+})
+
 app.get('/client-side-visit', (req, res) =>
   inertia.render(req, res, {
     component: 'ClientSideVisit/Page1',

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -831,6 +831,11 @@ test('cancels pending request when navigating back', async ({ page }) => {
   await expect(page).toHaveURL('/links/cancel-sync-request/1')
   await page.waitForTimeout(750)
   await expect(page).toHaveURL('/links/cancel-sync-request/1')
+  // make sure page 2 is still in the history stack
+  await page.goForward()
+  await expect(page).toHaveURL('/links/cancel-sync-request/2')
+  await page.goBack()
+  await expect(page).toHaveURL('/links/cancel-sync-request/1')
 })
 
 test('will update href if prop is updated', async ({ page }) => {

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -822,6 +822,17 @@ test.describe('data-loading attribute', () => {
   })
 })
 
+test('cancels pending request when navigating back', async ({ page }) => {
+  await page.goto('/links/cancel-sync-request/1')
+  await page.getByRole('link', { name: 'Go to Page 2' }).click()
+  await expect(page).toHaveURL('/links/cancel-sync-request/2')
+  await page.getByRole('link', { name: 'Go to Page 3' }).click() // This one is slow (500ms)
+  await page.goBack()
+  await expect(page).toHaveURL('/links/cancel-sync-request/1')
+  await page.waitForTimeout(750)
+  await expect(page).toHaveURL('/links/cancel-sync-request/1')
+})
+
 test('will update href if prop is updated', async ({ page }) => {
   await page.goto('/links/prop-update')
   const link = await page.getByRole('link', { name: 'The Link' })


### PR DESCRIPTION
This PR fixes a navigation issue that happened when a user went back in their browser history while a new page was still loading.

Previously, if a user navigated from `/page1` to `/page2`, then clicked a link to `/page3` (which is slow), and immediately pressed the browser's back button, `/page1` would appear but the request to `/page3` would still be running. Once finished, it would show `/page3`.

Now when a user goes back in history (while a new page is still loading), all pending (sync) requests are cancelled.