### PR TITLE
Fix single-use prefetching

### DIFF
--- a/packages/core/src/prefetched.ts
+++ b/packages/core/src/prefetched.ts
@@ -63,7 +63,7 @@ class PrefetchedRequests {
         params: { ...params },
         staleTimestamp: Date.now() + stale,
         response: promise,
-        singleUse: cacheFor === 0,
+        singleUse: expires === 0,
         timestamp: Date.now(),
         inFlight: false,
       })

--- a/packages/react/test-app/Layouts/Prefetch.jsx
+++ b/packages/react/test-app/Layouts/Prefetch.jsx
@@ -15,6 +15,9 @@ export default ({ children }) => {
       <Link href="/prefetch/4" prefetch={['hover', 'mount']} cacheFor="1s">
         On Hover + Mount
       </Link>
+      <Link href="/prefetch/5" prefetch="mount" cacheFor="0">
+        On Mount (Once)
+      </Link>
       <div>{children}</div>
     </div>
   )

--- a/packages/svelte/test-app/Layouts/Prefetch.svelte
+++ b/packages/svelte/test-app/Layouts/Prefetch.svelte
@@ -7,6 +7,7 @@
   <a href="/prefetch/2" use:inertia={{ prefetch: 'mount' }}>On Mount</a>
   <a href="/prefetch/3" use:inertia={{ prefetch: 'click' }}>On Click</a>
   <a href="/prefetch/4" use:inertia={{ prefetch: ['hover', 'mount'], cacheFor: '1s' }}>On Hover + Mount</a>
+  <a href="/prefetch/5" use:inertia={{ prefetch: 'mount', cacheFor: '0' }}>On Mount (Once)</a>
   <div>
     <slot />
   </div>

--- a/packages/vue3/test-app/Layouts/Prefetch.vue
+++ b/packages/vue3/test-app/Layouts/Prefetch.vue
@@ -8,6 +8,7 @@ import { Link } from '@inertiajs/vue3'
     <Link href="/prefetch/2" prefetch="mount">On Mount</Link>
     <Link href="/prefetch/3" prefetch="click">On Click</Link>
     <Link href="/prefetch/4" :prefetch="['hover', 'mount']" cacheFor="1s">On Hover + Mount</Link>
+    <Link href="/prefetch/5" prefetch="mount" cacheFor="0">On Mount (Once)</Link>
     <div>
       <slot />
     </div>

--- a/tests/prefetch.spec.ts
+++ b/tests/prefetch.spec.ts
@@ -39,6 +39,22 @@ test('will not prefetch current page', async ({ page }) => {
   await expect(requests.requests.length).toBe(0)
 })
 
+test('removes single-use prefetch from cache when cacheFor is 0', async ({ page }) => {
+  const prefetch5 = page.waitForResponse('prefetch/5')
+
+  await page.goto('prefetch/1')
+  await prefetch5
+
+  requests.listen(page)
+  await page.getByRole('link', { name: 'On Mount (Once)' }).click()
+  await isPrefetchPage(page, 5)
+  await expect(requests.requests.length).toBe(0)
+
+  // Now that we've used it, it should be removed from the cache
+  await page.getByRole('link', { name: 'On Mount (Once)' }).click()
+  await expect(requests.requests.length).toBe(1)
+})
+
 test('can prefetch using link props', async ({ page }) => {
   // These two prefetch requests should be made on mount
   const prefetch2 = page.waitForResponse('prefetch/2')
@@ -52,7 +68,7 @@ test('can prefetch using link props', async ({ page }) => {
 
   requests.listen(page)
 
-  await page.getByRole('link', { name: 'On Mount' }).click()
+  await page.getByRole('link', { name: 'On Mount', exact: true }).click()
   await isPrefetchPage(page, 2)
   await expect(requests.requests.length).toBe(0)
 


### PR DESCRIPTION
This PR fixes an issue where the `singleUse` value was evaluated against the raw `cacheFor` value instead of the parsed `expires` value.