### PR TITLE
Make errorBag parameter optional

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -82,7 +82,7 @@ export interface ClientSideVisitOptions {
   encryptHistory?: Page['encryptHistory']
   preserveScroll?: VisitOptions['preserveScroll']
   preserveState?: VisitOptions['preserveState']
-  errorBag: string | null
+  errorBag?: string | null
   onError?: (errors: Errors) => void
   onFinish?: (visit: ClientSideVisitOptions) => void
   onSuccess?: (page: Page) => void


### PR DESCRIPTION
Before today, I could write the following code:

```ts
router.replace({
  url: `/some-url`,
  preserveScroll: true,
  preserveState: true,
})
```

However, with the latest release, now I receive a Typescript error:

> Argument of type '{ url: string; preserveScroll: true; preserveState: true; }' is not assignable to parameter of type 'ClientSideVisitOptions'.    │
│   Property 'errorBag' is missing in type '{ url: string; preserveScroll: true; preserveState: true; }' but required in type 'ClientSideVisitOptions'.

This pull request makes the `errorBag` property optional.