### PR TITLE
Add missing generic type support to PendingVisit and VisitHelperOptions

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -161,9 +161,9 @@ export class Router {
     const visit: PendingVisit = this.getPendingVisit(href, {
       ...options,
       showProgress: options.showProgress ?? !options.async,
-    })
+    } as VisitOptions)
 
-    const events = this.getVisitEvents(options)
+    const events = this.getVisitEvents(options as VisitOptions)
 
     // If either of these return false, we don't want to continue
     if (events.onBefore(visit) === false || !fireBeforeEvent(visit)) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -277,7 +277,7 @@ export type PendingVisitOptions = {
   interrupted: boolean
 }
 
-export type PendingVisit = Visit & PendingVisitOptions
+export type PendingVisit<T extends RequestPayload = RequestPayload> = Visit<T> & PendingVisitOptions
 
 export type ActiveVisit = PendingVisit & Required<VisitOptions>
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -219,7 +219,7 @@ export type PageEvent = 'newComponent' | 'firstLoad'
 
 export type GlobalEventNames<T extends RequestPayload = RequestPayload> = keyof GlobalEventsMap<T>
 
-export type GlobalEvent<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = CustomEvent<GlobalEventDetails<TEventName>>
+export type GlobalEvent<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = CustomEvent<GlobalEventDetails<TEventName, T>>
 
 export type GlobalEventParameters<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = GlobalEventsMap<T>[TEventName]['parameters']
 
@@ -279,7 +279,7 @@ export type PendingVisitOptions = {
 
 export type PendingVisit<T extends RequestPayload = RequestPayload> = Visit<T> & PendingVisitOptions
 
-export type ActiveVisit<T extends RequestPayload = RequestPayload> = PendingVisit<T> & Required<VisitOptions>
+export type ActiveVisit<T extends RequestPayload = RequestPayload> = PendingVisit<T> & Required<VisitOptions<T>>
 
 export type InternalActiveVisit = ActiveVisit & {
   onPrefetchResponse?: (response: Response) => void

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -128,18 +128,18 @@ export type Visit<T extends RequestPayload = RequestPayload> = {
   preserveUrl: boolean
 }
 
-export type GlobalEventsMap = {
+export type GlobalEventsMap<T extends RequestPayload = RequestPayload> = {
   before: {
-    parameters: [PendingVisit]
+    parameters: [PendingVisit<T>]
     details: {
-      visit: PendingVisit
+      visit: PendingVisit<T>
     }
     result: boolean | void
   }
   start: {
-    parameters: [PendingVisit]
+    parameters: [PendingVisit<T>]
     details: {
-      visit: PendingVisit
+      visit: PendingVisit<T>
     }
     result: void
   }
@@ -151,9 +151,9 @@ export type GlobalEventsMap = {
     result: void
   }
   finish: {
-    parameters: [ActiveVisit]
+    parameters: [ActiveVisit<T>]
     details: {
-      visit: ActiveVisit
+      visit: ActiveVisit<T>
     }
     result: void
   }
@@ -198,18 +198,18 @@ export type GlobalEventsMap = {
     result: boolean | void
   }
   prefetched: {
-    parameters: [AxiosResponse, ActiveVisit]
+    parameters: [AxiosResponse, ActiveVisit<T>]
     details: {
       response: AxiosResponse
       fetchedAt: number
-      visit: ActiveVisit
+      visit: ActiveVisit<T>
     }
     result: void
   }
   prefetching: {
-    parameters: [ActiveVisit]
+    parameters: [ActiveVisit<T>]
     details: {
-      visit: ActiveVisit
+      visit: ActiveVisit<T>
     }
     result: void
   }
@@ -217,40 +217,40 @@ export type GlobalEventsMap = {
 
 export type PageEvent = 'newComponent' | 'firstLoad'
 
-export type GlobalEventNames = keyof GlobalEventsMap
+export type GlobalEventNames<T extends RequestPayload = RequestPayload> = keyof GlobalEventsMap<T>
 
-export type GlobalEvent<TEventName extends GlobalEventNames> = CustomEvent<GlobalEventDetails<TEventName>>
+export type GlobalEvent<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = CustomEvent<GlobalEventDetails<TEventName>>
 
-export type GlobalEventParameters<TEventName extends GlobalEventNames> = GlobalEventsMap[TEventName]['parameters']
+export type GlobalEventParameters<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = GlobalEventsMap<T>[TEventName]['parameters']
 
-export type GlobalEventResult<TEventName extends GlobalEventNames> = GlobalEventsMap[TEventName]['result']
+export type GlobalEventResult<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = GlobalEventsMap<T>[TEventName]['result']
 
-export type GlobalEventDetails<TEventName extends GlobalEventNames> = GlobalEventsMap[TEventName]['details']
+export type GlobalEventDetails<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = GlobalEventsMap<T>[TEventName]['details']
 
-export type GlobalEventTrigger<TEventName extends GlobalEventNames> = (
-  ...params: GlobalEventParameters<TEventName>
-) => GlobalEventResult<TEventName>
+export type GlobalEventTrigger<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = (
+  ...params: GlobalEventParameters<TEventName, T>
+) => GlobalEventResult<TEventName, T>
 
-export type GlobalEventCallback<TEventName extends GlobalEventNames> = (
-  ...params: GlobalEventParameters<TEventName>
-) => GlobalEventResult<TEventName>
+export type GlobalEventCallback<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = (
+  ...params: GlobalEventParameters<TEventName, T>
+) => GlobalEventResult<TEventName, T>
 
 export type InternalEvent = 'missingHistoryItem' | 'loadDeferredProps'
 
-export type VisitCallbacks = {
+export type VisitCallbacks<T extends RequestPayload = RequestPayload> = {
   onCancelToken: { ({ cancel }: { cancel: VoidFunction }): void }
-  onBefore: GlobalEventCallback<'before'>
-  onStart: GlobalEventCallback<'start'>
-  onProgress: GlobalEventCallback<'progress'>
-  onFinish: GlobalEventCallback<'finish'>
-  onCancel: GlobalEventCallback<'cancel'>
-  onSuccess: GlobalEventCallback<'success'>
-  onError: GlobalEventCallback<'error'>
-  onPrefetched: GlobalEventCallback<'prefetched'>
-  onPrefetching: GlobalEventCallback<'prefetching'>
+  onBefore: GlobalEventCallback<'before', T>
+  onStart: GlobalEventCallback<'start', T>
+  onProgress: GlobalEventCallback<'progress', T>
+  onFinish: GlobalEventCallback<'finish', T>
+  onCancel: GlobalEventCallback<'cancel', T>
+  onSuccess: GlobalEventCallback<'success', T>
+  onError: GlobalEventCallback<'error', T>
+  onPrefetched: GlobalEventCallback<'prefetched', T>
+  onPrefetching: GlobalEventCallback<'prefetching', T>
 }
 
-export type VisitOptions<T extends RequestPayload = RequestPayload> = Partial<Visit<T> & VisitCallbacks>
+export type VisitOptions<T extends RequestPayload = RequestPayload> = Partial<Visit<T> & VisitCallbacks<T>>
 
 export type ReloadOptions<T extends RequestPayload = RequestPayload> = Omit<
   VisitOptions<T>,
@@ -279,7 +279,7 @@ export type PendingVisitOptions = {
 
 export type PendingVisit<T extends RequestPayload = RequestPayload> = Visit<T> & PendingVisitOptions
 
-export type ActiveVisit = PendingVisit & Required<VisitOptions>
+export type ActiveVisit<T extends RequestPayload = RequestPayload> = PendingVisit<T> & Required<VisitOptions>
 
 export type InternalActiveVisit = ActiveVisit & {
   onPrefetchResponse?: (response: Response) => void


### PR DESCRIPTION
## Description

This builds on the recent change (#2304 & #1537) where `Visit` was made generic. Since `PendingVisit` is based on `Visit`, it made sense to make it generic too, along with related types like `VisitCallbacks`.

Now we can pass a data type to those hooks, which helps with type checking when working with things like `onBefore`, `onError`, etc.

Example:

```ts
const options: VisitHelperOptions<MyFormData> = {
    onBefore: (visit: PendingVisit<MyFormData>) => {
        // visit.data is now typed
    },
    onError: (errors) => {
        // ...
    },
};
```

This just makes things a bit smoother and safer when working with form data and Inertia events.
