### PR TITLE
allow passing partial errors object to `setError()`

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -38,7 +38,7 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   clearErrors: (...fields: FormDataKeys<TForm>[]) => void
   resetAndClearErrors: (...fields: FormDataKeys<TForm>[]) => void
   setError(field: FormDataKeys<TForm>, value: string): void
-  setError(errors: Record<FormDataKeys<TForm>, string>): void
+  setError(errors: Partial<Record<FormDataKeys<TForm>, string>>): void
   submit: (...args: [Method, string, FormOptions?] | [{ url: string; method: Method }, FormOptions?]) => void
   get: (url: string, options?: FormOptions) => void
   patch: (url: string, options?: FormOptions) => void
@@ -256,7 +256,7 @@ export default function useForm<TForm extends FormDataType>(
   )
 
   const setError = useCallback(
-    (fieldOrFields: FormDataKeys<TForm> | Record<FormDataKeys<TForm>, string>, maybeValue?: string) => {
+    (fieldOrFields: FormDataKeys<TForm> | Partial<Record<FormDataKeys<TForm>, string>>, maybeValue?: string) => {
       setErrors((errors) => {
         const newErrors = {
           ...errors,

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -38,7 +38,7 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   clearErrors(...fields: FormDataKeys<TForm>[]): this
   resetAndClearErrors(...fields: FormDataKeys<TForm>[]): this
   setError(field: FormDataKeys<TForm>, value: string): this
-  setError(errors: Errors): this
+  setError(errors: Partial<Record<FormDataKeys<TForm>, string>>): this
   submit: (...args: [Method, string, FormOptions?] | [{ url: string; method: Method }, FormOptions?]) => void
   get(url: string, options?: FormOptions): void
   post(url: string, options?: FormOptions): void
@@ -121,7 +121,7 @@ export default function useForm<TForm extends FormDataType>(
 
       return this
     },
-    setError(fieldOrFields: FormDataKeys<TForm> | Errors, maybeValue?: string) {
+    setError(fieldOrFields: FormDataKeys<TForm> | Partial<Record<FormDataKeys<TForm>, string>>, maybeValue?: string) {
       this.setStore('errors', {
         ...this.errors,
         ...((typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields) as Errors),

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -23,7 +23,7 @@ export interface InertiaFormProps<TForm extends FormDataType> {
   clearErrors(...fields: FormDataKeys<TForm>[]): this
   resetAndClearErrors(...fields: FormDataKeys<TForm>[]): this
   setError(field: FormDataKeys<TForm>, value: string): this
-  setError(errors: Record<FormDataKeys<TForm>, string>): this
+  setError(errors: Partial<Record<FormDataKeys<TForm>, string>>): this
   submit: (...args: [Method, string, FormOptions?] | [{ url: string; method: Method }, FormOptions?]) => void
   get(url: string, options?: FormOptions): void
   post(url: string, options?: FormOptions): void
@@ -107,7 +107,7 @@ export default function useForm<TForm extends FormDataType>(
 
       return this
     },
-    setError(fieldOrFields: FormDataKeys<TForm> | Record<FormDataKeys<TForm>, string>, maybeValue?: string) {
+    setError(fieldOrFields: FormDataKeys<TForm> | Partial<Record<FormDataKeys<TForm>, string>>, maybeValue?: string) {
       Object.assign(this.errors, typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields)
 
       this.hasErrors = Object.keys(this.errors).length > 0


### PR DESCRIPTION
The documentation at https://inertiajs.com/forms#form-helper says following about `setError()` for React:
```js
const { setError } = useForm({ ... })

// Set a single error...
setError('field', 'Your error message.');

// Set multiple errors at once...
setError({
  foo: 'Your error message for the foo field.',
  bar: 'Some other error for the bar field.'
});
```
The documentation does not say that errors object passed to `setError()` should contain error for all form fields. And, the functionality of `setError()` is as per the documentation. But, because of the type, errors object should contain error for all form fields.

For the following code:
```ts
import { useForm } from "@inertiajs/react";

const form = useForm({
  name: '',
  address: '',
});
form.setError({
  name: '',
});
```
the type error is:
```
Argument of type '{ name: string; }' is not assignable to parameter of type 'Record<"name" | "address", string>'.
  Property 'address' is missing in type '{ name: string; }' but required in type 'Record<"name" | "address", string>'.ts(2345)
```

This change allows partial errors object.

Similar change is applied to the package for Vue.

Regarding package for Svelte, the type is now more specific similar to React and Vue.