### PR TITLE
improve type in `useForm.ts` files

### DIFF
--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -32,7 +32,7 @@ export interface InertiaFormProps<TForm extends FormDataType<TForm>> {
   setStore(data: TForm): void
   setStore<T extends FormDataKeys<TForm>>(key: T, value: FormDataValues<TForm, T>): void
   data(): TForm
-  transform(callback: (data: TForm) => object): this
+  transform(callback: (data: TForm) => FormDataType<TForm>): this
   defaults(): this
   defaults(fields: Partial<TForm>): this
   defaults<T extends FormDataKeys<TForm>>(field: T, value: FormDataValues<TForm, T>): this
@@ -208,7 +208,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
         onError: (errors: Errors) => {
           this.setStore('processing', false)
           this.setStore('progress', null)
-          this.clearErrors().setError(errors)
+          this.clearErrors().setError(errors as FormDataError<TForm>)
 
           if (options.onError) {
             return options.onError(errors)

--- a/packages/vue3/tsconfig.json
+++ b/packages/vue3/tsconfig.json
@@ -6,7 +6,6 @@
 
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "target": "ES2020",
-    "types": ["node"],
 
     "declaration": true,
     "declarationDir": "types",
@@ -21,7 +20,7 @@
     "noUnusedParameters": true,
     "preserveConstEnums": true,
     "removeComments": true,
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": []
     // "strict": true
   }
 }


### PR DESCRIPTION
This PR improves type in `useForm.ts` files.

If you enable `strict: true` in React and Vue packages' `tsconfig.json`, you can see that all type error in those files are gone. In the case of Svelte, the type problem still exist and all are related to `setStore()`.