### PR TITLE
TypeScript improvements for `Link` component and Client Side Visits

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -296,6 +296,7 @@ export class Router {
     const current = currentPage.get()
 
     const props = typeof params.props === 'function' ? params.props(current.props) : (params.props ?? current.props)
+    props.errors = props.errors || {}
 
     const { onError, onFinish, onSuccess, ...pageParams } = params
 
@@ -304,7 +305,7 @@ export class Router {
         {
           ...current,
           ...pageParams,
-          props,
+          props: props as Page['props'],
         },
         {
           replace,

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -296,7 +296,6 @@ export class Router {
     const current = currentPage.get()
 
     const props = typeof params.props === 'function' ? params.props(current.props) : (params.props ?? current.props)
-    props.errors = props.errors || {}
 
     const { onError, onFinish, onSuccess, ...pageParams } = params
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -118,14 +118,10 @@ export type ScrollRegion = {
   left: number
 }
 
-export type ClientSidePageProps = Omit<PageProps, 'errors'> & {
-  errors?: Errors
-}
-
 export interface ClientSideVisitOptions {
   component?: Page['component']
   url?: Page['url']
-  props?: ((props: Page['props']) => ClientSidePageProps) | ClientSidePageProps
+  props?: ((props: Page['props']) => PageProps) | PageProps
   clearHistory?: Page['clearHistory']
   encryptHistory?: Page['encryptHistory']
   preserveScroll?: VisitOptions['preserveScroll']

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,10 +10,10 @@ declare module 'axios' {
 export type DefaultInertiaConfig = {
   errorValueType: string
 }
-/** 
+/**
  * Designed to allow overriding of some core types using TypeScript
  * interface declaration merging.
- * 
+ *
  * @see {@link DefaultInertiaConfig} for keys to override
  * @example
  * ```ts
@@ -118,10 +118,14 @@ export type ScrollRegion = {
   left: number
 }
 
+export type ClientSidePageProps = Omit<PageProps, 'errors'> & {
+  errors?: Errors
+}
+
 export interface ClientSideVisitOptions {
   component?: Page['component']
   url?: Page['url']
-  props?: ((props: Page['props']) => Page['props']) | Page['props']
+  props?: ((props: Page['props']) => ClientSidePageProps) | ClientSidePageProps
   clearHistory?: Page['clearHistory']
   encryptHistory?: Page['encryptHistory']
   preserveScroll?: VisitOptions['preserveScroll']
@@ -345,7 +349,7 @@ export type PrefetchOptions = {
 export interface LinkComponentBaseProps
   extends Partial<
     Pick<
-      Visit<Record<string, FormDataConvertible>>,
+      Visit<RequestPayload>,
       | 'data'
       | 'method'
       | 'replace'
@@ -357,13 +361,13 @@ export interface LinkComponentBaseProps
       | 'queryStringArrayFormat'
       | 'async'
     > &
-      Omit<VisitCallbacks, 'onCancelToken'>
-  > {
-  href: string | { url: string; method: Method }
-  onCancelToken?: (cancelToken: import('axios').CancelTokenSource) => void
-  prefetch?: boolean | LinkPrefetchOption | LinkPrefetchOption[]
-  cacheFor?: CacheForOption | CacheForOption[]
-}
+      Omit<VisitCallbacks, 'onCancelToken'> & {
+        href: string | { url: string; method: Method }
+        onCancelToken: (cancelToken: import('axios').CancelTokenSource) => void
+        prefetch: boolean | LinkPrefetchOption | LinkPrefetchOption[]
+        cacheFor: CacheForOption | CacheForOption[]
+      }
+  > {}
 
 type PrefetchObject = {
   params: ActiveVisit

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -35,17 +35,17 @@ export function mergeDataIntoQueryString(
   data: RequestPayload,
   qsArrayFormat: 'indices' | 'brackets' = 'brackets',
 ): [string, RequestPayload] {
-  const hasData = isFormData(data) ? [...data.entries()].length > 0 : Object.keys(data).length > 0
+  const hasDataForQueryString = method === 'get' && !isFormData(data) && Object.keys(data).length > 0
   const hasHost = /^[a-z][a-z0-9+.-]*:\/\//i.test(href.toString())
   const hasAbsolutePath = hasHost || href.toString().startsWith('/')
   const hasRelativePath = !hasAbsolutePath && !href.toString().startsWith('#') && !href.toString().startsWith('?')
   const hasRelativePathWithDotPrefix = /^[.]{1,2}([/]|$)/.test(href.toString())
-  const hasSearch = href.toString().includes('?') || (method === 'get' && hasData)
+  const hasSearch = href.toString().includes('?') || hasDataForQueryString
   const hasHash = href.toString().includes('#')
 
   const url = new URL(href.toString(), typeof window === 'undefined' ? 'http://localhost' : window.location.toString())
 
-  if (method === 'get' && hasData) {
+  if (hasDataForQueryString) {
     const parseOptions = { ignoreQueryPrefix: true, parseArrays: false }
     url.search = qs.stringify(
       { ...qs.parse(url.search, parseOptions), ...data },

--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -27,7 +27,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
       children,
       as = 'a',
       data = {},
-      href,
+      href = '',
       method = 'get',
       preserveScroll = false,
       preserveState = null,
@@ -71,13 +71,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
     }, [as, _method])
 
     const mergeDataArray = useMemo(
-      () =>
-        mergeDataIntoQueryString(
-          _method,
-          typeof href === 'object' ? href.url : href || '',
-          data,
-          queryStringArrayFormat,
-        ),
+      () => mergeDataIntoQueryString(_method, typeof href === 'object' ? href.url : href, data, queryStringArrayFormat),
       [href, _method, data, queryStringArrayFormat],
     )
 

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -34,7 +34,7 @@ const Link: InertiaLink = defineComponent({
     },
     href: {
       type: [String, Object] as PropType<InertiaLinkProps['href']>,
-      required: true,
+      default: '',
     },
     method: {
       type: String as PropType<Method>,
@@ -181,7 +181,7 @@ const Link: InertiaLink = defineComponent({
     const mergeDataArray = computed(() =>
       mergeDataIntoQueryString(
         method.value,
-        typeof props.href === 'object' ? props.href.url : props.href || '',
+        typeof props.href === 'object' ? props.href.url : props.href,
         props.data,
         props.queryStringArrayFormat,
       ),

--- a/tests/core/url.test.ts
+++ b/tests/core/url.test.ts
@@ -11,6 +11,16 @@ test.describe('url.ts', () => {
         expect(data).toEqual({})
       })
 
+      test('returns the FormData instance when passed as data', () => {
+        const formData = new FormData()
+        formData.append('q', 'foo')
+
+        const [href, data] = mergeDataIntoQueryString('post', '/search', formData)
+
+        expect(href).toBe('/search')
+        expect(data).toEqual(formData)
+      })
+
       test('merges new data into an existing query string', () => {
         const [href, data] = mergeDataIntoQueryString('get', '/search?lang=en', { q: 'bar' })
 


### PR DESCRIPTION
This PR brings some improvements to the TypeScript implementation:

- The `Link` component now accepts a `FormData` type as `data`.
- The `href` attribute of the `Link` component is now optional as it already defaulted to `''` in the components.
- When making Client Side Visits, it expected the returned props to include an `errors` key. That's not required anymore.