### PR TITLE
Only reset useForm processing and progress with onFinish

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -124,8 +124,6 @@ export default function useForm<TForm extends FormDataType>(
         },
         onSuccess: (page) => {
           if (isMounted.current) {
-            setProcessing(false)
-            setProgress(null)
             setErrors({})
             setHasErrors(false)
             setWasSuccessful(true)
@@ -144,8 +142,6 @@ export default function useForm<TForm extends FormDataType>(
         },
         onError: (errors) => {
           if (isMounted.current) {
-            setProcessing(false)
-            setProgress(null)
             setErrors(errors)
             setHasErrors(true)
           }
@@ -155,11 +151,6 @@ export default function useForm<TForm extends FormDataType>(
           }
         },
         onCancel: () => {
-          if (isMounted.current) {
-            setProcessing(false)
-            setProgress(null)
-          }
-
           if (options.onCancel) {
             return options.onCancel()
           }

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -190,8 +190,6 @@ export default function useForm<TForm extends FormDataType>(
           }
         },
         onSuccess: async (page: Page) => {
-          this.setStore('processing', false)
-          this.setStore('progress', null)
           this.clearErrors()
           this.setStore('wasSuccessful', true)
           this.setStore('recentlySuccessful', true)
@@ -202,8 +200,6 @@ export default function useForm<TForm extends FormDataType>(
           return onSuccess
         },
         onError: (errors: Errors) => {
-          this.setStore('processing', false)
-          this.setStore('progress', null)
           this.clearErrors().setError(errors)
 
           if (options.onError) {
@@ -211,9 +207,6 @@ export default function useForm<TForm extends FormDataType>(
           }
         },
         onCancel: () => {
-          this.setStore('processing', false)
-          this.setStore('progress', null)
-
           if (options.onCancel) {
             return options.onCancel()
           }

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -173,8 +173,6 @@ export default function useForm<TForm extends FormDataType>(
           }
         },
         onSuccess: async (page) => {
-          this.processing = false
-          this.progress = null
           this.clearErrors()
           this.wasSuccessful = true
           this.recentlySuccessful = true
@@ -186,8 +184,6 @@ export default function useForm<TForm extends FormDataType>(
           return onSuccess
         },
         onError: (errors) => {
-          this.processing = false
-          this.progress = null
           this.clearErrors().setError(errors)
 
           if (options.onError) {
@@ -195,9 +191,6 @@ export default function useForm<TForm extends FormDataType>(
           }
         },
         onCancel: () => {
-          this.processing = false
-          this.progress = null
-
           if (options.onCancel) {
             return options.onCancel()
           }

--- a/tests/form-helper.spec.ts
+++ b/tests/form-helper.spec.ts
@@ -658,36 +658,6 @@ test.describe('Form Helper', () => {
         await expect(pageData).toHaveProperty('version')
       })
 
-      test('marks the form as no longer processing', async ({ page }) => {
-        await page.getByRole('button', { exact: true, name: 'onSuccess resets processing' }).click()
-
-        const data = await page.evaluate(() => (window as any).data)
-
-        const processing = data.find((d) => d.event === 'onStart' && d.type === 'processing').data
-        const notProcessing = data.find((d) => d.event === 'onFinish' && d.type === 'processing').data
-
-        await expect(processing).toBe(true)
-        await expect(notProcessing).toBe(false)
-      })
-
-      test('resets the progress property back to null', async ({ page }) => {
-        await clickAndWaitForResponse(page, 'onSuccess progress property', 'sleep', 'button')
-
-        const messages = await page.evaluate(() => (window as any).events)
-        const data = await page.evaluate(() => (window as any).data)
-        const event = data.find((d) => d.event === 'onProgress' && d.type === 'progress').data
-        const endEvent = data.find((d) => d.event === 'onFinish' && d.type === 'progress').data
-
-        await expect(event).toHaveProperty('percentage')
-        await expect(event).toHaveProperty('total')
-        await expect(event).toHaveProperty('loaded')
-        await expect(event.percentage).toBeGreaterThanOrEqual(0)
-        await expect(event.percentage).toBeLessThanOrEqual(100)
-
-        await expect(messages[4]).toBe('onFinish')
-        await expect(endEvent).toBeNull()
-      })
-
       test('can delay onFinish from firing by returning a promise', async ({ page }) => {
         await clickAndWaitForResponse(page, 'onSuccess promise', '/dump/post', 'button')
 
@@ -775,42 +745,6 @@ test.describe('Form Helper', () => {
         await expect(errors.name).toBe('Some name error')
       })
 
-      test('marks the form as no longer processing', async ({ page }) => {
-        await clickAndWaitForResponse(page, 'onError resets processing', 'form-helper/events/errors', 'button')
-
-        const messages = await page.evaluate(() => (window as any).events)
-        const data = await page.evaluate(() => (window as any).data)
-
-        await expect(messages).toEqual(['onBefore', 'onCancelToken', 'onStart', 'onError', 'onFinish'])
-
-        const processing = data.find((d) => d.event === 'onStart' && d.type === 'processing').data
-        const notProcessing = data.find((d) => d.event === 'onFinish' && d.type === 'processing').data
-
-        await expect(processing).toBe(true)
-        await expect(notProcessing).toBe(false)
-      })
-
-      test('resets the progress property back to null', async ({ page }) => {
-        await clickAndWaitForResponse(page, 'onError progress property', 'form-helper/events/errors', 'button')
-
-        const messages = await page.evaluate(() => (window as any).events)
-        const data = await page.evaluate(() => (window as any).data)
-
-        await expect(messages[3]).toBe('onProgress')
-
-        const event = data.find((d) => d.event === 'onProgress' && d.type === 'progress').data
-        const finishEvent = data.find((d) => d.event === 'onFinish' && d.type === 'progress').data
-
-        await expect(event).toHaveProperty('percentage')
-        await expect(event).toHaveProperty('total')
-        await expect(event).toHaveProperty('loaded')
-        await expect(event.percentage).toBeGreaterThanOrEqual(0)
-        await expect(event.percentage).toBeLessThanOrEqual(100)
-
-        await expect(messages[4]).toBe('onError')
-        await expect(finishEvent).toBeNull()
-      })
-
       test('sets form errors', async ({ page }) => {
         await clickAndWaitForResponse(page, 'Errors set on error', 'form-helper/events/errors', 'button')
 
@@ -853,6 +787,36 @@ test.describe('Form Helper', () => {
         const messages = await page.evaluate(() => (window as any).events)
 
         await expect(messages).toEqual(['onBefore', 'onCancelToken', 'onStart', 'onSuccess', 'onFinish'])
+      })
+
+      test('marks the form as no longer processing', async ({ page }) => {
+        await page.getByRole('button', { exact: true, name: 'onSuccess resets processing' }).click()
+
+        const data = await page.evaluate(() => (window as any).data)
+
+        const processing = data.find((d) => d.event === 'onStart' && d.type === 'processing').data
+        const notProcessing = data.find((d) => d.event === 'onFinish' && d.type === 'processing').data
+
+        await expect(processing).toBe(true)
+        await expect(notProcessing).toBe(false)
+      })
+
+      test('resets the progress property back to null', async ({ page }) => {
+        await clickAndWaitForResponse(page, 'onSuccess progress property', 'sleep', 'button')
+
+        const messages = await page.evaluate(() => (window as any).events)
+        const data = await page.evaluate(() => (window as any).data)
+        const event = data.find((d) => d.event === 'onProgress' && d.type === 'progress').data
+        const endEvent = data.find((d) => d.event === 'onFinish' && d.type === 'progress').data
+
+        await expect(event).toHaveProperty('percentage')
+        await expect(event).toHaveProperty('total')
+        await expect(event).toHaveProperty('loaded')
+        await expect(event.percentage).toBeGreaterThanOrEqual(0)
+        await expect(event.percentage).toBeLessThanOrEqual(100)
+
+        await expect(messages[4]).toBe('onFinish')
+        await expect(endEvent).toBeNull()
       })
     })
   })


### PR DESCRIPTION
Closes #2463

Previously the form helper's onSuccess, onError, onCancel, and onFinish callbacks all set `processing = false` and `progress = null`. This PR makes it so that now only happens in `onFinish`.

Aside from the pedantic and DRY reasons to do this, this also helps those of us using the feature of onSuccess and onError where you can [return a promise](https://inertiajs.com/manual-visits#event-callbacks), and onFinish won't be called until it resolves.

I'm using that feature in some forms that do work in a background job, which I poll the status of inside the promise, and this change allows the form's processing to remain true during that entire time and not just the initial submission.
