### PR TITLE
Improve consistency in `useForm` across adapters

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -2,6 +2,7 @@ import {
   ErrorValue,
   FormDataErrors,
   FormDataKeys,
+  FormDataType,
   FormDataValues,
   Method,
   Progress,
@@ -52,12 +53,12 @@ export interface InertiaFormProps<TForm extends object> {
   delete: (url: string, options?: FormOptions) => void
   cancel: () => void
 }
-export default function useForm<TForm extends object>(initialValues?: TForm | (() => TForm)): InertiaFormProps<TForm>
-export default function useForm<TForm extends object>(
+export default function useForm<TForm extends FormDataType<TForm>>(initialValues?: TForm | (() => TForm)): InertiaFormProps<TForm>
+export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKey: string,
   initialValues?: TForm | (() => TForm),
 ): InertiaFormProps<TForm>
-export default function useForm<TForm extends object>(
+export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKeyOrInitialValues?: string | TForm | (() => TForm),
   maybeInitialValues?: TForm | (() => TForm),
 ): InertiaFormProps<TForm> {

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -4,6 +4,7 @@ import type {
   ErrorValue,
   FormDataErrors,
   FormDataKeys,
+  FormDataType,
   FormDataValues,
   Method,
   Page,
@@ -51,12 +52,12 @@ export interface InertiaFormProps<TForm extends object> {
 
 export type InertiaForm<TForm extends object> = InertiaFormProps<TForm> & TForm
 
-export default function useForm<TForm extends object>(data: TForm | (() => TForm)): Writable<InertiaForm<TForm>>
-export default function useForm<TForm extends object>(
+export default function useForm<TForm extends FormDataType<TForm>>(data: TForm | (() => TForm)): Writable<InertiaForm<TForm>>
+export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKey: string,
   data: TForm | (() => TForm),
 ): Writable<InertiaForm<TForm>>
-export default function useForm<TForm extends object>(
+export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKeyOrData: string | TForm | (() => TForm),
   maybeData?: TForm | (() => TForm),
 ): Writable<InertiaForm<TForm>> {


### PR DESCRIPTION
Use `FormDataType` in the React and Svelte implementations as well.