### PR TITLE
Improve TypeScript support for Client Side Visit `props` callback

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -284,18 +284,19 @@ export class Router {
     return currentPage.resolve(component)
   }
 
-  public replace(params: ClientSideVisitOptions): void {
+  public replace<TProps = Page['props']>(params: ClientSideVisitOptions<TProps>): void {
     this.clientVisit(params, { replace: true })
   }
 
-  public push(params: ClientSideVisitOptions): void {
+  public push<TProps = Page['props']>(params: ClientSideVisitOptions<TProps>): void {
     this.clientVisit(params)
   }
 
-  protected clientVisit(params: ClientSideVisitOptions, { replace = false }: { replace?: boolean } = {}): void {
+  protected clientVisit<TProps = Page['props']>(params: ClientSideVisitOptions<TProps>, { replace = false }: { replace?: boolean } = {}): void {
     const current = currentPage.get()
 
-    const props = typeof params.props === 'function' ? params.props(current.props) : (params.props ?? current.props)
+    const props =
+      typeof params.props === 'function' ? params.props(current.props as TProps) : (params.props ?? current.props)
 
     const { onError, onFinish, onSuccess, ...pageParams } = params
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -127,17 +127,17 @@ export type ScrollRegion = {
   left: number
 }
 
-export interface ClientSideVisitOptions {
+export interface ClientSideVisitOptions<TProps = Page['props']> {
   component?: Page['component']
   url?: Page['url']
-  props?: ((props: Page['props']) => PageProps) | PageProps
+  props?: ((props: TProps) => PageProps) | PageProps
   clearHistory?: Page['clearHistory']
   encryptHistory?: Page['encryptHistory']
   preserveScroll?: VisitOptions['preserveScroll']
   preserveState?: VisitOptions['preserveState']
   errorBag?: string | null
   onError?: (errors: Errors) => void
-  onFinish?: (visit: ClientSideVisitOptions) => void
+  onFinish?: (visit: ClientSideVisitOptions<TProps>) => void
   onSuccess?: (page: Page) => void
 }
 


### PR DESCRIPTION
This PR brings support for type-safe `props` callbacks in Client Side Visits:

```ts
interface PageProps {
  foo: string
  bar: string
}

const props = defineProps<PageProps>()

router.replace({
  props: (props: PageProps) => ({ ...props, bar: 'baz' }),
})
```