### PR TITLE
TS improvements to Svelte's `<Form>` and `useForm()` implementations

### DIFF
--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -3,6 +3,7 @@
     formDataToObject,
     mergeDataIntoQueryString,
     type FormDataConvertible,
+    type Errors,
     type FormComponentProps,
     type VisitOptions,
   } from '@inertiajs/core'
@@ -107,6 +108,7 @@
       formEvents.forEach((e) => formElement?.removeEventListener(e, updateDirtyState))
     }
   })
+  $: slotErrors = $form.errors as Errors
 </script>
 
 <form
@@ -116,7 +118,7 @@
   on:submit={handleSubmit} {...$$restProps}
 >
   <slot
-    errors={$form.errors}
+    errors={slotErrors}
     hasErrors={$form.hasErrors}
     processing={$form.processing}
     progress={$form.progress}

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -19,6 +19,8 @@ import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
 import { writable, type Writable } from 'svelte/store'
 
+type InertiaFormStore<TForm extends object> = Writable<InertiaForm<TForm>> & InertiaForm<TForm>
+
 type FormOptions = Omit<VisitOptions, 'data'>
 
 export interface InertiaFormProps<TForm extends object> {
@@ -52,15 +54,15 @@ export interface InertiaFormProps<TForm extends object> {
 
 export type InertiaForm<TForm extends object> = InertiaFormProps<TForm> & TForm
 
-export default function useForm<TForm extends FormDataType<TForm>>(data: TForm | (() => TForm)): Writable<InertiaForm<TForm>>
+export default function useForm<TForm extends FormDataType<TForm>>(data: TForm | (() => TForm)): InertiaFormStore<TForm>
 export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKey: string,
   data: TForm | (() => TForm),
-): Writable<InertiaForm<TForm>>
+): InertiaFormStore<TForm>
 export default function useForm<TForm extends FormDataType<TForm>>(
   rememberKeyOrData: string | TForm | (() => TForm),
   maybeData?: TForm | (() => TForm),
-): Writable<InertiaForm<TForm>> {
+): InertiaFormStore<TForm> {
   const rememberKey = typeof rememberKeyOrData === 'string' ? rememberKeyOrData : null
   const inputData = (typeof rememberKeyOrData === 'string' ? maybeData : rememberKeyOrData) ?? {}
   const data: TForm = typeof inputData === 'function' ? inputData() : (inputData as TForm)


### PR DESCRIPTION
Fixes TS errors when accessing errors within the `<Form>` component