### PR TITLE
Add Support for Dynamic Root-level Form Properties in Vue and Svelte

### DIFF
--- a/packages/react/test-app/Pages/FormHelper/Data.jsx
+++ b/packages/react/test-app/Pages/FormHelper/Data.jsx
@@ -1,10 +1,12 @@
 import { useForm, usePage } from '@inertiajs/react'
+import { useEffect, useState } from 'react'
 
 export default (props) => {
   const form = useForm({
     name: 'foo',
     handle: 'example',
     remember: false,
+    custom: {},
   })
 
   const page = usePage()
@@ -32,6 +34,23 @@ export default (props) => {
   const reassignSingle = () => {
     form.setDefaults('name', 'single value')
   }
+
+  const addCustomOtherProp = () => {
+    form.setData((prevData) => ({
+      ...prevData,
+      custom: {
+        ...prevData.custom,
+        other_prop: 'dynamic_value',
+      },
+    }))
+  }
+
+  const [formDataOutput, setFormDataOutput] = useState('')
+
+  // Effect to watch form.data and update formDataOutput
+  useEffect(() => {
+    setFormDataOutput(JSON.stringify(form.data))
+  }, [form.data])
 
   return (
     <div>
@@ -69,6 +88,18 @@ export default (props) => {
       </label>
       {form.errors.remember && <span className="remember_error">{form.errors.remember}</span>}
 
+      <label>
+        Accept Terms and Conditions
+        <input
+          type="checkbox"
+          id="accept_tos"
+          name="accept_tos"
+          onChange={(e) => form.setData('accept_tos', e.target.checked)}
+          checked={!!form.data.accept_tos}
+        />
+      </label>
+      {form.errors.accept_tos && <span className="accept_tos_error">{form.errors.accept_tos}</span>}
+
       <button onClick={submit} className="submit">
         Submit form
       </button>
@@ -90,7 +121,15 @@ export default (props) => {
         Reassign single default
       </button>
 
+      <button onClick={addCustomOtherProp} className="add-custom-other-prop">
+        Add custom.other_prop
+      </button>
+
       <span className="errors-status">Form has {form.hasErrors ? '' : 'no '}errors</span>
+
+      <div id="form-data-output" data-test-id="form-data-output" style={{ display: 'none' }}>
+        {formDataOutput}
+      </div>
     </div>
   )
 }

--- a/packages/svelte/test-app/Pages/FormHelper/Data.svelte
+++ b/packages/svelte/test-app/Pages/FormHelper/Data.svelte
@@ -5,6 +5,7 @@
     name: 'foo',
     handle: 'example',
     remember: false,
+    custom: {},
   })
 
   const submit = () => {
@@ -33,6 +34,22 @@
   const reassignSingle = () => {
     $form.defaults('name', 'single value')
   }
+
+  // New functions for dynamic properties
+  const addAcceptTos = () => {
+    $form.accept_tos = true // Add root-level dynamic property
+  }
+
+  const addCustomOtherProp = () => {
+    $form.custom.other_prop = 'dynamic_value' // Add nested dynamic property
+  }
+
+  // Reactive property to hold the stringified form.data() output
+  import { writable } from 'svelte/store'
+  const formDataOutput = writable('')
+
+  // Watch $form.data() and update formDataOutput
+  $: formDataOutput.set(JSON.stringify($form.data()))
 </script>
 
 <div>
@@ -58,6 +75,14 @@
     <span class="remember_error">{$form.errors.remember}</span>
   {/if}
 
+  <label>
+    Accept Terms and Conditions
+    <input type="checkbox" id="accept_tos" name="accept_tos" on:change={() => ($form.accept_tos = true)} />
+  </label>
+  {#if $form.errors.accept_tos}
+    <span class="accept_tos_error">{$form.errors.accept_tos}</span>
+  {/if}
+
   <button on:click={submit} class="submit">Submit form</button>
 
   <button on:click={resetAll} class="reset">Reset all data</button>
@@ -67,5 +92,10 @@
   <button on:click={reassignObject} class="reassign-object">Reassign default values</button>
   <button on:click={reassignSingle} class="reassign-single">Reassign single default</button>
 
+  <button on:click={addCustomOtherProp} class="add-custom-other-prop">Add custom.other_prop</button>
+
   <span class="errors-status">Form has {$form.hasErrors ? '' : 'no '}errors</span>
+
+  <!-- Hidden div to display form.data() output for Playwright -->
+  <div id="form-data-output" data-test-id="form-data-output" style="display: none">{$formDataOutput}</div>
 </div>

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -54,8 +54,10 @@ export default function useForm<TForm extends FormDataType>(
   let recentlySuccessfulTimeoutId = null
   let transform = (data) => data
 
+  const initialData = restored ? restored.data : cloneDeep(defaults)
+
   const form = reactive({
-    ...(restored ? restored.data : cloneDeep(defaults)),
+    ...initialData,
     isDirty: false,
     errors: restored ? restored.errors : {},
     hasErrors: false,
@@ -64,7 +66,10 @@ export default function useForm<TForm extends FormDataType>(
     wasSuccessful: false,
     recentlySuccessful: false,
     data() {
-      return (Object.keys(defaults) as Array<FormDataKeys<TForm>>).reduce((carry, key) => {
+      return (Object.keys(this) as Array<FormDataKeys<TForm>>).reduce((carry, key) => {
+        if (RESERVED_KEYS.includes(key)) {
+          return carry
+        }
         return set(carry, key, get(this, key))
       }, {} as Partial<TForm>) as TForm
     },
@@ -248,6 +253,8 @@ export default function useForm<TForm extends FormDataType>(
       this.setError(restored.errors)
     },
   })
+
+  const RESERVED_KEYS = Object.keys(form).filter((key) => !(key in initialData))
 
   watch(
     form,

--- a/packages/vue3/test-app/Pages/FormHelper/Data.vue
+++ b/packages/vue3/test-app/Pages/FormHelper/Data.vue
@@ -1,10 +1,12 @@
 <script setup>
 import { useForm, usePage } from '@inertiajs/vue3'
+import { reactive, watch } from 'vue'
 
 const form = useForm({
   name: 'foo',
   handle: 'example',
   remember: false,
+  custom: {},
 })
 
 const page = usePage()
@@ -35,6 +37,21 @@ const reassignObject = () => {
 const reassignSingle = () => {
   form.defaults('name', 'single value')
 }
+
+const addCustomOtherProp = () => {
+  form.custom.other_prop = 'dynamic_value' // Add nested dynamic property
+}
+
+const formDataOutput = reactive({
+  json: '',
+})
+watch(
+  () => form.data(),
+  (newData) => {
+    formDataOutput.json = JSON.stringify(newData)
+  },
+  { deep: true, immediate: true },
+)
 </script>
 
 <template>
@@ -54,6 +71,11 @@ const reassignSingle = () => {
       <input type="checkbox" id="remember" name="remember" v-model="form.remember" />
     </label>
     <span class="remember_error" v-if="form.errors.remember">{{ form.errors.remember }}</span>
+    <label>
+      Accept Terms and Conditions
+      <input type="checkbox" id="accept_tos" name="accept_tos" v-model="form.accept_tos" />
+    </label>
+    <span class="accept_tos_error" v-if="form.errors.accept_tos">{{ form.errors.accept_tos }}</span>
 
     <button @click="submit" class="submit">Submit form</button>
 
@@ -64,6 +86,10 @@ const reassignSingle = () => {
     <button @click="reassignObject" class="reassign-object">Reassign default values</button>
     <button @click="reassignSingle" class="reassign-single">Reassign single default</button>
 
+    <button @click="addCustomOtherProp" class="add-custom-other-prop">Add custom.other_prop</button>
+
     <span class="errors-status">Form has {{ form.hasErrors ? '' : 'no ' }}errors</span>
+
+    <div id="form-data-output" data-test-id="form-data-output" style="display: none">{{ formDataOutput.json }}</div>
   </div>
 </template>

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -109,6 +109,56 @@ test.describe('Form Component', () => {
     })
   })
 
+  test.describe('Dynamic Properties', () => {
+    test.beforeEach(async ({ page }) => {
+      pageLoads.watch(page)
+      await page.goto('/form-helper/data') // Navigate to the FormHelper/Data page
+    })
+
+    test('initial data() output contains only initial properties', async ({ page }) => {
+      const formDataOutput = await page.locator('#form-data-output').innerText()
+      const data = JSON.parse(formDataOutput)
+
+      expect(data).toEqual({
+        name: 'foo',
+        handle: 'example',
+        remember: false,
+        custom: {},
+      })
+    })
+
+    test('data() output includes root-level dynamic property', async ({ page }) => {
+      await page.check('input[name="accept_tos"]')
+
+      const formDataOutput = await page.locator('#form-data-output').innerText()
+      const data = JSON.parse(formDataOutput)
+
+      expect(data).toEqual({
+        name: 'foo',
+        handle: 'example',
+        remember: false,
+        custom: {},
+        accept_tos: true,
+      })
+    })
+
+    test('data() output includes nested dynamic property', async ({ page }) => {
+      await page.getByRole('button', { name: 'Add custom.other_prop' }).click()
+
+      const formDataOutput = await page.locator('#form-data-output').innerText()
+      const data = JSON.parse(formDataOutput)
+
+      expect(data).toEqual({
+        name: 'foo',
+        handle: 'example',
+        remember: false,
+        custom: {
+          other_prop: 'dynamic_value',
+        },
+      })
+    })
+  })
+
   test.describe('Headers', () => {
     test.beforeEach(async ({ page }) => {
       pageLoads.watch(page)
@@ -653,6 +703,5 @@ test.describe('Form Component', () => {
         },
       })
     })
-
   })
 })


### PR DESCRIPTION
Adds support for dynamic root-level form properties in Vue and Svelte, matching existing React behavior. Properties can be added after initialization, which helps avoid pre-defining every possible field on create pages and supports temporary values like “type your username to confirm.”  

**Changes**  
- Update `form.data()` in Vue and Svelte to track all form properties, including those added at runtime, not only those defined at initialization.  
- Update example pages to demonstrate dynamic properties.  
- Add Playwright tests for dynamic root-level and nested properties in all adapters.  

**Motivation**  
Fixes [#968](https://github.com/inertiajs/inertia/issues/968) and follows [discussion #859](https://github.com/inertiajs/inertia/discussions/859). Ensures consistent behavior across adapters.  
