### PR TITLE
Add Form component ref support

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -371,6 +371,8 @@ export type FormComponentSlotProps = {
   submit: () => void
 }
 
+export type FormComponentRef = FormComponentSlotProps
+
 declare global {
   interface DocumentEventMap {
     'inertia:before': GlobalEvent<'before'>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -355,21 +355,26 @@ export type FormComponentProps = Partial<
   options?: FormComponentOptions
 }
 
-export type FormComponentSlotProps = {
+export type FormComponentMethods = {
+  clearErrors: (...fields: string[]) => void
+  resetAndClearErrors: (...fields: string[]) => void
+  setError(field: string, value: string): void
+  setError(errors: Record<string, string>): void
+  reset: () => void
+  submit: () => void
+}
+
+export type FormComponentState = {
   errors: Record<string, string>
   hasErrors: boolean
   processing: boolean
   progress: Progress | null
   wasSuccessful: boolean
   recentlySuccessful: boolean
-  clearErrors: (...fields: string[]) => void
-  resetAndClearErrors: (...fields: string[]) => void
-  setError(field: string, value: string): void
-  setError(errors: Record<string, string>): void
   isDirty: boolean
-  reset: () => void
-  submit: () => void
 }
+
+export type FormComponentSlotProps = FormComponentMethods & FormComponentState
 
 export type FormComponentRef = FormComponentSlotProps
 

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -1,5 +1,6 @@
 import {
   FormComponentProps,
+  FormComponentRef,
   FormComponentSlotProps,
   FormDataConvertible,
   formDataToObject,
@@ -8,7 +9,17 @@ import {
   VisitOptions,
 } from '@inertiajs/core'
 import { isEqual } from 'es-toolkit'
-import { createElement, FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  createElement,
+  FormEvent,
+  forwardRef,
+  ReactNode,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import useForm from './useForm'
 
 type ComponentProps = (FormComponentProps &
@@ -21,113 +32,137 @@ type FormSubmitOptions = Omit<VisitOptions, 'data' | 'onPrefetched' | 'onPrefetc
 
 const noop = () => undefined
 
-const Form = ({
-  action = '',
-  method = 'get',
-  headers = {},
-  queryStringArrayFormat = 'brackets',
-  errorBag = null,
-  showProgress = true,
-  transform = (data) => data,
-  options = {},
-  onStart = noop,
-  onProgress = noop,
-  onFinish = noop,
-  onBefore = noop,
-  onCancel = noop,
-  onSuccess = noop,
-  onError = noop,
-  onCancelToken = noop,
-  children,
-  ...props
-}: ComponentProps) => {
-  const form = useForm({})
-  const formElement = useRef<HTMLFormElement>(null)
+const Form = forwardRef<FormComponentRef, ComponentProps>(
+  (
+    {
+      action = '',
+      method = 'get',
+      headers = {},
+      queryStringArrayFormat = 'brackets',
+      errorBag = null,
+      showProgress = true,
+      transform = (data) => data,
+      options = {},
+      onStart = noop,
+      onProgress = noop,
+      onFinish = noop,
+      onBefore = noop,
+      onCancel = noop,
+      onSuccess = noop,
+      onError = noop,
+      onCancelToken = noop,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const form = useForm({})
+    const formElement = useRef<HTMLFormElement>(null)
 
-  const resolvedMethod = useMemo(() => {
-    return typeof action === 'object' ? action.method : (method.toLowerCase() as Method)
-  }, [action, method])
+    const resolvedMethod = useMemo(() => {
+      return typeof action === 'object' ? action.method : (method.toLowerCase() as Method)
+    }, [action, method])
 
-  const [isDirty, setIsDirty] = useState(false)
-  const defaultValues = useRef<Record<string, FormDataConvertible>>({})
+    const [isDirty, setIsDirty] = useState(false)
+    const defaultValues = useRef<Record<string, FormDataConvertible>>({})
 
-  const getData = (): Record<string, FormDataConvertible> => {
-    // Convert the FormData to an object because we can't compare two FormData
-    // instances directly (which is needed for isDirty), mergeDataIntoQueryString()
-    // expects an object, and submitting a FormData instance directly causes problems with nested objects.
-    return formDataToObject(new FormData(formElement.current))
-  }
-
-  const updateDirtyState = (event: Event) =>
-    setIsDirty(event.type === 'reset' ? false : !isEqual(getData(), defaultValues.current))
-
-  useEffect(() => {
-    defaultValues.current = getData()
-
-    const formEvents: Array<keyof HTMLElementEventMap> = ['input', 'change', 'reset']
-
-    formEvents.forEach((e) => formElement.current.addEventListener(e, updateDirtyState))
-
-    return () => formEvents.forEach((e) => formElement.current?.removeEventListener(e, updateDirtyState))
-  }, [])
-
-  const submit = () => {
-    const [url, _data] = mergeDataIntoQueryString(
-      resolvedMethod,
-      typeof action === 'object' ? action.url : action,
-      getData(),
-      queryStringArrayFormat,
-    )
-
-    const submitOptions: FormSubmitOptions = {
-      headers,
-      errorBag,
-      showProgress,
-      onCancelToken,
-      onBefore,
-      onStart,
-      onProgress,
-      onFinish,
-      onCancel,
-      onSuccess,
-      onError,
-      ...options,
+    const getData = (): Record<string, FormDataConvertible> => {
+      // Convert the FormData to an object because we can't compare two FormData
+      // instances directly (which is needed for isDirty), mergeDataIntoQueryString()
+      // expects an object, and submitting a FormData instance directly causes problems with nested objects.
+      return formDataToObject(new FormData(formElement.current))
     }
 
-    form.transform(() => transform(_data))
-    form.submit(resolvedMethod, url, submitOptions)
-  }
+    const updateDirtyState = (event: Event) =>
+      setIsDirty(event.type === 'reset' ? false : !isEqual(getData(), defaultValues.current))
 
-  return createElement(
-    'form',
-    {
-      ...props,
-      ref: formElement,
-      action: typeof action === 'object' ? action.url : action,
-      method: resolvedMethod,
-      onSubmit: (event: FormEvent<HTMLFormElement>) => {
-        event.preventDefault()
-        submit()
+    useEffect(() => {
+      defaultValues.current = getData()
+
+      const formEvents: Array<keyof HTMLElementEventMap> = ['input', 'change', 'reset']
+
+      formEvents.forEach((e) => formElement.current.addEventListener(e, updateDirtyState))
+
+      return () => formEvents.forEach((e) => formElement.current?.removeEventListener(e, updateDirtyState))
+    }, [])
+
+    const submit = () => {
+      const [url, _data] = mergeDataIntoQueryString(
+        resolvedMethod,
+        typeof action === 'object' ? action.url : action,
+        getData(),
+        queryStringArrayFormat,
+      )
+
+      const submitOptions: FormSubmitOptions = {
+        headers,
+        errorBag,
+        showProgress,
+        onCancelToken,
+        onBefore,
+        onStart,
+        onProgress,
+        onFinish,
+        onCancel,
+        onSuccess,
+        onError,
+        ...options,
+      }
+
+      form.transform(() => transform(_data))
+      form.submit(resolvedMethod, url, submitOptions)
+    }
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        errors: form.errors,
+        hasErrors: form.hasErrors,
+        processing: form.processing,
+        progress: form.progress,
+        wasSuccessful: form.wasSuccessful,
+        recentlySuccessful: form.recentlySuccessful,
+        clearErrors: form.clearErrors,
+        resetAndClearErrors: form.resetAndClearErrors,
+        setError: form.setError,
+        isDirty,
+        reset: () => formElement.current?.reset(),
+        submit,
+      }),
+      [form, isDirty, submit],
+    )
+
+    return createElement(
+      'form',
+      {
+        ...props,
+        ref: formElement,
+        action: typeof action === 'object' ? action.url : action,
+        method: resolvedMethod,
+        onSubmit: (event: FormEvent<HTMLFormElement>) => {
+          event.preventDefault()
+          submit()
+        },
       },
-    },
-    typeof children === 'function'
-      ? children({
-          errors: form.errors,
-          hasErrors: form.hasErrors,
-          processing: form.processing,
-          progress: form.progress,
-          wasSuccessful: form.wasSuccessful,
-          recentlySuccessful: form.recentlySuccessful,
-          setError: form.setError,
-          clearErrors: form.clearErrors,
-          resetAndClearErrors: form.resetAndClearErrors,
-          isDirty,
-          reset: () => formElement.current?.reset(),
-          submit,
-        })
-      : children,
-  )
-}
+      typeof children === 'function'
+        ? children({
+            errors: form.errors,
+            hasErrors: form.hasErrors,
+            processing: form.processing,
+            progress: form.progress,
+            wasSuccessful: form.wasSuccessful,
+            recentlySuccessful: form.recentlySuccessful,
+            setError: form.setError,
+            clearErrors: form.clearErrors,
+            resetAndClearErrors: form.resetAndClearErrors,
+            isDirty,
+            reset: () => formElement.current?.reset(),
+            submit,
+          })
+        : children,
+    )
+  },
+)
 
 Form.displayName = 'InertiaForm'
 

--- a/packages/react/test-app/Pages/FormComponent/Ref.jsx
+++ b/packages/react/test-app/Pages/FormComponent/Ref.jsx
@@ -12,10 +12,6 @@ export default function Ref() {
     formRef.current?.reset()
   }
 
-  const checkDirtyState = () => {
-    alert(`Form is dirty: ${formRef.current?.isDirty}`)
-  }
-
   const clearAllErrors = () => {
     formRef.current?.clearErrors()
   }
@@ -24,28 +20,31 @@ export default function Ref() {
     formRef.current?.setError('name', 'This is a test error')
   }
 
-  const checkErrors = () => {
-    const hasErrors = formRef.current?.hasErrors
-    const errors = formRef.current?.errors
-    alert(`Has errors: ${hasErrors}, Errors: ${JSON.stringify(errors)}`)
-  }
-
   return (
     <div>
       <h1>Form Ref Test</h1>
 
       <Form ref={formRef} action="/dump/post" method="post">
-        <div>
-          <input type="text" name="name" placeholder="Name" defaultValue="John Doe" />
-        </div>
+        {({ isDirty, hasErrors, errors }) => (
+          <>
+            {/* State display for testing */}
+            <div>Form is {isDirty ? 'dirty' : 'clean'}</div>
+            {hasErrors && <div>Form has errors</div>}
+            {errors.name && <div id="error_name">{errors.name}</div>}
 
-        <div>
-          <input type="email" name="email" placeholder="Email" defaultValue="john@example.com" />
-        </div>
+            <div>
+              <input type="text" name="name" placeholder="Name" defaultValue="John Doe" />
+            </div>
 
-        <div>
-          <button type="submit">Submit via Form</button>
-        </div>
+            <div>
+              <input type="email" name="email" placeholder="Email" defaultValue="john@example.com" />
+            </div>
+
+            <div>
+              <button type="submit">Submit via Form</button>
+            </div>
+          </>
+        )}
       </Form>
 
       <div>
@@ -55,17 +54,11 @@ export default function Ref() {
         <button onClick={resetForm}>
           Reset Form
         </button>
-        <button onClick={checkDirtyState}>
-          Check Dirty State
-        </button>
         <button onClick={clearAllErrors}>
           Clear Errors
         </button>
         <button onClick={setTestError}>
           Set Test Error
-        </button>
-        <button onClick={checkErrors}>
-          Check Errors
         </button>
       </div>
     </div>

--- a/packages/react/test-app/Pages/FormComponent/Ref.jsx
+++ b/packages/react/test-app/Pages/FormComponent/Ref.jsx
@@ -5,28 +5,28 @@ export default function Ref() {
   const formRef = useRef(null)
 
   const submitProgrammatically = () => {
-    formRef.current.submit()
+    formRef.current?.submit()
   }
 
   const resetForm = () => {
-    formRef.current.reset()
+    formRef.current?.reset()
   }
 
   const checkDirtyState = () => {
-    alert(`Form is dirty: ${formRef.current.isDirty}`)
+    alert(`Form is dirty: ${formRef.current?.isDirty}`)
   }
 
   const clearAllErrors = () => {
-    formRef.current.clearErrors()
+    formRef.current?.clearErrors()
   }
 
   const setTestError = () => {
-    formRef.current.setError('name', 'This is a test error')
+    formRef.current?.setError('name', 'This is a test error')
   }
 
   const checkErrors = () => {
-    const hasErrors = formRef.current.hasErrors
-    const errors = formRef.current.errors
+    const hasErrors = formRef.current?.hasErrors
+    const errors = formRef.current?.errors
     alert(`Has errors: ${hasErrors}, Errors: ${JSON.stringify(errors)}`)
   }
 

--- a/packages/react/test-app/Pages/FormComponent/Ref.jsx
+++ b/packages/react/test-app/Pages/FormComponent/Ref.jsx
@@ -1,0 +1,73 @@
+import { Form } from '@inertiajs/react'
+import { useRef } from 'react'
+
+export default function Ref() {
+  const formRef = useRef(null)
+
+  const submitProgrammatically = () => {
+    formRef.current.submit()
+  }
+
+  const resetForm = () => {
+    formRef.current.reset()
+  }
+
+  const checkDirtyState = () => {
+    alert(`Form is dirty: ${formRef.current.isDirty}`)
+  }
+
+  const clearAllErrors = () => {
+    formRef.current.clearErrors()
+  }
+
+  const setTestError = () => {
+    formRef.current.setError('name', 'This is a test error')
+  }
+
+  const checkErrors = () => {
+    const hasErrors = formRef.current.hasErrors
+    const errors = formRef.current.errors
+    alert(`Has errors: ${hasErrors}, Errors: ${JSON.stringify(errors)}`)
+  }
+
+  return (
+    <div>
+      <h1>Form Ref Test</h1>
+
+      <Form ref={formRef} action="/dump/post" method="post">
+        <div>
+          <input type="text" name="name" placeholder="Name" defaultValue="John Doe" />
+        </div>
+
+        <div>
+          <input type="email" name="email" placeholder="Email" defaultValue="john@example.com" />
+        </div>
+
+        <div>
+          <button type="submit">Submit via Form</button>
+        </div>
+      </Form>
+
+      <div>
+        <button onClick={submitProgrammatically}>
+          Submit Programmatically
+        </button>
+        <button onClick={resetForm}>
+          Reset Form
+        </button>
+        <button onClick={checkDirtyState}>
+          Check Dirty State
+        </button>
+        <button onClick={clearAllErrors}>
+          Clear Errors
+        </button>
+        <button onClick={setTestError}>
+          Set Test Error
+        </button>
+        <button onClick={checkErrors}>
+          Check Errors
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -97,7 +97,6 @@
     }
   }
 
-
   onMount(() => {
     defaultValues = getData()
 

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -36,7 +36,6 @@
   let isDirty = false
   let defaultValues: Record<string, FormDataConvertible> = {}
 
-
   $: _method = typeof action === 'object' ? action.method : (method.toLowerCase() as FormComponentProps['method'])
   $: _action = typeof action === 'object' ? action.url : action
 

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -36,6 +36,7 @@
   let isDirty = false
   let defaultValues: Record<string, FormDataConvertible> = {}
 
+
   $: _method = typeof action === 'object' ? action.method : (method.toLowerCase() as FormComponentProps['method'])
   $: _action = typeof action === 'object' ? action.url : action
 
@@ -47,7 +48,7 @@
     isDirty = event.type === 'reset' ? false : !isEqual(getData(), defaultValues)
   }
 
-  function submit() {
+  export function submit() {
     const [url, _data] = mergeDataIntoQueryString(_method, _action, getData(), queryStringArrayFormat)
 
     const submitOptions: FormSubmitOptions = {
@@ -73,21 +74,21 @@
     submit()
   }
 
-  function reset() {
+  export function reset() {
     formElement.reset()
   }
 
-  function clearErrors(...fields: string[]) {
+  export function clearErrors(...fields: string[]) {
     // @ts-expect-error
     $form.clearErrors(...fields)
   }
 
-  function resetAndClearErrors(...fields: string[]) {
+  export function resetAndClearErrors(...fields: string[]) {
     // @ts-expect-error
     $form.resetAndClearErrors(...fields)
   }
 
-  function setError(field: string | object, value?: string) {
+  export function setError(field: string | object, value?: string) {
     if (typeof field === 'string') {
       // @ts-expect-error
       $form.setError(field, value)
@@ -96,6 +97,7 @@
       $form.setError(field)
     }
   }
+
 
   onMount(() => {
     defaultValues = getData()

--- a/packages/svelte/test-app/Pages/FormComponent/Ref.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/Ref.svelte
@@ -12,14 +12,6 @@
     formRef.reset()
   }
 
-  function checkDirtyState() {
-    // Since reactive slot values aren't accessible via bind:this,
-    // we read from DOM elements that are updated by the slot
-    const isDirtySpan = document.getElementById('current-dirty-state')
-    const isDirty = isDirtySpan?.textContent === 'true'
-    alert(`Form is dirty: ${isDirty}`)
-  }
-
   function clearAllErrors() {
     formRef.clearErrors()
   }
@@ -28,26 +20,20 @@
     formRef.setError('name', 'This is a test error')
   }
 
-  function checkErrors() {
-    // Since reactive slot values aren't accessible via bind:this,
-    // we read from DOM elements that are updated by the slot
-    const hasErrorsSpan = document.getElementById('current-has-errors')
-    const errorsSpan = document.getElementById('current-errors')
-    const hasErrors = hasErrorsSpan?.textContent === 'true'
-    const errors = JSON.parse(errorsSpan?.textContent || '{}')
-    alert(`Has errors: ${hasErrors}, Errors: ${JSON.stringify(errors)}`)
-  }
-
 </script>
 
 <div>
   <h1>Form Ref Test</h1>
 
   <Form bind:this={formRef} action="/dump/post" method="post" let:isDirty let:errors let:hasErrors>
-    <!-- Hidden spans to store current reactive state -->
-    <span id="current-dirty-state" style="display: none;">{isDirty}</span>
-    <span id="current-has-errors" style="display: none;">{hasErrors}</span>
-    <span id="current-errors" style="display: none;">{JSON.stringify(errors)}</span>
+    <!-- State display for testing -->
+    <div>Form is {isDirty ? 'dirty' : 'clean'}</div>
+    {#if hasErrors}
+      <div>Form has errors</div>
+    {/if}
+    {#if errors.name}
+      <div id="error_name">{errors.name}</div>
+    {/if}
 
     <div>
       <input type="text" name="name" placeholder="Name" value="John Doe" />
@@ -69,17 +55,11 @@
     <button on:click={resetForm}>
       Reset Form
     </button>
-    <button on:click={checkDirtyState}>
-      Check Dirty State
-    </button>
     <button on:click={clearAllErrors}>
       Clear Errors
     </button>
     <button on:click={setTestError}>
       Set Test Error
-    </button>
-    <button on:click={checkErrors}>
-      Check Errors
     </button>
   </div>
 </div>

--- a/packages/svelte/test-app/Pages/FormComponent/Ref.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/Ref.svelte
@@ -1,0 +1,84 @@
+<script>
+  import { Form } from '@inertiajs/svelte'
+
+  let formRef
+
+  function submitProgrammatically() {
+    formRef.submit()
+  }
+
+  function resetForm() {
+    formRef.reset()
+  }
+
+  function checkDirtyState() {
+    // Since reactive slot values aren't accessible via bind:this,
+    // we read from DOM elements that are updated by the slot
+    const isDirtySpan = document.getElementById('current-dirty-state')
+    const isDirty = isDirtySpan?.textContent === 'true'
+    alert(`Form is dirty: ${isDirty}`)
+  }
+
+  function clearAllErrors() {
+    formRef.clearErrors()
+  }
+
+  function setTestError() {
+    formRef.setError('name', 'This is a test error')
+  }
+
+  function checkErrors() {
+    // Since reactive slot values aren't accessible via bind:this,
+    // we read from DOM elements that are updated by the slot
+    const hasErrorsSpan = document.getElementById('current-has-errors')
+    const errorsSpan = document.getElementById('current-errors')
+    const hasErrors = hasErrorsSpan?.textContent === 'true'
+    const errors = JSON.parse(errorsSpan?.textContent || '{}')
+    alert(`Has errors: ${hasErrors}, Errors: ${JSON.stringify(errors)}`)
+  }
+
+</script>
+
+<div>
+  <h1>Form Ref Test</h1>
+
+  <Form bind:this={formRef} action="/dump/post" method="post" let:isDirty let:errors let:hasErrors>
+    <!-- Hidden spans to store current reactive state -->
+    <span id="current-dirty-state" style="display: none;">{isDirty}</span>
+    <span id="current-has-errors" style="display: none;">{hasErrors}</span>
+    <span id="current-errors" style="display: none;">{JSON.stringify(errors)}</span>
+    
+    <div>
+      <input type="text" name="name" placeholder="Name" value="John Doe" />
+    </div>
+
+    <div>
+      <input type="email" name="email" placeholder="Email" value="john@example.com" />
+    </div>
+
+    <div>
+      <button type="submit">Submit via Form</button>
+    </div>
+  </Form>
+
+  <div>
+    <button on:click={submitProgrammatically}>
+      Submit Programmatically
+    </button>
+    <button on:click={resetForm}>
+      Reset Form
+    </button>
+    <button on:click={checkDirtyState}>
+      Check Dirty State
+    </button>
+    <button on:click={clearAllErrors}>
+      Clear Errors
+    </button>
+    <button on:click={setTestError}>
+      Set Test Error
+    </button>
+    <button on:click={checkErrors}>
+      Check Errors
+    </button>
+  </div>
+</div>

--- a/packages/svelte/test-app/Pages/FormComponent/Ref.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/Ref.svelte
@@ -1,6 +1,7 @@
 <script>
   import { Form } from '@inertiajs/svelte'
 
+  // Svelte Form component ref exposes only methods via bind:this
   let formRef
 
   function submitProgrammatically() {
@@ -47,7 +48,7 @@
     <span id="current-dirty-state" style="display: none;">{isDirty}</span>
     <span id="current-has-errors" style="display: none;">{hasErrors}</span>
     <span id="current-errors" style="display: none;">{JSON.stringify(errors)}</span>
-    
+
     <div>
       <input type="text" name="name" placeholder="Name" value="John Doe" />
     </div>

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -83,7 +83,7 @@ const Form: InertiaForm = defineComponent({
       default: noop,
     },
   },
-  setup(props, { slots, attrs }) {
+  setup(props, { slots, attrs, expose }) {
     const form = useForm({} as Record<string, FormDataConvertible>)
     const formElement = ref()
     const method = computed(() =>
@@ -147,6 +147,36 @@ const Form: InertiaForm = defineComponent({
       // We need transform because we can't override the default data with different keys (by design)
       form.transform(() => props.transform(data)).submit(method.value, action, submitOptions)
     }
+
+    expose({
+      get errors() {
+        return form.errors
+      },
+      get hasErrors() {
+        return form.hasErrors
+      },
+      get processing() {
+        return form.processing
+      },
+      get progress() {
+        return form.progress
+      },
+      get wasSuccessful() {
+        return form.wasSuccessful
+      },
+      get recentlySuccessful() {
+        return form.recentlySuccessful
+      },
+      clearErrors: (...fields: string[]) => form.clearErrors(...fields),
+      resetAndClearErrors: (...fields: string[]) => form.resetAndClearErrors(...fields),
+      setError: (fieldOrFields: string | Record<string, string>, maybeValue?: string) =>
+        form.setError(typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields),
+      get isDirty() {
+        return isDirty.value
+      },
+      reset: () => formElement.value.reset(),
+      submit,
+    })
 
     return () => {
       return h(

--- a/packages/vue3/test-app/Pages/FormComponent/Ref.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/Ref.vue
@@ -5,28 +5,28 @@ import { ref } from 'vue'
 const formRef = ref(null)
 
 const submitProgrammatically = () => {
-  formRef.value.submit()
+  formRef.value?.submit()
 }
 
 const resetForm = () => {
-  formRef.value.reset()
+  formRef.value?.reset()
 }
 
 const checkDirtyState = () => {
-  alert(`Form is dirty: ${formRef.value.isDirty}`)
+  alert(`Form is dirty: ${formRef.value?.isDirty}`)
 }
 
 const clearAllErrors = () => {
-  formRef.value.clearErrors()
+  formRef.value?.clearErrors()
 }
 
 const setTestError = () => {
-  formRef.value.setError('name', 'This is a test error')
+  formRef.value?.setError('name', 'This is a test error')
 }
 
 const checkErrors = () => {
-  const hasErrors = formRef.value.hasErrors
-  const errors = formRef.value.errors
+  const hasErrors = formRef.value?.hasErrors
+  const errors = formRef.value?.errors
   alert(`Has errors: ${hasErrors}, Errors: ${JSON.stringify(errors)}`)
 }
 </script>

--- a/packages/vue3/test-app/Pages/FormComponent/Ref.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/Ref.vue
@@ -12,10 +12,6 @@ const resetForm = () => {
   formRef.value?.reset()
 }
 
-const checkDirtyState = () => {
-  alert(`Form is dirty: ${formRef.value?.isDirty}`)
-}
-
 const clearAllErrors = () => {
   formRef.value?.clearErrors()
 }
@@ -23,19 +19,18 @@ const clearAllErrors = () => {
 const setTestError = () => {
   formRef.value?.setError('name', 'This is a test error')
 }
-
-const checkErrors = () => {
-  const hasErrors = formRef.value?.hasErrors
-  const errors = formRef.value?.errors
-  alert(`Has errors: ${hasErrors}, Errors: ${JSON.stringify(errors)}`)
-}
 </script>
 
 <template>
   <div>
     <h1>Form Ref Test</h1>
 
-    <Form ref="formRef" action="/dump/post" method="post">
+    <Form ref="formRef" action="/dump/post" method="post" #default="{ isDirty, hasErrors, errors }">
+      <!-- State display for testing -->
+      <div>Form is <span v-if="isDirty">dirty</span><span v-else>clean</span></div>
+      <div v-if="hasErrors">Form has errors</div>
+      <div v-if="errors.name" id="error_name">{{ errors.name }}</div>
+
       <div>
         <input type="text" name="name" placeholder="Name" value="John Doe" />
       </div>
@@ -52,10 +47,8 @@ const checkErrors = () => {
     <div>
       <button @click="submitProgrammatically">Submit Programmatically</button>
       <button @click="resetForm">Reset Form</button>
-      <button @click="checkDirtyState">Check Dirty State</button>
       <button @click="clearAllErrors">Clear Errors</button>
       <button @click="setTestError">Set Test Error</button>
-      <button @click="checkErrors">Check Errors</button>
     </div>
   </div>
 </template>

--- a/packages/vue3/test-app/Pages/FormComponent/Ref.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/Ref.vue
@@ -1,0 +1,61 @@
+<script setup>
+import { Form } from '@inertiajs/vue3'
+import { ref } from 'vue'
+
+const formRef = ref(null)
+
+const submitProgrammatically = () => {
+  formRef.value.submit()
+}
+
+const resetForm = () => {
+  formRef.value.reset()
+}
+
+const checkDirtyState = () => {
+  alert(`Form is dirty: ${formRef.value.isDirty}`)
+}
+
+const clearAllErrors = () => {
+  formRef.value.clearErrors()
+}
+
+const setTestError = () => {
+  formRef.value.setError('name', 'This is a test error')
+}
+
+const checkErrors = () => {
+  const hasErrors = formRef.value.hasErrors
+  const errors = formRef.value.errors
+  alert(`Has errors: ${hasErrors}, Errors: ${JSON.stringify(errors)}`)
+}
+</script>
+
+<template>
+  <div>
+    <h1>Form Ref Test</h1>
+
+    <Form ref="formRef" action="/dump/post" method="post">
+      <div>
+        <input type="text" name="name" placeholder="Name" value="John Doe" />
+      </div>
+
+      <div>
+        <input type="email" name="email" placeholder="Email" value="john@example.com" />
+      </div>
+
+      <div>
+        <button type="submit">Submit via Form</button>
+      </div>
+    </Form>
+
+    <div>
+      <button @click="submitProgrammatically">Submit Programmatically</button>
+      <button @click="resetForm">Reset Form</button>
+      <button @click="checkDirtyState">Check Dirty State</button>
+      <button @click="clearAllErrors">Clear Errors</button>
+      <button @click="setTestError">Set Test Error</button>
+      <button @click="checkErrors">Check Errors</button>
+    </div>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -548,9 +548,7 @@ app.post('/form-component/progress', async (req, res) =>
   setTimeout(() => inertia.render(req, res, { component: 'FormComponent/Progress' }), 500),
 )
 app.get('/form-component/state', (req, res) => inertia.render(req, res, { component: 'FormComponent/State' }))
-app.get('/form-component/dotted-keys', (req, res) =>
-  inertia.render(req, res, { component: 'FormComponent/DottedKeys' }),
-)
+app.get('/form-component/dotted-keys', (req, res) => inertia.render(req, res, { component: 'FormComponent/DottedKeys' }))
 app.get('/form-component/ref', (req, res) => inertia.render(req, res, { component: 'FormComponent/Ref' }))
 
 app.all('*', (req, res) => inertia.render(req, res))

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -548,7 +548,10 @@ app.post('/form-component/progress', async (req, res) =>
   setTimeout(() => inertia.render(req, res, { component: 'FormComponent/Progress' }), 500),
 )
 app.get('/form-component/state', (req, res) => inertia.render(req, res, { component: 'FormComponent/State' }))
-app.get('/form-component/dotted-keys', (req, res) => inertia.render(req, res, { component: 'FormComponent/DottedKeys' }))
+app.get('/form-component/dotted-keys', (req, res) =>
+  inertia.render(req, res, { component: 'FormComponent/DottedKeys' }),
+)
+app.get('/form-component/ref', (req, res) => inertia.render(req, res, { component: 'FormComponent/Ref' }))
 
 app.all('*', (req, res) => inertia.render(req, res))
 

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -673,46 +673,23 @@ test.describe('Form Component', () => {
     test('can access errors and hasErrors via ref', async ({ page }) => {
       await page.goto('/form-component/ref')
 
+      await expect(page.getByText('Form has errors')).not.toBeVisible()
+      await expect(page.locator('#error_name')).not.toBeVisible()
+
       await page.getByRole('button', { name: 'Set Test Error' }).click()
 
-      let dialogMessage = ''
-      page.once('dialog', async (dialog) => {
-        dialogMessage = dialog.message()
-        await dialog.accept()
-      })
-
-      await page.getByRole('button', { name: 'Check Errors' }).click()
-      await page.waitForTimeout(100)
-
-      expect(dialogMessage).toContain('Has errors: true')
-      expect(dialogMessage).toContain('This is a test error')
+      await expect(page.getByText('Form has errors')).toBeVisible()
+      await expect(page.locator('#error_name')).toHaveText('This is a test error')
     })
 
     test('can check isDirty state via ref', async ({ page }) => {
       await page.goto('/form-component/ref')
 
-      let dialogMessage = ''
-      page.once('dialog', async (dialog) => {
-        dialogMessage = dialog.message()
-        await dialog.accept()
-      })
-
-      await page.click('button:has-text("Check Dirty State")')
-      await page.waitForTimeout(100)
-
-      expect(dialogMessage).toContain('Form is dirty: false')
+      await expect(page.getByText('Form is clean')).toBeVisible()
 
       await page.fill('input[name="name"]', 'Modified Name')
 
-      page.once('dialog', async (dialog) => {
-        dialogMessage = dialog.message()
-        await dialog.accept()
-      })
-
-      await page.click('button:has-text("Check Dirty State")')
-      await page.waitForTimeout(100)
-
-      expect(dialogMessage).toContain('Form is dirty: true')
+      await expect(page.getByText('Form is dirty')).toBeVisible()
     })
 
     test('can reset form via ref', async ({ page }) => {


### PR DESCRIPTION
This PR adds programmatic access to Form component methods and state via refs:

```vue
<script setup>
import { Form } from '@inertiajs/vue3'
import { ref } from 'vue'

const formRef = ref()

const submitForm = () => {
  formRef.value.submit()
}

const checkState = () => {
  console.log('Is dirty:', formRef.value.isDirty)
  console.log('Has errors:', formRef.value.hasErrors)
  console.log('Errors:', formRef.value.errors)
}
</script>

<template>
  <Form ref="formRef" action="/submit" method="post">
    <input name="email" type="email" />
    <button type="submit">Submit</button>
  </Form>
</template>
```