### PR TITLE
Fix empty action in `<Form>` component when the current URL has more than one segment

### DIFF
--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -40,7 +40,7 @@ export function mergeDataIntoQueryString<T extends RequestPayload>(
 ): [string, MergeDataIntoQueryStringDataReturnType<T>] {
   const hasDataForQueryString = method === 'get' && !isFormData(data) && Object.keys(data).length > 0
   const hasHost = /^[a-z][a-z0-9+.-]*:\/\//i.test(href.toString())
-  const hasAbsolutePath = hasHost || href.toString().startsWith('/')
+  const hasAbsolutePath = hasHost || href.toString().startsWith('/') || href.toString() === ''
   const hasRelativePath = !hasAbsolutePath && !href.toString().startsWith('#') && !href.toString().startsWith('?')
   const hasRelativePathWithDotPrefix = /^[.]{1,2}([/]|$)/.test(href.toString())
   const hasSearch = href.toString().includes('?') || hasDataForQueryString

--- a/packages/react/test-app/Pages/FormComponent/EmptyAction.tsx
+++ b/packages/react/test-app/Pages/FormComponent/EmptyAction.tsx
@@ -1,0 +1,24 @@
+import { Form } from '@inertiajs/react'
+
+export default () => {
+  return (
+    <div>
+      <h1>Form Empty Action Test</h1>
+
+      <Form method="post">
+        {({ errors }) => (
+          <>
+            <div>
+              <input type="text" name="name" placeholder="Name" defaultValue="John Doe" />
+              {errors.name && <p id="error_name">{errors.name}</p>}
+            </div>
+
+            <div>
+              <button type="submit">Submit</button>
+            </div>
+          </>
+        )}
+      </Form>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/FormComponent/EmptyAction.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/EmptyAction.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { Form } from '@inertiajs/svelte'
+</script>
+
+<div>
+  <h1>Form Empty Action Test</h1>
+
+  <Form method="post" let:errors>
+    <div>
+      <input type="text" name="name" placeholder="Name" value="John Doe" />
+      {#if errors.name}
+        <p id="error_name">{errors.name}</p>
+      {/if}
+    </div>
+
+    <div>
+      <button type="submit">Submit</button>
+    </div>
+  </Form>
+</div>

--- a/packages/vue3/test-app/Pages/FormComponent/EmptyAction.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/EmptyAction.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <div>
+    <h1>Form Empty Action Test</h1>
+
+    <Form method="post" #default="{ errors }">
+      <div>
+        <input type="text" name="name" placeholder="Name" value="John Doe" />
+        <p v-if="errors.name" id="error_name">{{ errors.name }}</p>
+      </div>
+
+      <div>
+        <button type="submit">Submit</button>
+      </div>
+    </Form>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -552,6 +552,14 @@ app.get('/form-component/state', (req, res) => inertia.render(req, res, { compon
 app.get('/form-component/dotted-keys', (req, res) => inertia.render(req, res, { component: 'FormComponent/DottedKeys' }))
 app.get('/form-component/ref', (req, res) => inertia.render(req, res, { component: 'FormComponent/Ref' }))
 
+app.get('/form-component/url/with/segements', (req, res) => inertia.render(req, res, { component: 'FormComponent/EmptyAction' }))
+app.post('/form-component/url/with/segements', async (req, res) =>
+  inertia.render(req, res, {
+    component: 'FormComponent/EmptyAction',
+    props: { errors: { name: 'Something went wrong' } },
+  }),
+)
+
 app.all('*', (req, res) => inertia.render(req, res))
 
 const adapterPorts = {

--- a/tests/core/url.test.ts
+++ b/tests/core/url.test.ts
@@ -245,6 +245,13 @@ test.describe('url.ts', () => {
         expect(href).toBe('https://example.com/api?existing=value#section')
         expect(data).toEqual({ new: 'data' })
       })
+
+      test('handles a URL that is an empty string', () => {
+        const [href, data] = mergeDataIntoQueryString('post', '', { name: 'foo' })
+
+        expect(href).toBe('/')
+        expect(data).toEqual({ name: 'foo' })
+      })
     })
   })
 })

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -442,6 +442,24 @@ test.describe('Form Component', () => {
     await expect(page).toHaveURL('/article')
   })
 
+  test('submit without an action attribute uses the current URL', async ({ page }) => {
+    await page.goto('/form-component/url/with/segements')
+    await expect(page.locator('#error_name')).not.toBeVisible()
+
+    requests.listen(page)
+
+    await page.getByRole('button', { name: 'Submit' }).click()
+    await expect(page.locator('#error_name')).toHaveText('Something went wrong')
+
+    await expect(requests.requests).toHaveLength(1)
+    const request = requests.requests[0]
+
+    expect(request.method()).toBe('POST')
+    expect(request.url().includes('/form-component/url/with/segements')).toBe(true)
+
+    await expect(page).toHaveURL('/form-component/url/with/segements')
+  })
+
   test.describe('Methods', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/form-component/methods')


### PR DESCRIPTION
This PR fixes an issue where the`<Form>` component would not correctly submit the data to the current URL when it has more than one segment and when the `action` attribute is missing:

```
<Form method="post">
    ...
</Form>
```