### PR TITLE
Support uppercase method in `<Form>` component

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -423,9 +423,10 @@ export type FormComponentOptions = Pick<
 >
 
 export type FormComponentProps = Partial<
-  Pick<Visit, 'method' | 'headers' | 'queryStringArrayFormat' | 'errorBag' | 'showProgress'> &
+  Pick<Visit, 'headers' | 'queryStringArrayFormat' | 'errorBag' | 'showProgress'> &
     Omit<VisitCallbacks, 'onPrefetched' | 'onPrefetching'>
 > & {
+  method?: Method | Uppercase<Method>
   action?: string | { url: string; method: Method }
   transform?: (data: Record<string, FormDataConvertible>) => Record<string, FormDataConvertible>
   options?: FormComponentOptions

--- a/packages/react/test-app/Pages/FormComponent/UppercaseMethod.tsx
+++ b/packages/react/test-app/Pages/FormComponent/UppercaseMethod.tsx
@@ -1,0 +1,33 @@
+import { Form } from '@inertiajs/react'
+
+export default () => {
+  return (
+    <div>
+      <h1>Uppercase Method Test</h1>
+
+      {/* Test with uppercase POST */}
+      <Form action="/dump/post" method="POST">
+        <div>
+          <input type="text" name="name" placeholder="Name" defaultValue="Test POST" />
+        </div>
+        <button type="submit">Submit POST</button>
+      </Form>
+
+      {/* Test with uppercase GET */}
+      <Form action="/dump/get" method="GET">
+        <div>
+          <input type="text" name="query" placeholder="Query" defaultValue="Test GET" />
+        </div>
+        <button type="submit">Submit GET</button>
+      </Form>
+
+      {/* Test with uppercase PUT */}
+      <Form action="/dump/put" method="PUT">
+        <div>
+          <input type="text" name="data" placeholder="Data" defaultValue="Test PUT" />
+        </div>
+        <button type="submit">Submit PUT</button>
+      </Form>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/FormComponent/UppercaseMethod.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/UppercaseMethod.svelte
@@ -1,0 +1,31 @@
+<script>
+  import { Form } from '@inertiajs/svelte'
+</script>
+
+<div>
+  <h1>Uppercase Method Test</h1>
+
+  <!-- Test with uppercase POST -->
+  <Form action="/dump/post" method="POST">
+    <div>
+      <input type="text" name="name" placeholder="Name" value="Test POST" />
+    </div>
+    <button type="submit">Submit POST</button>
+  </Form>
+
+  <!-- Test with uppercase GET -->
+  <Form action="/dump/get" method="GET">
+    <div>
+      <input type="text" name="query" placeholder="Query" value="Test GET" />
+    </div>
+    <button type="submit">Submit GET</button>
+  </Form>
+
+  <!-- Test with uppercase PUT -->
+  <Form action="/dump/put" method="PUT">
+    <div>
+      <input type="text" name="data" placeholder="Data" value="Test PUT" />
+    </div>
+    <button type="submit">Submit PUT</button>
+  </Form>
+</div>

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -4,6 +4,7 @@ import {
   FormDataConvertible,
   formDataToObject,
   mergeDataIntoQueryString,
+  Method,
   VisitOptions,
 } from '@inertiajs/core'
 import { isEqual } from 'es-toolkit'
@@ -89,7 +90,7 @@ const Form: InertiaForm = defineComponent({
     const method = computed(() =>
       typeof props.action === 'object'
         ? props.action.method
-        : (props.method.toLowerCase() as FormComponentProps['method']),
+        : (props.method.toLowerCase() as Method),
     )
 
     // Can't use computed because FormData is not reactive

--- a/packages/vue3/test-app/Pages/FormComponent/UppercaseMethod.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/UppercaseMethod.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <div>
+    <h1>Uppercase Method Test</h1>
+
+    <!-- Test with uppercase POST -->
+    <Form action="/dump/post" method="POST">
+      <div>
+        <input type="text" name="name" placeholder="Name" value="Test POST" />
+      </div>
+      <button type="submit">Submit POST</button>
+    </Form>
+
+    <!-- Test with uppercase GET -->
+    <Form action="/dump/get" method="GET">
+      <div>
+        <input type="text" name="query" placeholder="Query" value="Test GET" />
+      </div>
+      <button type="submit">Submit GET</button>
+    </Form>
+
+    <!-- Test with uppercase PUT -->
+    <Form action="/dump/put" method="PUT">
+      <div>
+        <input type="text" name="data" placeholder="Data" value="Test PUT" />
+      </div>
+      <button type="submit">Submit PUT</button>
+    </Form>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -551,6 +551,7 @@ app.post('/form-component/progress', async (req, res) =>
 app.get('/form-component/state', (req, res) => inertia.render(req, res, { component: 'FormComponent/State' }))
 app.get('/form-component/dotted-keys', (req, res) => inertia.render(req, res, { component: 'FormComponent/DottedKeys' }))
 app.get('/form-component/ref', (req, res) => inertia.render(req, res, { component: 'FormComponent/Ref' }))
+app.get('/form-component/uppercase-method', (req, res) => inertia.render(req, res, { component: 'FormComponent/UppercaseMethod' }))
 
 app.all('*', (req, res) => inertia.render(req, res))
 

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -707,4 +707,43 @@ test.describe('Form Component', () => {
       expect(await page.inputValue('input[name="email"]')).toBe('john@example.com')
     })
   })
+
+  test.describe('Uppercase Methods', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/form-component/uppercase-method')
+    })
+
+    test('accepts uppercase POST method', async ({ page }) => {
+      await page.getByRole('button', { name: 'Submit POST' }).click()
+
+      const dump = await shouldBeDumpPage(page, 'post')
+
+      await expect(dump.method).toEqual('post')
+      await expect(dump.form).toEqual({
+        name: 'Test POST',
+      })
+    })
+
+    test('accepts uppercase GET method', async ({ page }) => {
+      await page.getByRole('button', { name: 'Submit GET' }).click()
+
+      const dump = await shouldBeDumpPage(page, 'get')
+
+      await expect(dump.method).toEqual('get')
+      await expect(dump.query).toEqual({
+        query: 'Test GET',
+      })
+    })
+
+    test('accepts uppercase PUT method', async ({ page }) => {
+      await page.getByRole('button', { name: 'Submit PUT' }).click()
+
+      const dump = await shouldBeDumpPage(page, 'put')
+
+      await expect(dump.method).toEqual('put')
+      await expect(dump.form).toEqual({
+        data: 'Test PUT',
+      })
+    })
+  })
 })


### PR DESCRIPTION
The `method` attribute of the classic HTML `<form>` element is case-insensitive. This PR brings support for that as well in the Inertia `<Form>` component.