### PR TITLE
Add `onSubmitComplete` prop to `Form` component

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -434,26 +434,6 @@ export type FormComponentProps = Partial<
   disableWhileProcessing?: boolean
 }
 
-export type FormComponentonSubmitCompleteArguments = {
-  clearErrors: (...fields: string[]) => void
-  resetAndClearErrors: (...fields: string[]) => void
-  reset: (...fields: string[]) => void
-}
-
-export type FormComponentChildProps = {
-  errors: Record<string, string>
-  hasErrors: boolean
-  processing: boolean
-  progress: {
-    percentage: number
-  } | null
-  wasSuccessful: boolean
-  recentlySuccessful: boolean
-  setError: (fieldOrFields: string | Record<string, string>, maybeValue?: string) => void
-  isDirty: boolean
-  submit: () => void
-} & FormComponentonSubmitCompleteArguments
-
 export type FormComponentMethods = {
   clearErrors: (...fields: string[]) => void
   resetAndClearErrors: (...fields: string[]) => void
@@ -462,6 +442,11 @@ export type FormComponentMethods = {
   reset: (...fields: string[]) => void
   submit: () => void
 }
+
+export type FormComponentonSubmitCompleteArguments = Pick<
+  FormComponentMethods,
+  'clearErrors' | 'resetAndClearErrors' | 'reset'
+>
 
 export type FormComponentState = {
   errors: Record<string, string>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -430,7 +430,28 @@ export type FormComponentProps = Partial<
   action?: string | { url: string; method: Method }
   transform?: (data: Record<string, FormDataConvertible>) => Record<string, FormDataConvertible>
   options?: FormComponentOptions
+  afterSubmit?: (props: FormComponentAfterSubmitArguments) => void
 }
+
+export type FormComponentAfterSubmitArguments = {
+  clearErrors: (...fields: string[]) => void
+  resetAndClearErrors: (...fields: string[]) => void
+  reset: (...fields: string[]) => void
+}
+
+export type FormComponentChildProps = {
+  errors: Record<string, string>
+  hasErrors: boolean
+  processing: boolean
+  progress: {
+    percentage: number
+  } | null
+  wasSuccessful: boolean
+  recentlySuccessful: boolean
+  setError: (fieldOrFields: string | Record<string, string>, maybeValue?: string) => void
+  isDirty: boolean
+  submit: () => void
+} & FormComponentAfterSubmitArguments
 
 export type FormComponentMethods = {
   clearErrors: (...fields: string[]) => void

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -430,10 +430,10 @@ export type FormComponentProps = Partial<
   action?: string | { url: string; method: Method }
   transform?: (data: Record<string, FormDataConvertible>) => Record<string, FormDataConvertible>
   options?: FormComponentOptions
-  afterSubmit?: (props: FormComponentAfterSubmitArguments) => void
+  onSubmitComplete?: (props: FormComponentonSubmitCompleteArguments) => void
 }
 
-export type FormComponentAfterSubmitArguments = {
+export type FormComponentonSubmitCompleteArguments = {
   clearErrors: (...fields: string[]) => void
   resetAndClearErrors: (...fields: string[]) => void
   reset: (...fields: string[]) => void
@@ -451,7 +451,7 @@ export type FormComponentChildProps = {
   setError: (fieldOrFields: string | Record<string, string>, maybeValue?: string) => void
   isDirty: boolean
   submit: () => void
-} & FormComponentAfterSubmitArguments
+} & FormComponentonSubmitCompleteArguments
 
 export type FormComponentMethods = {
   clearErrors: (...fields: string[]) => void

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,9 +60,8 @@ export type FormDataKeys<T> = T extends Function | FormDataConvertibleValue
               [Key in Extract<keyof T, `${number}`>]: `${Key & string}.${FormDataKeys<T[Key & string]> & string}`
             }[Extract<keyof T, `${number}`>]
     : string extends keyof T
-      ? string
-      :
-          | Extract<keyof T, string>
+        ? string
+        : | Extract<keyof T, string>
           | {
               [Key in Extract<keyof T, string>]: `${Key}.${FormDataKeys<T[Key]> & string}`
             }[Extract<keyof T, string>]
@@ -273,25 +272,13 @@ export type PageEvent = 'newComponent' | 'firstLoad'
 
 export type GlobalEventNames<T extends RequestPayload = RequestPayload> = keyof GlobalEventsMap<T>
 
-export type GlobalEvent<
-  TEventName extends GlobalEventNames<T>,
-  T extends RequestPayload = RequestPayload,
-> = CustomEvent<GlobalEventDetails<TEventName, T>>
+export type GlobalEvent<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = CustomEvent<GlobalEventDetails<TEventName, T>>
 
-export type GlobalEventParameters<
-  TEventName extends GlobalEventNames<T>,
-  T extends RequestPayload = RequestPayload,
-> = GlobalEventsMap<T>[TEventName]['parameters']
+export type GlobalEventParameters<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = GlobalEventsMap<T>[TEventName]['parameters']
 
-export type GlobalEventResult<
-  TEventName extends GlobalEventNames<T>,
-  T extends RequestPayload = RequestPayload,
-> = GlobalEventsMap<T>[TEventName]['result']
+export type GlobalEventResult<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = GlobalEventsMap<T>[TEventName]['result']
 
-export type GlobalEventDetails<
-  TEventName extends GlobalEventNames<T>,
-  T extends RequestPayload = RequestPayload,
-> = GlobalEventsMap<T>[TEventName]['details']
+export type GlobalEventDetails<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = GlobalEventsMap<T>[TEventName]['details']
 
 export type GlobalEventTrigger<TEventName extends GlobalEventNames<T>, T extends RequestPayload = RequestPayload> = (
   ...params: GlobalEventParameters<TEventName, T>

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -132,24 +132,22 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
       form.submit(resolvedMethod, url, submitOptions)
     }
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        errors: form.errors,
-        hasErrors: form.hasErrors,
-        processing: form.processing,
-        progress: form.progress,
-        wasSuccessful: form.wasSuccessful,
-        recentlySuccessful: form.recentlySuccessful,
-        clearErrors: form.clearErrors,
-        resetAndClearErrors,
-        setError: form.setError,
-        isDirty,
-        reset,
-        submit,
-      }),
-      [form, isDirty, submit],
-    )
+    const exposed = () => ({
+      errors: form.errors,
+      hasErrors: form.hasErrors,
+      processing: form.processing,
+      progress: form.progress,
+      wasSuccessful: form.wasSuccessful,
+      recentlySuccessful: form.recentlySuccessful,
+      isDirty,
+      clearErrors: form.clearErrors,
+      resetAndClearErrors,
+      setError: form.setError,
+      reset,
+      submit,
+    })
+
+    useImperativeHandle(ref, exposed, [form, isDirty, submit])
 
     return createElement(
       'form',
@@ -164,22 +162,7 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
         },
         inert: disableWhileProcessing && form.processing,
       },
-      typeof children === 'function'
-        ? children({
-            errors: form.errors,
-            hasErrors: form.hasErrors,
-            processing: form.processing,
-            progress: form.progress,
-            wasSuccessful: form.wasSuccessful,
-            recentlySuccessful: form.recentlySuccessful,
-            setError: form.setError,
-            clearErrors: form.clearErrors,
-            resetAndClearErrors,
-            isDirty,
-            reset,
-            submit,
-          })
-        : children,
+      typeof children === 'function' ? children(exposed()) : children,
     )
   },
 )

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -95,7 +95,7 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
           const input = formElement.current?.querySelector(`[name="${field}"]`) as HTMLInputElement
 
           if (input) {
-            // @ts-ignore
+            // @ts-expect-error
             input.value = defaultValues.current[field] || ''
           }
         })
@@ -103,7 +103,7 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
     }
 
     const resetAndClearErrors = (...fields: string[]) => {
-      // @ts-ignore
+      // @ts-expect-error
       form.resetAndClearErrors(...fields)
       reset(...fields)
     }

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -51,7 +51,7 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
       onSuccess = noop,
       onError = noop,
       onCancelToken = noop,
-      afterSubmit = noop,
+      onSubmitComplete = noop,
       children,
       ...props
     },
@@ -126,7 +126,7 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
         onProgress,
         onFinish: (...args) => {
           onFinish(...args)
-          afterSubmit({
+          onSubmitComplete({
             reset,
             resetAndClearErrors,
             clearErrors: form.clearErrors,

--- a/packages/react/test-app/Pages/FormComponent/AfterSubmit.tsx
+++ b/packages/react/test-app/Pages/FormComponent/AfterSubmit.tsx
@@ -1,0 +1,29 @@
+import { Form } from '@inertiajs/react'
+
+export default () => {
+  return (
+    <div>
+      <h1>After Submit Test</h1>
+
+      <Form method="post" afterSubmit={(props) => props.reset('name')}>
+        {({ errors }) => (
+          <>
+            <div>
+              <input type="text" name="name" id="name" placeholder="Name" defaultValue="John Doe" />
+              {errors.name && <p id="error_name">{errors.name}</p>}
+            </div>
+
+            <div>
+              <input type="email" name="email" id="email" placeholder="Email" defaultValue="john@doe.biz" />
+              {errors.email && <p id="error_email">{errors.email}</p>}
+            </div>
+
+            <div>
+              <button type="submit">Submit</button>
+            </div>
+          </>
+        )}
+      </Form>
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/FormComponent/AfterSubmit.tsx
+++ b/packages/react/test-app/Pages/FormComponent/AfterSubmit.tsx
@@ -5,7 +5,7 @@ export default () => {
     <div>
       <h1>After Submit Test</h1>
 
-      <Form method="post" afterSubmit={(props) => props.reset('name')}>
+      <Form method="post" onSubmitComplete={(props) => props.reset('name')}>
         {({ errors }) => (
           <>
             <div>

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -29,7 +29,7 @@
   export let onCancel: FormComponentProps['onCancel'] = noop
   export let onSuccess: FormComponentProps['onSuccess'] = noop
   export let onError: FormComponentProps['onError'] = noop
-  export let afterSubmit: FormComponentProps['afterSubmit'] = noop
+  export let onSubmitComplete: FormComponentProps['onSubmitComplete'] = noop
 
   type FormSubmitOptions = Omit<VisitOptions, 'data' | 'onPrefetched' | 'onPrefetching'>
 
@@ -65,8 +65,8 @@
             onFinish(visit)
         }
 
-        if (afterSubmit) {
-            afterSubmit({
+        if (onSubmitComplete) {
+            onSubmitComplete({
                 reset,
                 resetAndClearErrors,
                 clearErrors,

--- a/packages/svelte/test-app/Pages/FormComponent/AfterSubmit.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/AfterSubmit.svelte
@@ -5,7 +5,7 @@
 <div>
   <h1>After Submit Test</h1>
 
-  <Form method="post" let:errors afterSubmit={(props) => props.reset('name')}>
+  <Form method="post" let:errors onSubmitComplete={(props) => props.reset('name')}>
     <div>
       <input type="text" name="name" id="name" placeholder="Name" value="John Doe" />
       {#if errors.name}

--- a/packages/svelte/test-app/Pages/FormComponent/AfterSubmit.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/AfterSubmit.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { Form } from '@inertiajs/svelte'
+</script>
+
+<div>
+  <h1>After Submit Test</h1>
+
+  <Form method="post" let:errors afterSubmit={(props) => props.reset('name')}>
+    <div>
+      <input type="text" name="name" id="name" placeholder="Name" value="John Doe" />
+      {#if errors.name}
+        <p id="error_name">{errors.name}</p>
+      {/if}
+    </div>
+
+    <div>
+      <input type="email" name="email" id="email" placeholder="Email" value="john@doe.biz" />
+      {#if errors.email}
+        <p id="error_email">{errors.email}</p>
+      {/if}
+    </div>
+
+    <div>
+      <button type="submit">Submit</button>
+    </div>
+  </Form>
+</div>

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -214,23 +214,7 @@ const Form: InertiaForm = defineComponent({
           },
           inert: props.disableWhileProcessing && form.processing,
         },
-        slots.default
-          ? slots.default(<FormComponentSlotProps>{
-              errors: form.errors,
-              hasErrors: form.hasErrors,
-              processing: form.processing,
-              progress: form.progress,
-              wasSuccessful: form.wasSuccessful,
-              recentlySuccessful: form.recentlySuccessful,
-              setError: (fieldOrFields: string | Record<string, string>, maybeValue?: string) =>
-                form.setError(typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields),
-              clearErrors: (...fields: string[]) => form.clearErrors(...fields),
-              resetAndClearErrors,
-              isDirty: isDirty.value,
-              reset,
-              submit,
-            })
-          : [],
+        slots.default ? slots.default(<FormComponentSlotProps>exposed) : [],
       )
     }
   },

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -1,6 +1,6 @@
 import {
-  FormComponentChildProps,
   FormComponentProps,
+  FormComponentRef,
   FormComponentSlotProps,
   FormDataConvertible,
   formDataToObject,
@@ -86,7 +86,7 @@ const Form: InertiaForm = defineComponent({
       default: noop,
     },
     onSubmitComplete: {
-      type: Function as PropType<(props: FormComponentChildProps) => void>,
+      type: Function as PropType<FormComponentProps['onSubmitComplete']>,
       default: noop,
     },
     disableWhileProcessing: {
@@ -198,7 +198,7 @@ const Form: InertiaForm = defineComponent({
       submit,
     }
 
-    expose<FormComponentChildProps>(exposed)
+    expose<FormComponentRef>(exposed)
 
     return () => {
       return h(

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -84,7 +84,7 @@ const Form: InertiaForm = defineComponent({
       type: Function as PropType<FormComponentProps['onError']>,
       default: noop,
     },
-    afterSubmit: {
+    onSubmitComplete: {
       type: Function as PropType<(props: FormComponentChildProps) => void>,
       default: noop,
     },
@@ -93,9 +93,7 @@ const Form: InertiaForm = defineComponent({
     const form = useForm<Record<string, any>>({})
     const formElement = ref()
     const method = computed(() =>
-      typeof props.action === 'object'
-        ? props.action.method
-        : (props.method.toLowerCase() as Method),
+      typeof props.action === 'object' ? props.action.method : (props.method.toLowerCase() as Method),
     )
 
     // Can't use computed because FormData is not reactive
@@ -145,7 +143,7 @@ const Form: InertiaForm = defineComponent({
         onProgress: props.onProgress,
         onFinish: (...args) => {
           props.onFinish(...args)
-          props.afterSubmit(exposed)
+          props.onSubmitComplete(exposed)
         },
         onCancel: props.onCancel,
         onSuccess: props.onSuccess,

--- a/packages/vue3/test-app/Pages/FormComponent/AfterSubmit.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/AfterSubmit.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <div>
+    <h1>After Submit Test</h1>
+
+    <Form method="post" #default="{ errors }" :after-submit="(props) => props.reset('name')">
+      <div>
+        <input type="text" name="name" id="name" placeholder="Name" value="John Doe" />
+        <p v-if="errors.name" id="error_name">{{ errors.name }}</p>
+      </div>
+
+      <div>
+        <input type="email" name="email" id="email" placeholder="Email" value="john@doe.biz" />
+        <p v-if="errors.email" id="error_email">{{ errors.email }}</p>
+      </div>
+
+      <div>
+        <button type="submit">Submit</button>
+      </div>
+    </Form>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/FormComponent/AfterSubmit.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/AfterSubmit.vue
@@ -6,7 +6,7 @@ import { Form } from '@inertiajs/vue3'
   <div>
     <h1>After Submit Test</h1>
 
-    <Form method="post" #default="{ errors }" :after-submit="(props) => props.reset('name')">
+    <Form method="post" #default="{ errors }" @submit-complete="(props) => props.reset('name')">
       <div>
         <input type="text" name="name" id="name" placeholder="Name" value="John Doe" />
         <p v-if="errors.name" id="error_name">{{ errors.name }}</p>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -548,6 +548,9 @@ app.get('/form-component/progress', (req, res) => inertia.render(req, res, { com
 app.post('/form-component/progress', async (req, res) =>
   setTimeout(() => inertia.render(req, res, { component: 'FormComponent/Progress' }), 500),
 )
+app.get('/form-component/after-submit', (req, res) =>
+  inertia.render(req, res, { component: 'FormComponent/AfterSubmit' }),
+)
 app.get('/form-component/state', (req, res) => inertia.render(req, res, { component: 'FormComponent/State' }))
 app.get('/form-component/dotted-keys', (req, res) => inertia.render(req, res, { component: 'FormComponent/DottedKeys' }))
 app.get('/form-component/ref', (req, res) => inertia.render(req, res, { component: 'FormComponent/Ref' }))

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -460,6 +460,25 @@ test.describe('Form Component', () => {
     await expect(page).toHaveURL('/form-component/url/with/segements')
   })
 
+  test('reset a field after submit', async ({ page }) => {
+    await page.goto('/form-component/after-submit')
+
+    await expect(page.locator('#name')).toHaveValue('John Doe')
+    await expect(page.locator('#email')).toHaveValue('john@doe.biz')
+
+    await page.fill('#name', 'John Who')
+    await page.fill('#email', 'john@who.biz')
+
+    requests.listen(page)
+
+    await page.getByRole('button', { name: 'Submit' }).click()
+
+    await expect(requests.requests).toHaveLength(1)
+
+    await expect(page.locator('#name')).toHaveValue('John Doe')
+    await expect(page.locator('#email')).toHaveValue('john@who.biz')
+  })
+
   test.describe('Methods', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/form-component/methods')


### PR DESCRIPTION
This PR adds an `afterSubmit` prop to the `Form` component, allowing you to `reset`, `resetAndClearErrors`, and/or `clearErrors` after a form submission.

```tsx
<Form method="post" afterSubmit={(props) => props.reset('name')}>
    <input type="text" name="name" id="name" placeholder="Name" defaultValue="John Doe" />
    <input type="email" name="email" id="email" placeholder="Email" defaultValue="john@doe.biz" />
    <button type="submit">Submit</button>
</Form>
```

This is fired right after the `onFinish` event in the request lifecycle.

I also updated the `Form` component `reset` function to receive field names in the event that the user wants to reset individual fields instead of the whole form.

Questions:

- Do we like `afterSubmit`?
- Is the timing right in the request lifecycle (after `onFinish`)?
- I whittled down the props being sent to the callback to just the above functions as the other props didn't seem relevant to this action, anything else I may have missed?
- I decided against the `beforeSubmit` prop as `onBefore` does essentially the same thing