### PR TITLE
Introduce temporary props

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -66,6 +66,9 @@ class History {
 
   protected getPageData(page: Page): Promise<Page | ArrayBuffer> {
     return new Promise((resolve) => {
+      if (page.temporaryProps) {
+        page.temporaryProps.forEach((key) => { delete page.props[key] })
+      }
       return page.encryptHistory ? encryptHistory(page).then(resolve) : resolve(page)
     })
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -117,6 +117,7 @@ export interface Page<SharedProps extends PageProps = PageProps> {
   mergeProps?: string[]
   deepMergeProps?: string[]
   matchPropsOn?: string[]
+  temporaryProps?: string[]
 
   /** @internal */
   rememberedState: Record<string, unknown>

--- a/packages/react/test-app/Pages/TemporaryProps.tsx
+++ b/packages/react/test-app/Pages/TemporaryProps.tsx
@@ -1,0 +1,18 @@
+import { Link } from '@inertiajs/react'
+
+export default function TemporaryProps({
+  regular,
+  tmp,
+}: {
+  regular?: number
+  tmp?: number
+}) {
+  return (
+    <>
+      <div>regular is {regular ?? 'undefined'}</div>
+      <div>tmp is {tmp ?? 'undefined'}</div>
+
+      <Link href="/">homepage</Link>
+    </>
+  )
+}

--- a/packages/svelte/test-app/Pages/TemporaryProps.svelte
+++ b/packages/svelte/test-app/Pages/TemporaryProps.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { Link } from '@inertiajs/svelte'
+
+  export let regular: number | undefined
+  export let tmp: number | undefined
+</script>
+
+<div>regular is {regular ?? 'undefined'}</div>
+<div>tmp is {tmp ?? 'undefined'}</div>
+<Link href="/">homepage</Link>

--- a/packages/vue3/test-app/Pages/TemporaryProps.vue
+++ b/packages/vue3/test-app/Pages/TemporaryProps.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+
+defineProps<{
+  regular?: number
+  tmp?: number
+}>()
+</script>
+
+<template>
+  <div>regular is {{ regular ?? 'undefined' }}</div>
+  <div>tmp is {{ tmp ?? 'undefined' }}</div>
+  <Link href="/">homepage</Link>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -285,6 +285,17 @@ app.get('/history/version/:pageNumber', (req, res) => {
   })
 })
 
+app.get('/temporary-props', (req, res) => {
+  inertia.render(req, res, {
+    component: 'TemporaryProps',
+    props: {
+      regular: 1,
+      tmp: 1,
+    },
+    temporaryProps: ['tmp']
+  })
+})
+
 app.get('/when-visible', (req, res) => {
   const page = () =>
     inertia.render(req, res, {

--- a/tests/temporary-props.spec.ts
+++ b/tests/temporary-props.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+
+test('temporary props disappear after partial reload and remain absent on back', async ({ page }) => {
+  await page.goto('/temporary-props')
+
+  // Initially, both props are present
+  await expect(page.getByText('regular is 1')).toBeVisible()
+  await expect(page.getByText('tmp is 1')).toBeVisible()
+
+  // Navigate away and then go back to ensure history state doesn't contain tmp
+  await page.getByRole('link', { name: 'homepage' }).click()
+  await page.waitForURL('/')
+  await page.goBack()
+  await page.waitForURL('/temporary-props')
+
+  await expect(page.getByText('regular is 1')).toBeVisible()
+  // tmp should be absent when pulled from history
+  await expect(page.getByText('tmp is undefined')).toBeVisible()
+})


### PR DESCRIPTION
Inertia temporary props are server-provided properties that should be available only for the next render and then be discarded. Inertia deliberately does not cache them in history. This gives you predictable one-time UI feedback and prevents stale data (like status messages ) from resurfacing when users navigate back/forward or when a cached page is reused.

Usage example (requires implementation in Laravel adapter):

```php
    /**
     * Show the login page.
     */
    public function create(Request $request): Response
    {
        return Inertia::render('auth/login', [
            'canResetPassword' => Route::has('password.request'),
            'status' => Inertia::temp($request->session()->get('status')),
            // should we support Inertia::defer(...).temp, Inertia::optional(...).temp?
        ]);
    }
```

I believe this is a simple yet useful addition to the Inertia API, but you might want to keep the public API short, so before implementing the Laravel adapter PR, I'd love to hear your thoughts.