### PR TITLE
Add `defaults()` method to Form component

### DIFF
--- a/packages/core/src/resetFormFields.ts
+++ b/packages/core/src/resetFormFields.ts
@@ -159,7 +159,10 @@ function resetFieldElements(
 export function resetFormFields(formElement: HTMLFormElement, defaults: FormData, fieldNames?: string[]): void {
   // If no specific fields provided, reset the entire form
   if (!fieldNames || fieldNames.length === 0) {
-    fieldNames = [...defaults.keys()]
+    // Get all field names from both defaults and form elements (including disabled ones)
+    const formData = new FormData(formElement)
+    const formElementNames = Array.from(formElement.elements).map(el => isFormElement(el) ? el.name : '').filter(Boolean)
+    fieldNames = [...new Set([...defaults.keys(), ...formData.keys(), ...formElementNames])]
   }
 
   let hasChanged = false

--- a/packages/core/src/resetFormFields.ts
+++ b/packages/core/src/resetFormFields.ts
@@ -159,8 +159,7 @@ function resetFieldElements(
 export function resetFormFields(formElement: HTMLFormElement, defaults: FormData, fieldNames?: string[]): void {
   // If no specific fields provided, reset the entire form
   if (!fieldNames || fieldNames.length === 0) {
-    formElement.reset()
-    return
+    fieldNames = [...defaults.keys()]
   }
 
   let hasChanged = false

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -442,6 +442,7 @@ export type FormComponentMethods = {
   setError(errors: Record<string, string>): void
   reset: (...fields: string[]) => void
   submit: () => void
+  defaults: () => void
 }
 
 export type FormComponentonSubmitCompleteArguments = Pick<

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -67,7 +67,7 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
     }, [action, method])
 
     const [isDirty, setIsDirty] = useState(false)
-    const defaults = useRef<FormData>(new FormData())
+    const defaultData = useRef<FormData>(new FormData())
 
     const getFormData = (): FormData => new FormData(formElement.current)
 
@@ -77,10 +77,10 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
     const getData = (): Record<string, FormDataConvertible> => formDataToObject(getFormData())
 
     const updateDirtyState = (event: Event) =>
-      setIsDirty(event.type === 'reset' ? false : !isEqual(getData(), formDataToObject(defaults.current)))
+      setIsDirty(event.type === 'reset' ? false : !isEqual(getData(), formDataToObject(defaultData.current)))
 
     useEffect(() => {
-      defaults.current = getFormData()
+      defaultData.current = getFormData()
 
       const formEvents: Array<keyof HTMLElementEventMap> = ['input', 'change', 'reset']
 
@@ -90,7 +90,7 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
     }, [])
 
     const reset = (...fields: string[]) => {
-      resetFormFields(formElement.current, defaults.current, fields)
+      resetFormFields(formElement.current, defaultData.current, fields)
     }
 
     const resetAndClearErrors = (...fields: string[]) => {
@@ -132,6 +132,11 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
       form.submit(resolvedMethod, url, submitOptions)
     }
 
+    const defaults = () => {
+      defaultData.current = getFormData()
+      setIsDirty(false)
+    }
+
     const exposed = () => ({
       errors: form.errors,
       hasErrors: form.hasErrors,
@@ -145,6 +150,7 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
       setError: form.setError,
       reset,
       submit,
+      defaults,
     })
 
     useImperativeHandle(ref, exposed, [form, isDirty, submit])

--- a/packages/react/test-app/Pages/FormComponent/Ref.tsx
+++ b/packages/react/test-app/Pages/FormComponent/Ref.tsx
@@ -25,6 +25,10 @@ export default function Ref() {
     formRef.current?.setError('name', 'This is a test error')
   }
 
+  const setCurrentAsDefaults = () => {
+    formRef.current?.defaults()
+  }
+
   return (
     <div>
       <h1>Form Ref Test</h1>
@@ -67,6 +71,9 @@ export default function Ref() {
         </button>
         <button onClick={setTestError}>
           Set Test Error
+        </button>
+        <button onClick={setCurrentAsDefaults}>
+          Set Current as Defaults
         </button>
       </div>
     </div>

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -97,12 +97,6 @@
   }
 
   export function reset(...fields: string[]) {
-    if (fields.length === 0) {
-      // Svelte doesn't set the default values correctly in the DOM
-      // See: https://github.com/sveltejs/svelte/issues/9230
-      fields = [...defaults.keys()]
-    }
-
     resetFormFields(formElement, defaults, fields)
   }
 

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -38,7 +38,7 @@
   const form = useForm({})
   let formElement: HTMLFormElement
   let isDirty = false
-  let defaults: FormData = new FormData()
+  let defaultData: FormData = new FormData()
 
   $: _method = typeof action === 'object' ? action.method : (method.toLowerCase() as FormComponentProps['method'])
   $: _action = typeof action === 'object' ? action.url : action
@@ -55,7 +55,7 @@
   }
 
   function updateDirtyState(event: Event) {
-    isDirty = event.type === 'reset' ? false : !isEqual(getData(), formDataToObject(defaults))
+    isDirty = event.type === 'reset' ? false : !isEqual(getData(), formDataToObject(defaultData))
   }
 
   export function submit() {
@@ -97,7 +97,7 @@
   }
 
   export function reset(...fields: string[]) {
-    resetFormFields(formElement, defaults, fields)
+    resetFormFields(formElement, defaultData, fields)
   }
 
 
@@ -121,8 +121,13 @@
     }
   }
 
+  export function defaults() {
+    defaultData = getFormData()
+    isDirty = false
+  }
+
   onMount(() => {
-    defaults = getFormData()
+    defaultData = getFormData()
 
     const formEvents = ['input', 'change', 'reset']
     formEvents.forEach((e) => formElement.addEventListener(e, updateDirtyState))
@@ -153,5 +158,6 @@
     {setError}
     {isDirty}
     {submit}
+    {defaults}
   />
 </form>

--- a/packages/svelte/test-app/Pages/FormComponent/Ref.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/Ref.svelte
@@ -25,6 +25,10 @@
     formRef?.setError('name', 'This is a test error')
   }
 
+  function setCurrentAsDefaults() {
+    formRef?.defaults()
+  }
+
 </script>
 
 <div>
@@ -68,6 +72,9 @@
     </button>
     <button on:click={setTestError}>
       Set Test Error
+    </button>
+    <button on:click={setCurrentAsDefaults}>
+      Set Current as Defaults
     </button>
   </div>
 </div>

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -104,19 +104,19 @@ const Form: InertiaForm = defineComponent({
     // Can't use computed because FormData is not reactive
     const isDirty = ref(false)
 
-    const defaults = ref(new FormData())
+    const defaultData = ref(new FormData())
 
     const onFormUpdate = (event: Event) => {
       // If the form is reset, we set isDirty to false as we already know it's back
       // to defaults. Also, the fields are updated after the reset event, so the
       // comparison will be incorrect unless we use nextTick/setTimeout.
-      isDirty.value = event.type === 'reset' ? false : !isEqual(getData(), formDataToObject(defaults.value))
+      isDirty.value = event.type === 'reset' ? false : !isEqual(getData(), formDataToObject(defaultData.value))
     }
 
     const formEvents: Array<keyof HTMLElementEventMap> = ['input', 'change', 'reset']
 
     onMounted(() => {
-      defaults.value = getFormData()
+      defaultData.value = getFormData()
       formEvents.forEach((e) => formElement.value.addEventListener(e, onFormUpdate))
     })
 
@@ -160,12 +160,17 @@ const Form: InertiaForm = defineComponent({
     }
 
     const reset = (...fields: string[]) => {
-      resetFormFields(formElement.value, defaults.value, fields)
+      resetFormFields(formElement.value, defaultData.value, fields)
     }
 
     const resetAndClearErrors = (...fields: string[]) => {
       form.clearErrors(...fields)
       reset(...fields)
+    }
+
+    const defaults = () => {
+      defaultData.value = getFormData()
+      isDirty.value = false
     }
 
     const exposed = {
@@ -196,6 +201,7 @@ const Form: InertiaForm = defineComponent({
       },
       reset,
       submit,
+      defaults,
     }
 
     expose<FormComponentRef>(exposed)

--- a/packages/vue3/test-app/Pages/FormComponent/Ref.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/Ref.vue
@@ -24,6 +24,10 @@ const clearAllErrors = () => {
 const setTestError = () => {
   formRef.value?.setError('name', 'This is a test error')
 }
+
+const setCurrentAsDefaults = () => {
+  formRef.value?.defaults()
+}
 </script>
 
 <template>
@@ -55,6 +59,7 @@ const setTestError = () => {
       <button @click="resetNameField">Reset Name Field</button>
       <button @click="clearAllErrors">Clear Errors</button>
       <button @click="setTestError">Set Test Error</button>
+      <button @click="setCurrentAsDefaults">Set Current as Defaults</button>
     </div>
   </div>
 </template>

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -772,6 +772,31 @@ test.describe('Form Component', () => {
       expect(await page.inputValue('input[name="name"]')).toBe('John Doe')
       expect(await page.inputValue('input[name="email"]')).toBe('modified@example.com')
     })
+
+    test('can set current form data as defaults via ref', async ({ page }) => {
+      await page.goto('/form-component/ref')
+
+      // Modify form fields
+      await page.fill('input[name="name"]', 'New Name')
+      await page.fill('input[name="email"]', 'new@example.com')
+      
+      // Form should be dirty
+      await expect(page.getByText('Form is dirty')).toBeVisible()
+
+      // Set current values as defaults
+      await page.click('button:has-text("Set Current as Defaults")')
+
+      // Form should no longer be dirty
+      await expect(page.getByText('Form is clean')).toBeVisible()
+
+      // Reset form should now use the new defaults
+      await page.fill('input[name="name"]', 'Modified Again')
+      await page.click('button:has-text("Reset Form")')
+
+      expect(await page.inputValue('input[name="name"]')).toBe('New Name')
+      expect(await page.inputValue('input[name="email"]')).toBe('new@example.com')
+    })
+
   })
 
   test.describe('Uppercase Methods', () => {

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -839,7 +839,6 @@ test.describe('Form Component', () => {
     }
 
     test('resets all fields to their default values', async ({ page }) => {
-      test.skip(process.env.PACKAGE === 'svelte', 'Skipping Svelte for now')
       // Change all field values
       await page.fill('#name', 'Jane Smith')
       await page.fill('#email', 'jane@test.com')
@@ -978,7 +977,6 @@ test.describe('Form Component', () => {
     })
 
     test('disabled fields reset behavior', async ({ page }) => {
-      test.skip(process.env.PACKAGE === 'svelte', 'Skipping Svelte for now')
       // Get initial value of the disabled field
       const initialValue = await page.locator('#disabled_field').inputValue()
       expect(initialValue).toBe('Ignore me')
@@ -1044,7 +1042,6 @@ test.describe('Form Component', () => {
     })
 
     test('edge cases - non-existent fields and dynamic fields', async ({ page }) => {
-      test.skip(process.env.PACKAGE === 'svelte', 'Skipping Svelte for now')
       // Scenario 1: Handles non-existent field names gracefully
       await page.fill('#name', 'Changed Name')
       await page.fill('#email', 'changed@email.com')


### PR DESCRIPTION
This PR brings the `defaults()` method to the Form component. It's similar to the implementation in `useForm()` except that it doesn't support arguments. This would be confusing as you might assume that `defaults('name', 'newName')` would update the form element itself as well, but this won't trigger any changes in the DOM.

Some tests for `resetFormFields()` were skipped when testing the Svelte adapter. That has been fixed as well.