### PR TITLE
Only `reset()` and `defaults()` in `onSubmitComplete`

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -445,10 +445,7 @@ export type FormComponentMethods = {
   defaults: () => void
 }
 
-export type FormComponentonSubmitCompleteArguments = Pick<
-  FormComponentMethods,
-  'clearErrors' | 'resetAndClearErrors' | 'reset' | 'defaults'
->
+export type FormComponentonSubmitCompleteArguments = Pick<FormComponentMethods, 'reset' | 'defaults'>
 
 export type FormComponentState = {
   errors: Record<string, string>

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -120,8 +120,6 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
           onSuccess(...args)
           onSubmitComplete({
             reset,
-            resetAndClearErrors,
-            clearErrors: form.clearErrors,
             defaults,
           })
         },

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -79,8 +79,6 @@
         if (onSubmitComplete) {
             onSubmitComplete({
                 reset,
-                resetAndClearErrors,
-                clearErrors,
                 defaults,
             })
         }


### PR DESCRIPTION
`clearErrors` and `resetAndClearErrors` are not needed because the errors are already cleared on a successful form submission.