### PR TITLE
Fix for manipulating form after redirect in `onSubmitComplete`

### DIFF
--- a/packages/core/src/resetFormFields.ts
+++ b/packages/core/src/resetFormFields.ts
@@ -157,6 +157,10 @@ function resetFieldElements(
 }
 
 export function resetFormFields(formElement: HTMLFormElement, defaults: FormData, fieldNames?: string[]): void {
+  if (!formElement) {
+    return
+  }
+
   // If no specific fields provided, reset the entire form
   if (!fieldNames || fieldNames.length === 0) {
     // Get all field names from both defaults and form elements (including disabled ones)

--- a/packages/react/test-app/Pages/FormComponent/SubmitComplete/Redirect.tsx
+++ b/packages/react/test-app/Pages/FormComponent/SubmitComplete/Redirect.tsx
@@ -1,0 +1,24 @@
+import { Form } from '@inertiajs/react'
+
+export default () => {
+  return (
+    <div>
+      <h1>Form Redirect Test</h1>
+
+      <Form method="post" onSubmitComplete={(form) => form.reset('name')}>
+        {({ errors }) => (
+          <>
+            <div>
+              <input type="text" name="name" id="name" placeholder="Name" defaultValue="John Doe" />
+              {errors.name && <p id="error_name">{errors.name}</p>}
+            </div>
+
+            <div>
+              <button type="submit">Submit</button>
+            </div>
+          </>
+        )}
+      </Form>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/FormComponent/SubmitComplete/Redirect.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/SubmitComplete/Redirect.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { Form } from '@inertiajs/svelte'
+</script>
+
+<div>
+  <h1>Form Empty Action Test</h1>
+
+  <Form method="post" let:errors onSubmitComplete={(props) => props.reset('name')}>
+    <div>
+      <input type="text" name="name" id="name" placeholder="Name" value="John Doe" />
+      {#if errors.name}
+        <p id="error_name">{errors.name}</p>
+      {/if}
+    </div>
+
+    <div>
+      <button type="submit">Submit</button>
+    </div>
+  </Form>
+</div>

--- a/packages/vue3/test-app/Pages/FormComponent/SubmitComplete/Redirect.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/SubmitComplete/Redirect.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <div>
+    <h1>Form Redirect Test</h1>
+
+    <Form method="post" #default="{ errors }" @submit-complete="(form) => form.reset('name')">
+      <div>
+        <input type="text" name="name" id="name" placeholder="Name" value="John Doe" />
+        <p v-if="errors.name" id="error_name">{{ errors.name }}</p>
+      </div>
+
+      <div>
+        <button type="submit">Submit</button>
+      </div>
+    </Form>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -606,6 +606,11 @@ app.post('/form-component/url/with/segements', async (req, res) =>
   }),
 )
 
+app.get('/form-component/submit-complete/redirect', (req, res) =>
+  inertia.render(req, res, { component: 'FormComponent/SubmitComplete/Redirect' }),
+)
+app.post('/form-component/submit-complete/redirect', (req, res) => res.redirect('/'))
+
 app.all('*', (req, res) => inertia.render(req, res))
 
 const adapterPorts = {

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -521,6 +521,21 @@ test.describe('Form Component', () => {
       // Most importantly: form should no longer be dirty after calling defaults()
       await expect(page.locator('#dirty-status')).toHaveText('Form is clean')
     })
+
+    test('redirect and reset', async ({ page }) => {
+      page.on('pageerror', (msg) => {
+        throw new Error(msg.message)
+      })
+
+      await page.goto('/form-component/submit-complete/redirect')
+
+      await expect(page.locator('#name')).toHaveValue('John Doe')
+      await page.fill('#name', 'John Who')
+
+      await page.getByRole('button', { name: 'Submit' }).click()
+
+      await expect(page.locator('#name')).not.toBeVisible()
+    })
   })
 
   test.describe('Methods', () => {


### PR DESCRIPTION
If the response to a form submission using the `Form` component is a redirect, any call to `reset` would fail because the form element is no longer on the page. This PR adds a check for the form element before continuing with the reset.