### PR TITLE
Fix for Form Component in Svelte when resetting use input/button

### DIFF
--- a/packages/react/test-app/Pages/FormComponent/Reset.tsx
+++ b/packages/react/test-app/Pages/FormComponent/Reset.tsx
@@ -173,6 +173,7 @@ export default function Reset() {
       <input type="button" name="button_input" value="Click me" />
       <input type="submit" name="submit_input" value="Submit Form" />
       <input type="reset" name="reset_input" value="Reset Form" />
+      <button type="reset" name="reset_button">Reset Form</button>
 
       {/* Dotted & Array Notation */}
       <h2>Dotted & Array Notation</h2>

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -124,6 +124,11 @@
     submit()
   }
 
+  function handleReset(event: Event) {
+    event.preventDefault()
+    reset()
+  }
+
   export function reset(...fields: string[]) {
     resetFormFields(formElement, defaultData, fields)
   }
@@ -171,6 +176,7 @@
   action={_action}
   method={_method}
   on:submit={handleSubmit}
+  on:reset={handleReset}
   {...$$restProps}
   inert={disableWhileProcessing && $form.processing ? true : undefined}
 >

--- a/packages/svelte/test-app/Pages/FormComponent/Reset.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/Reset.svelte
@@ -153,6 +153,7 @@
   <input type="button" name="button_input" value="Click me" />
   <input type="submit" name="submit_input" value="Submit Form" />
   <input type="reset" name="reset_input" value="Reset Form" />
+  <button type="reset" name="reset_button">Reset Form</button>
 
   <!-- Dotted & Array Notation -->
   <h2>Dotted & Array Notation</h2>

--- a/packages/vue3/test-app/Pages/FormComponent/Reset.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/Reset.vue
@@ -148,6 +148,7 @@ window.resetForm = (...fields: string[]) => {
     <input type="button" name="button_input" value="Click me" />
     <input type="submit" name="submit_input" value="Submit Form" />
     <input type="reset" name="reset_input" value="Reset Form" />
+    <button type="reset" name="reset_button">Reset Form</button>
 
     <!-- Dotted & Array Notation -->
     <h2>Dotted & Array Notation</h2>

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -1217,6 +1217,32 @@ test.describe('Form Component', () => {
       await expect(page.locator('#name')).toHaveValue('John Doe')
     })
 
+    test('can reset form using reset-type input element', async ({ page }) => {
+      await page.fill('#name', 'Changed Name')
+      await page.fill('#email', 'changed@example.com')
+
+      await expect(page.locator('#name')).toHaveValue('Changed Name')
+      await expect(page.locator('#email')).toHaveValue('changed@example.com')
+
+      await page.click('input[name="reset_input"]')
+
+      await expect(page.locator('#name')).toHaveValue('John Doe')
+      await expect(page.locator('#email')).toHaveValue('john@example.com')
+    })
+
+    test('can reset form using reset-type button element', async ({ page }) => {
+      await page.fill('#name', 'Changed Name')
+      await page.fill('#email', 'changed@example.com')
+
+      await expect(page.locator('#name')).toHaveValue('Changed Name')
+      await expect(page.locator('#email')).toHaveValue('changed@example.com')
+
+      await page.click('button[name="reset_button"]')
+
+      await expect(page.locator('#name')).toHaveValue('John Doe')
+      await expect(page.locator('#email')).toHaveValue('john@example.com')
+    })
+
     test('multi-select reset behavior comprehensive test', async ({ page }) => {
       // Multi-select with no defaults resets to empty
       await page.selectOption('#languages', ['javascript', 'python'])


### PR DESCRIPTION
Fixes #2521. This previously didn't work correctly in Svelte:

```html
<input type="reset" name="reset_input" value="Reset Form" />
<button type="reset" name="reset_button">Reset Form</button>
```