### PR TITLE
Revert to back to Lodash to retain ES2020 compatibility

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,8 +50,9 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
+    "@types/lodash-es": "^4.17.12",
     "axios": "^1.8.2",
-    "es-toolkit": "^1.34.1",
+    "lodash-es": "^4.17.21",
     "qs": "^6.9.0"
   },
   "devDependencies": {

--- a/packages/core/src/formObject.ts
+++ b/packages/core/src/formObject.ts
@@ -1,4 +1,4 @@
-import { get, set } from 'es-toolkit/compat'
+import { get, set } from 'lodash-es'
 import { FormDataConvertible } from './types'
 
 /**

--- a/packages/core/src/prefetched.ts
+++ b/packages/core/src/prefetched.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'es-toolkit'
+import { cloneDeep } from 'lodash-es'
 import { objectsAreEqual } from './objectUtils'
 import { Response } from './response'
 import { timeToMs } from './time'

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@inertiajs/core": "workspace:*",
-    "es-toolkit": "^1.33.0"
+    "@types/lodash-es": "^4.17.12",
+    "lodash-es": "^4.17.21"
   }
 }

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -9,7 +9,7 @@ import {
   resetFormFields,
   VisitOptions,
 } from '@inertiajs/core'
-import { isEqual } from 'es-toolkit'
+import { isEqual } from 'lodash-es'
 import {
   createElement,
   FormEvent,

--- a/packages/react/src/Head.ts
+++ b/packages/react/src/Head.ts
@@ -1,4 +1,4 @@
-import { escape } from 'es-toolkit'
+import { escape } from 'lodash-es'
 import React, { FunctionComponent, useContext, useEffect, useMemo } from 'react'
 import HeadContext from './HeadContext'
 

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -10,8 +10,8 @@ import {
   UrlMethodPair,
   VisitOptions,
 } from '@inertiajs/core'
-import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
+import { cloneDeep, isEqual } from 'lodash-es'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import useRemember from './useRemember'
 

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -10,8 +10,7 @@ import {
   UrlMethodPair,
   VisitOptions,
 } from '@inertiajs/core'
-import { get, has, set } from 'es-toolkit/compat'
-import { cloneDeep, isEqual } from 'lodash-es'
+import { cloneDeep, get, has, isEqual, set } from 'lodash-es'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import useRemember from './useRemember'
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -44,8 +44,9 @@
   },
   "dependencies": {
     "@inertiajs/core": "workspace:*",
-    "es-toolkit": "^1.33.0",
-    "html-escape": "^2.0.0"
+    "@types/lodash-es": "^4.17.12",
+    "html-escape": "^2.0.0",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.2.0",

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -8,7 +8,7 @@
     type FormDataConvertible,
     type VisitOptions,
   } from '@inertiajs/core'
-  import { isEqual } from 'es-toolkit'
+  import { isEqual } from 'lodash-es'
   import { onMount } from 'svelte'
   import useForm from '../useForm'
 

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -16,8 +16,7 @@ import type {
 } from '@inertiajs/core'
 import { router } from '@inertiajs/core'
 import type { AxiosProgressEvent } from 'axios'
-import { get, has, set } from 'es-toolkit/compat'
-import { cloneDeep, isEqual } from 'lodash-es'
+import { cloneDeep, get, has, isEqual, set } from 'lodash-es'
 import { writable, type Writable } from 'svelte/store'
 
 type InertiaFormStore<TForm extends object> = Writable<InertiaForm<TForm>> & InertiaForm<TForm>

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -16,8 +16,8 @@ import type {
 } from '@inertiajs/core'
 import { router } from '@inertiajs/core'
 import type { AxiosProgressEvent } from 'axios'
-import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
+import { cloneDeep, isEqual } from 'lodash-es'
 import { writable, type Writable } from 'svelte/store'
 
 type InertiaFormStore<TForm extends object> = Writable<InertiaForm<TForm>> & InertiaForm<TForm>

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "@inertiajs/core": "workspace:*",
-    "es-toolkit": "^1.33.0"
+    "@types/lodash-es": "^4.17.12",
+    "lodash-es": "^4.17.21"
   }
 }

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -9,7 +9,7 @@ import {
   resetFormFields,
   VisitOptions,
 } from '@inertiajs/core'
-import { isEqual } from 'es-toolkit'
+import { isEqual } from 'lodash-es'
 import { computed, defineComponent, DefineComponent, h, onBeforeUnmount, onMounted, PropType, ref } from 'vue'
 import useForm from './useForm'
 

--- a/packages/vue3/src/head.ts
+++ b/packages/vue3/src/head.ts
@@ -1,4 +1,4 @@
-import { escape } from 'es-toolkit'
+import { escape } from 'lodash-es'
 import { defineComponent, DefineComponent } from 'vue'
 
 export type InertiaHead = DefineComponent<{

--- a/packages/vue3/src/remember.ts
+++ b/packages/vue3/src/remember.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import { cloneDeep } from 'es-toolkit'
+import { cloneDeep } from 'lodash-es'
 import { ComponentOptions } from 'vue'
 
 const remember: ComponentOptions = {

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -10,8 +10,7 @@ import {
   UrlMethodPair,
   VisitOptions,
 } from '@inertiajs/core'
-import { get, has, set } from 'es-toolkit/compat'
-import { cloneDeep, isEqual } from 'lodash-es'
+import { cloneDeep, get, has, isEqual, set } from 'lodash-es'
 import { reactive, watch } from 'vue'
 
 type FormOptions = Omit<VisitOptions, 'data'>

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -10,8 +10,8 @@ import {
   UrlMethodPair,
   VisitOptions,
 } from '@inertiajs/core'
-import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
+import { cloneDeep, isEqual } from 'lodash-es'
 import { reactive, watch } from 'vue'
 
 type FormOptions = Omit<VisitOptions, 'data'>

--- a/packages/vue3/src/useRemember.ts
+++ b/packages/vue3/src/useRemember.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import { cloneDeep } from 'es-toolkit'
+import { cloneDeep } from 'lodash-es'
 import { isReactive, reactive, ref, Ref, watch } from 'vue'
 
 export default function useRemember<T extends object>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,12 +30,15 @@ importers:
 
   packages/core:
     dependencies:
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       axios:
         specifier: ^1.8.2
         version: 1.8.2
-      es-toolkit:
-        specifier: ^1.34.1
-        version: 1.39.1
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       qs:
         specifier: ^6.9.0
         version: 6.13.1
@@ -67,9 +70,12 @@ importers:
       '@inertiajs/core':
         specifier: workspace:*
         version: link:../core
-      es-toolkit:
-        specifier: ^1.33.0
-        version: 1.39.1
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
       '@types/react':
         specifier: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -135,12 +141,15 @@ importers:
       '@inertiajs/core':
         specifier: workspace:*
         version: link:../core
-      es-toolkit:
-        specifier: ^1.33.0
-        version: 1.39.1
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       html-escape:
         specifier: ^2.0.0
         version: 2.0.0
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.2.0
@@ -215,9 +224,12 @@ importers:
       '@inertiajs/core':
         specifier: workspace:*
         version: link:../core
-      es-toolkit:
-        specifier: ^1.33.0
-        version: 1.39.1
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
       '@types/node':
         specifier: ^22.5.3
@@ -1172,6 +1184,12 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+
+  '@types/lodash@4.17.20':
+    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
+
   '@types/node@18.19.111':
     resolution: {integrity: sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==}
 
@@ -1710,9 +1728,6 @@ packages:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.39.1:
-    resolution: {integrity: sha512-cJNIXXx861Brn2GaXourDn5h3WRjYVc5hHKBLve8r0vP9TFeyPCiNgJFLn30HiJyCK4lUyjDhBELBwZG1tgZ0A==}
-
   esbuild-node-externals@1.15.0:
     resolution: {integrity: sha512-lM5f3CQL9Ctv6mBwwYAEMcphK2qrjVRnemT1mufECpFaidZvFVvQDPcuno/MQfLVk4utVuSVxm1RHLyg/ONQ/A==}
     engines: {node: '>=12'}
@@ -2190,6 +2205,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3720,6 +3738,12 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.20
+
+  '@types/lodash@4.17.20': {}
+
   '@types/node@18.19.111':
     dependencies:
       undici-types: 5.26.5
@@ -4317,8 +4341,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  es-toolkit@1.39.1: {}
-
   esbuild-node-externals@1.15.0(esbuild@0.25.0):
     dependencies:
       esbuild: 0.25.0
@@ -4838,6 +4860,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.17.21: {}
 
   lodash.merge@4.6.2: {}
 


### PR DESCRIPTION
This is quite an unusual PR, but it reverts #2210. Inertia's build config currently targets ES2020, but `es-toolkit` targets ESNext. I've investigated some alternatives:

- Bundle the used `es-toolkit` functions by putting them in the `allowList` of `nodeExternalsPlugin()`. This increases the build-size by 18-55%, which is unacceptable. Of course, no tree-shaking here.
- Copy the used functions into the project itself. I honestly don't want the maintenance burden of this, and again, no tree-shaking.
- Bump the Inertia target to ESNext. Honestly not a bad idea, but definitely a breaking change if we do this in a minor or patch release. So, something we should probably do for Inertia 3.

Fixes #2458.