### PR TITLE
Run Playwright in parallel in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
+  /* 3 threads seems to be the sweet spot on CI */
   workers: process.env.CI ? 3 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   //   reporter: 'html',


### PR DESCRIPTION
Not super scientific, but here are the Playwright times when testing Vue:

1 thread: 2m 50s
2 threads: 1m 38s
3 threads: 1m 17s

The bump to 4 threads was minimal, so let's settle for 3 for now. If we need to improve to further we could shard the tests.