### PR TITLE
Prevent errors caused by null href value

### DIFF
--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -60,7 +60,7 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
     const hoverTimeout = useRef<number>(null)
 
     const _method = useMemo(() => {
-      return typeof href === 'object' ? href.method : (method.toLowerCase() as Method)
+      return href && typeof href === 'object' ? href.method : (method.toLowerCase() as Method)
     }, [href, method])
 
     const _as = useMemo(() => {

--- a/packages/svelte/src/link.ts
+++ b/packages/svelte/src/link.ts
@@ -137,7 +137,10 @@ function link(
 
     cacheTags = cacheTagValues
 
-    method = typeof params.href === 'object' ? params.href.method : ((params.method?.toLowerCase() || 'get') as Method)
+    method =
+      params.href && typeof params.href === 'object'
+        ? params.href.method
+        : ((params.method?.toLowerCase() || 'get') as Method)
     ;[href, data] = hrefAndData(method, params)
 
     if (node.tagName === 'A') {

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -173,7 +173,7 @@ const Link: InertiaLink = defineComponent({
     })
 
     const method = computed(() =>
-      typeof props.href === 'object' ? props.href.method : (props.method.toLowerCase() as Method),
+      props.href && typeof props.href === 'object' ? props.href.method : (props.method.toLowerCase() as Method),
     )
     const as = computed(() => {
       if (typeof props.as !== 'string' || props.as.toLowerCase() !== 'a') {


### PR DESCRIPTION
The adapters all use the same logic for retrieving the method for a Link component:
```js
method = typeof href === 'object' ? href.method : /* ... */
```
This logic, however, throws a `Cannot read properties of null (reading 'method')` error at runtime when the value of `href` is `null`, because `typeof null === 'object'` is also true.

Supposing the dev was paying attention to the dev console or using TypeScript, they have a chance to catch this: href is only allowed to be a string or an object, and `null` fails prop validation. I use TypeScript in my Vue project, but the use of `<component :is="as || Link"` got rid of type safety, and the case of `href` coming up as `null` was an unknown edge case to begin with, so I only noticed it after seeing production error logs with the error. So I believe that it's in the best interest of Inertia usability for it to have a bit of a safety net here.

On a side note about project maintainability, the project was mostly easy to set up, and I followed `CONTRIBUTING.md`, but still encountered some bumps in the road to contributing:

* buidl for types
* playwright install
* pr template 
* no unit tests
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
