### PR TITLE
Remove data from the dependency array of setDefaults

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -222,12 +222,18 @@ export default function useForm<TForm extends FormDataType<TForm>>(
 
   const [dataAsDefaults, setDataAsDefaults] = useState(false)
 
+  const dataRef = useRef(data)
+
+  useEffect(() => {
+    dataRef.current = data
+  })
+
   const setDefaultsFunction = useCallback(
     (fieldOrFields?: FormDataKeys<TForm> | Partial<TForm>, maybeValue?: unknown) => {
       setDefaultsCalledInOnSuccess.current = true
 
       if (typeof fieldOrFields === 'undefined') {
-        setDefaults(data)
+        setDefaults(dataRef.current)
         // If setData was called right before setDefaults, data was not
         // updated in that render yet, so we set a flag to update
         // defaults right after the next render.
@@ -240,7 +246,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
         })
       }
     },
-    [data, setDefaults],
+    [setDefaults],
   )
 
   useLayoutEffect(() => {

--- a/packages/react/test-app/Pages/FormHelper/EffectCount.tsx
+++ b/packages/react/test-app/Pages/FormHelper/EffectCount.tsx
@@ -1,0 +1,24 @@
+import { useForm } from '@inertiajs/react'
+import { useEffect, useState } from 'react'
+
+export default () => {
+  const [count, setCount] = useState(0)
+  const [effectCount, setEffectCount] = useState(0)
+  const { data, setData, setDefaults, reset } = useForm({ count: 0, foo: 'bar' })
+
+  useEffect(() => {
+    setData('count', count)
+    setDefaults()
+    setEffectCount(effectCount + 1)
+  }, [count, setData, setDefaults, effectCount, setEffectCount])
+
+  return (
+    <div>
+      <p id="data-count">Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>Increment</button>
+      <p id="form-data">Form data: {JSON.stringify(data)}</p>
+      <button onClick={() => reset()}>Reset</button>
+      <p id="effect-count">Effect count: {effectCount}</p>
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/FormHelper/EffectCount.tsx
+++ b/packages/react/test-app/Pages/FormHelper/EffectCount.tsx
@@ -10,7 +10,7 @@ export default () => {
     setData('count', count)
     setDefaults()
     setEffectCount(effectCount + 1)
-  }, [count, setData, setDefaults, effectCount, setEffectCount])
+  }, [count, setData, setDefaults])
 
   return (
     <div>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -175,6 +175,12 @@ app.get('/form-helper/dirty', (req, res) =>
   }),
 )
 
+app.post('/form-helper/effect-count', (req, res) =>
+  inertia.render(req, res, {
+    component: 'FormHelper/EffectCount',
+  }),
+)
+
 app.post('/form-helper/dirty', (req, res) => res.redirect(303, '/form-helper/dirty'))
 app.post('/form-helper/dirty/redirect-back', (req, res) => res.redirect(303, '/form-helper/dirty'))
 

--- a/tests/form-helper.spec.ts
+++ b/tests/form-helper.spec.ts
@@ -945,3 +945,21 @@ test.describe('Nested', () => {
     await expect(dump.form.organization.repo.tags).toEqual(['v0.2', 'v0.3'])
   })
 })
+
+test.describe('React', () => {
+  test.skip(process.env.PACKAGE !== 'react', 'Only for React')
+
+  test('setDefaults callback in useEffect executes once per change', async ({ page }) => {
+    page.goto('/form-helper/effect-count')
+
+    await expect(page.locator('#data-count')).toHaveText('Count: 0')
+    await expect(page.locator('#form-data')).toHaveText('Form data: {"count":0,"foo":"bar"}')
+    await expect(page.locator('#effect-count')).toHaveText('Effect count: 1')
+
+    await page.getByRole('button', { name: 'Increment' }).click()
+
+    await expect(page.locator('#data-count')).toHaveText('Count: 1')
+    await expect(page.locator('#form-data')).toHaveText('Form data: {"count":1,"foo":"bar"}')
+    await expect(page.locator('#effect-count')).toHaveText('Effect count: 2')
+  })
+})


### PR DESCRIPTION
In Laravel Cloud's edit dialogs, we have effects that watch for changes to the model we're passing in, then set the form data to that model's properties and sets the defaults.

Previously, we had to leave `setDefaults` out of the effect's dependency array and ignore the ESLint error because `setDefaults`'s memoization was dependent on the `data` property, so it would cause an infinite loop:

```
useEffect(() => {
    setData(model);
    setDefaults();
}, [model, setData]); // eslint-disable-line react-hooks/exhaustive-deps
```

The correct way would be to include the `setDefaults` function as a dependency:

```
useEffect(() => {
    setData(model);
    setDefaults();
}, [model, setData, setDefaults]);
```

This PR uses Kent C. Dodd's "latest ref" pattern to remove `data` from the dependency array. [This is an older article](https://www.epicreact.dev/the-latest-ref-pattern-in-react), but it still explains the idea.