### PR TITLE
Update dirty state after DOM changes (React only)

### DIFF
--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -15,6 +15,7 @@ import {
   FormEvent,
   forwardRef,
   ReactNode,
+  startTransition,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -81,7 +82,9 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
     const getData = (): Record<string, FormDataConvertible> => formDataToObject(getFormData())
 
     const updateDirtyState = (event: Event) =>
-      setIsDirty(event.type === 'reset' ? false : !isEqual(getData(), formDataToObject(defaultData.current)))
+      startTransition(() =>
+        setIsDirty(event.type === 'reset' ? false : !isEqual(getData(), formDataToObject(defaultData.current))),
+      )
 
     useEffect(() => {
       defaultData.current = getFormData()

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -10,12 +10,11 @@ import {
   VisitOptions,
 } from '@inertiajs/core'
 import { isEqual } from 'lodash-es'
-import {
+import React, {
   createElement,
   FormEvent,
   forwardRef,
   ReactNode,
-  startTransition,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -23,6 +22,11 @@ import {
   useState,
 } from 'react'
 import useForm from './useForm'
+
+// Polyfill for startTransition to support React 16.9+
+const deferStateUpdate = (callback: () => void) => {
+  typeof React.startTransition === 'function' ? React.startTransition(callback) : setTimeout(callback, 0)
+}
 
 type ComponentProps = (FormComponentProps &
   Omit<React.FormHTMLAttributes<HTMLFormElement>, keyof FormComponentProps | 'children'> &
@@ -82,7 +86,7 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
     const getData = (): Record<string, FormDataConvertible> => formDataToObject(getFormData())
 
     const updateDirtyState = (event: Event) =>
-      startTransition(() =>
+      deferStateUpdate(() =>
         setIsDirty(event.type === 'reset' ? false : !isEqual(getData(), formDataToObject(defaultData.current))),
       )
 

--- a/packages/react/test-app/Pages/FormComponent/ChildComponent.tsx
+++ b/packages/react/test-app/Pages/FormComponent/ChildComponent.tsx
@@ -1,0 +1,34 @@
+import { Form } from '@inertiajs/react'
+import { useMemo, useState } from 'react'
+
+const ChildElement = ({ name }: { name: string }) => {
+  const [internalState, setInternalState] = useState('')
+  const transformedState = useMemo(() => internalState.toUpperCase(), [internalState])
+
+  return (
+    <div>
+      <label htmlFor={name}>Child Input</label>
+      <input id={name} name={name} value={transformedState} onChange={(e) => setInternalState(e.target.value)} />
+    </div>
+  )
+}
+
+export default () => {
+  return (
+    <Form action="/dump/post" method="post">
+      {({ isDirty }) => (
+        <>
+          <h1>Form Elements</h1>
+
+          <div>
+            Form is <span>{isDirty ? 'dirty' : 'clean'}</span>
+          </div>
+
+          <ChildElement name="child" />
+
+          <button type="submit">Submit</button>
+        </>
+      )}
+    </Form>
+  )
+}

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -537,6 +537,9 @@ app.post('/redirect-external', (req, res) => inertia.location(res, '/non-inertia
 app.post('/disconnect', (req, res) => res.socket.destroy())
 app.post('/json', (req, res) => res.json({ foo: 'bar' }))
 
+app.get('/form-component/child-component', (req, res) =>
+  inertia.render(req, res, { component: 'FormComponent/ChildComponent' }),
+)
 app.get('/form-component/elements', (req, res) => inertia.render(req, res, { component: 'FormComponent/Elements' }))
 app.get('/form-component/errors', (req, res) => inertia.render(req, res, { component: 'FormComponent/Errors' }))
 app.post('/form-component/errors', (req, res) =>

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -1428,4 +1428,22 @@ test.describe('Form Component', () => {
       await expect(requests.requests.length).toBe(0)
     })
   })
+
+  test.describe('React', () => {
+    test.skip(process.env.PACKAGE !== 'react', 'Skipping React-specific tests')
+
+    test('it preserves the internal state of child components', async ({ page }) => {
+      await page.goto('/form-component/child-component')
+
+      await expect(page.getByText('Form is clean')).toBeVisible()
+
+      await page.fill('#child', 'a')
+      await expect(page.locator('#child')).toHaveValue('A')
+      await expect(page.getByText('Form is dirty')).toBeVisible()
+
+      await page.getByRole('button', { name: 'Submit' }).click()
+      const dump = await shouldBeDumpPage(page, 'post')
+      expect(dump.form).toEqual({ child: 'A' })
+    })
+  })
 })


### PR DESCRIPTION
This defers updating the `isDirty` state until after DOM changes are complete. Since we base the dirty state on the DOM using `new FormData(formElement)`, we need to ensure child components have finished updating their `value` attributes before we check the form state.

The fix wraps `setIsDirty` in `startTransition()` within `updateDirtyState` to defer the state update until after the current render cycle.