### PR TITLE
Fix flaky tests in CI

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -76,5 +76,6 @@ pnpm publish -r
 
 gh release create "$TAG" --generate-notes
 
-echo "\n✅ Release $TAG completed successfully."
+echo ""
+echo "✅ Release $TAG completed successfully."
 echo "🔗 https://github.com/inertiajs/inertia/releases/tag/$TAG"

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -5,7 +5,7 @@ test.describe('Form Component', () => {
   test.describe('Elements', () => {
     test.beforeEach(async ({ page }) => {
       pageLoads.watch(page)
-      page.goto('/form-component/elements')
+      await page.goto('/form-component/elements')
     })
 
     test('can submit the form with the default values', async ({ page }) => {

--- a/tests/form-helper.spec.ts
+++ b/tests/form-helper.spec.ts
@@ -63,9 +63,9 @@ test.describe('Form Helper', () => {
   test.describe('Errors', () => {
     test.beforeEach(async ({ page }) => {
       pageLoads.watch(page)
-      page.goto('/form-helper/errors')
-      const errorsStatus = await page.locator('.errors-status')
 
+      await page.goto('/form-helper/errors')
+      const errorsStatus = await page.locator('.errors-status')
       await expect(await errorsStatus.textContent()).toEqual('Form has no errors')
 
       await page.fill('#name', 'A')

--- a/tests/form-helper.spec.ts
+++ b/tests/form-helper.spec.ts
@@ -5,7 +5,7 @@ test.describe('Form Helper', () => {
   test.describe('Methods', () => {
     test.beforeEach(async ({ page }) => {
       pageLoads.watch(page)
-      page.goto('/form-helper/methods')
+      await page.goto('/form-helper/methods')
       await page.check('#remember')
     })
 
@@ -35,7 +35,7 @@ test.describe('Form Helper', () => {
   test.describe('Transform', () => {
     test.beforeEach(async ({ page }) => {
       pageLoads.watch(page)
-      page.goto('/form-helper/transform')
+      await page.goto('/form-helper/transform')
       await page.check('#remember')
     })
 
@@ -295,7 +295,7 @@ test.describe('Form Helper', () => {
   test.describe('Dirty', () => {
     test.beforeEach(async ({ page }) => {
       pageLoads.watch(page)
-      page.goto('/form-helper/dirty')
+      await page.goto('/form-helper/dirty')
     })
 
     test('can check if the form is dirty', async ({ page }) => {
@@ -354,7 +354,7 @@ test.describe('Form Helper', () => {
   test.describe('Data', () => {
     test.beforeEach(async ({ page }) => {
       pageLoads.watch(page)
-      page.goto('/form-helper/data')
+      await page.goto('/form-helper/data')
     })
 
     test('can reset all fields to their initial values', async ({ page }) => {
@@ -894,7 +894,7 @@ test.describe('Form Helper', () => {
 test.describe('Nested', () => {
   test.beforeEach(async ({ page }) => {
     pageLoads.watch(page)
-    page.goto('/form-helper/nested')
+    await page.goto('/form-helper/nested')
   })
 
   test('can handle nested data', async ({ page }) => {
@@ -950,7 +950,7 @@ test.describe('React', () => {
   test.skip(process.env.PACKAGE !== 'react', 'Only for React')
 
   test('setDefaults callback in useEffect executes once per change', async ({ page }) => {
-    page.goto('/form-helper/effect-count')
+    await page.goto('/form-helper/effect-count')
 
     await expect(page.locator('#data-count')).toHaveText('Count: 0')
     await expect(page.locator('#form-data')).toHaveText('Form data: {"count":0,"foo":"bar"}')

--- a/tests/head.spec.ts
+++ b/tests/head.spec.ts
@@ -5,6 +5,7 @@ test('renders the title tag and children', async ({ page }) => {
 
   await page.goto('/head')
 
+  await page.waitForSelector('title[inertia]', { state: 'attached' })
   const inertiaTitle = await page.evaluate(() => document.querySelector('title[inertia]')?.textContent)
 
   await expect(inertiaTitle).toBe('Test Head Component')

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -508,6 +508,7 @@ test.describe('enabled', () => {
     )
     await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
+    await page.waitForTimeout(100)
   })
 
   test('resets scroll regions to the top when doing a regular visit', async ({ page }) => {
@@ -579,7 +580,9 @@ test.describe('enabled', () => {
     await expect(page).toHaveURL('/links/preserve-scroll')
     await expect(page.getByText('Foo is now default')).toBeVisible()
     await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
-    await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
+
+    // Wait for scroll restoration to complete - use longer timeout for flaky CI
+    await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible({ timeout: 10000 })
   })
 
   test('restores the document scroll position when pressing the back button with history encryption enabled', async ({

--- a/tests/manual-visits.spec.ts
+++ b/tests/manual-visits.spec.ts
@@ -956,20 +956,22 @@ test.describe('Redirects', () => {
 
 test('can do a subsequent visit after the previous visit has thrown an error in onSuccess', async ({ page }) => {
   pageLoads.watch(page)
-  const consoleErrors = []
 
-  page.on('pageerror', (error: Error) => consoleErrors.push(error.message))
-
-  await expect(consoleMessages.messages).toHaveLength(0)
+  consoleMessages.listen(page)
 
   await page.goto('/visits/after-error/1')
+
+  await expect(consoleMessages.messages).toHaveLength(0)
+  await expect(consoleMessages.errors).toHaveLength(0)
+
   const response = page.waitForResponse('/visits/after-error/2')
 
   await page.getByRole('link', { name: 'Throw error on success' }).click()
   await response
 
-  await expect(consoleErrors).toHaveLength(1)
-  await expect(consoleErrors[0]).toBe('Error after visit')
+  await expect(consoleMessages.messages).toHaveLength(0)
+  await expect(consoleMessages.errors).toHaveLength(1)
+  await expect(consoleMessages.errors[0]).toBe('Error after visit')
 
   await page.getByRole('link', { name: 'Visit dump page' }).click()
 

--- a/tests/manual-visits.spec.ts
+++ b/tests/manual-visits.spec.ts
@@ -965,9 +965,15 @@ test('can do a subsequent visit after the previous visit has thrown an error in 
   await expect(consoleMessages.errors).toHaveLength(0)
 
   const response = page.waitForResponse('/visits/after-error/2')
+  
+  // Set up error promise before triggering the action that will cause the error
+  const errorPromise = page.waitForEvent('pageerror')
 
   await page.getByRole('link', { name: 'Throw error on success' }).click()
   await response
+
+  // Wait for the error to be thrown before checking
+  await errorPromise
 
   await expect(consoleMessages.messages).toHaveLength(0)
   await expect(consoleMessages.errors).toHaveLength(1)

--- a/tests/prefetch.spec.ts
+++ b/tests/prefetch.spec.ts
@@ -285,6 +285,7 @@ submitButtonTexts.forEach((buttonText) => {
       await page.getByRole('button', { name: buttonText }).click()
       await page.waitForURL('/prefetch/form')
 
+      await page.waitForTimeout(100)
       const secondRandomValue = await page.locator('.random-value').textContent()
       expect(secondRandomValue).not.toBe(firstRandomValue)
 

--- a/tests/prefetch.spec.ts
+++ b/tests/prefetch.spec.ts
@@ -1,5 +1,5 @@
 import { expect, Page, test } from '@playwright/test'
-import { clickAndWaitForResponse, requests } from './support'
+import { requests } from './support'
 
 const isPrefetchPage = async (page: Page, id: number) => {
   await page.waitForURL(`prefetch/${id}`)
@@ -12,9 +12,10 @@ const isPrefetchSwrPage = async (page: Page, id: number) => {
 }
 
 const hoverAndClick = async (page: Page, buttonText: string, id: number) => {
+  const prefetchPromise = page.waitForResponse(`prefetch/swr/${id}`)
   await page.getByRole('link', { name: buttonText, exact: true }).hover()
-  await page.waitForTimeout(75)
-  await clickAndWaitForResponse(page, buttonText, `prefetch/swr/${id}`)
+  await prefetchPromise
+  await page.getByRole('link', { name: buttonText, exact: true }).click()
   await isPrefetchSwrPage(page, id)
 }
 

--- a/tests/support.ts
+++ b/tests/support.ts
@@ -29,11 +29,14 @@ export const pageLoads = {
 }
 
 export const consoleMessages = {
+  errors: [] as string[],
   messages: [] as string[],
 
   listen(page: Page) {
+    this.errors = []
     this.messages = []
     page.on('console', (msg) => this.messages.push(msg.text()))
+    page.on('pageerror', (error: Error) => this.errors.push(error.message))
   },
 }
 


### PR DESCRIPTION
This PR is a little round of cleanup and improving tests that turn out to be flaky in CI. There's still a *scroll restoration* test that sometimes fails, but I'm not sure if that's a flaky test or if the actual implementation should be improved.