### PR TITLE
Client-side visit helpers to update props

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -331,22 +331,6 @@ export class Router {
     })
   }
 
-  protected mergeArrays(a: unknown, b: unknown): unknown[] {
-    if (Array.isArray(a) && Array.isArray(b)) {
-      return [...a, ...b]
-    }
-
-    if (Array.isArray(a)) {
-      return typeof b === 'undefined' ? a : [...a, b]
-    }
-
-    if (Array.isArray(b)) {
-      return typeof a === 'undefined' ? b : [a, ...b]
-    }
-
-    return [...(typeof a === 'undefined' ? [] : [a]), ...(typeof b === 'undefined' ? [] : [b])]
-  }
-
   public appendToProp<TProps = Page['props']>(
     name: string,
     value: unknown | unknown[] | ((oldValue: unknown, props: TProps) => unknown | unknown[]),
@@ -356,7 +340,12 @@ export class Router {
       name,
       (currentValue: unknown, currentProps: TProps) => {
         const newValue = typeof value === 'function' ? value(currentValue, currentProps) : value
-        return this.mergeArrays(currentValue, newValue)
+
+        if (!Array.isArray(currentValue)) {
+          currentValue = currentValue !== undefined ? [currentValue] : []
+        }
+
+        return [...(currentValue as unknown[]), newValue]
       },
       options,
     )
@@ -371,7 +360,12 @@ export class Router {
       name,
       (currentValue: unknown, currentProps: TProps) => {
         const newValue = typeof value === 'function' ? value(currentValue, currentProps) : value
-        return this.mergeArrays(newValue, currentValue)
+
+        if (!Array.isArray(currentValue)) {
+          currentValue = currentValue !== undefined ? [currentValue] : []
+        }
+
+        return [newValue, ...(currentValue as unknown[])]
       },
       options,
     )

--- a/packages/react/test-app/Pages/ClientSideVisit/Props.tsx
+++ b/packages/react/test-app/Pages/ClientSideVisit/Props.tsx
@@ -1,0 +1,136 @@
+import { router } from '@inertiajs/react'
+
+interface Tag {
+  id: number
+  name: string
+}
+
+interface User {
+  name: string
+  age: number
+}
+
+export default ({
+  items = [],
+  tags = [],
+  user,
+  count = 0,
+  singleValue,
+  undefinedValue,
+}: {
+  items?: string[]
+  tags?: Tag[]
+  user?: User
+  count?: number
+  singleValue?: string | string[]
+  undefinedValue?: string | string[]
+}) => {
+  const replacePropString = () => {
+    router.replaceProp('user.name', 'Jane Smith')
+  }
+
+  const replacePropNumber = () => {
+    router.replaceProp('count', 10)
+  }
+
+  const replacePropFunction = () => {
+    router.replaceProp('count', (oldValue) => (oldValue as number) * 2)
+  }
+
+  const appendToPropArray = () => {
+    router.appendToProp('items', 'item3')
+  }
+
+  const appendToPropMultiple = () => {
+    router.appendToProp('items', ['item4', 'item5'])
+  }
+
+  const appendToPropFunction = () => {
+    router.appendToProp('tags', () => [{ id: 3, name: 'tag3' }])
+  }
+
+  const prependToPropArray = () => {
+    router.prependToProp('items', 'item0')
+  }
+
+  const prependToPropMultiple = () => {
+    router.prependToProp('items', ['itemA', 'itemB'])
+  }
+
+  const prependToPropFunction = () => {
+    router.prependToProp('tags', () => [{ id: 0, name: 'tag0' }])
+  }
+
+  // Edge case tests for mergeArrays behavior
+  const appendToNonArray = () => {
+    router.appendToProp('singleValue', 'world')
+  }
+
+  const prependToNonArray = () => {
+    router.prependToProp('singleValue', 'hey')
+  }
+
+  const appendArrayToNonArray = () => {
+    router.appendToProp('singleValue', ['there', 'world'])
+  }
+
+  const prependArrayToNonArray = () => {
+    router.prependToProp('singleValue', ['hey', 'hi'])
+  }
+
+  const appendToUndefined = () => {
+    router.appendToProp('undefinedValue', 'new value')
+  }
+
+  const prependToUndefined = () => {
+    router.prependToProp('undefinedValue', 'start value')
+  }
+
+  const renderValue = (value: string | string[] | undefined): string => {
+    if (Array.isArray(value)) {
+      return value.join(', ')
+    }
+    return value || 'undefined'
+  }
+
+  return (
+    <div>
+      <h1>Client Side Visit Props Testing</h1>
+
+      <div>
+        User: {user?.name || 'Unknown'} (Age: {user?.age || 'Unknown'})
+      </div>
+      <div>Count: {count}</div>
+
+      <div>Items: {items.join(', ')}</div>
+      <div>Tags: {tags.map((tag) => tag.name).join(', ')}</div>
+      <div>Single Value: {renderValue(singleValue)}</div>
+      <div>Undefined Value: {renderValue(undefinedValue)}</div>
+
+      <hr />
+
+      <h2>Replace Prop Tests</h2>
+      <button onClick={replacePropString}>Replace user.name</button>
+      <button onClick={replacePropNumber}>Replace count</button>
+      <button onClick={replacePropFunction}>Replace count (function)</button>
+
+      <h2>Append To Prop Tests</h2>
+      <button onClick={appendToPropArray}>Append to items (single)</button>
+      <button onClick={appendToPropMultiple}>Append to items (multiple)</button>
+      <button onClick={appendToPropFunction}>Append to tags (function)</button>
+
+      <h2>Prepend To Prop Tests</h2>
+      <button onClick={prependToPropArray}>Prepend to items (single)</button>
+      <button onClick={prependToPropMultiple}>Prepend to items (multiple)</button>
+      <button onClick={prependToPropFunction}>Prepend to tags (function)</button>
+
+      <h2>Edge Case Tests (mergeArrays behavior)</h2>
+      <button onClick={appendToNonArray}>Append to non-array (single + single)</button>
+      <button onClick={prependToNonArray}>Prepend to non-array (single + single)</button>
+      <button onClick={appendArrayToNonArray}>Append array to non-array (single + array)</button>
+      <button onClick={prependArrayToNonArray}>Prepend array to non-array (array + single)</button>
+      <button onClick={appendToUndefined}>Append to undefined</button>
+      <button onClick={prependToUndefined}>Prepend to undefined</button>
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/ClientSideVisit/Props.tsx
+++ b/packages/react/test-app/Pages/ClientSideVisit/Props.tsx
@@ -46,7 +46,14 @@ export default ({
   }
 
   const appendToPropFunction = () => {
-    router.appendToProp('tags', () => [{ id: 3, name: 'tag3' }])
+    router.appendToProp('tags', () => ({ id: 3, name: 'tag3' }))
+  }
+
+  const appendArrayToArray = () => {
+    router.appendToProp('tags', [
+      { id: 3, name: 'tag3' },
+      { id: 4, name: 'tag4' },
+    ])
   }
 
   const prependToPropArray = () => {
@@ -58,7 +65,7 @@ export default ({
   }
 
   const prependToPropFunction = () => {
-    router.prependToProp('tags', () => [{ id: 0, name: 'tag0' }])
+    router.prependToProp('tags', () => ({ id: 0, name: 'tag0' }))
   }
 
   // Edge case tests for mergeArrays behavior
@@ -86,13 +93,6 @@ export default ({
     router.prependToProp('undefinedValue', 'start value')
   }
 
-  const renderValue = (value: string | string[] | undefined): string => {
-    if (Array.isArray(value)) {
-      return value.join(', ')
-    }
-    return value || 'undefined'
-  }
-
   return (
     <div>
       <h1>Client Side Visit Props Testing</h1>
@@ -102,10 +102,10 @@ export default ({
       </div>
       <div>Count: {count}</div>
 
-      <div>Items: {items.join(', ')}</div>
-      <div>Tags: {tags.map((tag) => tag.name).join(', ')}</div>
-      <div>Single Value: {renderValue(singleValue)}</div>
-      <div>Undefined Value: {renderValue(undefinedValue)}</div>
+      <div>Items: {JSON.stringify(items)}</div>
+      <div>Tags: {JSON.stringify(tags)}</div>
+      <div>Single Value: {JSON.stringify(singleValue)}</div>
+      <div>Undefined Value: {JSON.stringify(undefinedValue)}</div>
 
       <hr />
 
@@ -118,6 +118,7 @@ export default ({
       <button onClick={appendToPropArray}>Append to items (single)</button>
       <button onClick={appendToPropMultiple}>Append to items (multiple)</button>
       <button onClick={appendToPropFunction}>Append to tags (function)</button>
+      <button onClick={appendArrayToArray}>Append array to array (objects)</button>
 
       <h2>Prepend To Prop Tests</h2>
       <button onClick={prependToPropArray}>Prepend to items (single)</button>

--- a/packages/svelte/test-app/Pages/ClientSideVisit/Props.svelte
+++ b/packages/svelte/test-app/Pages/ClientSideVisit/Props.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import { router } from '@inertiajs/svelte'
+
+  interface Tag {
+    id: number
+    name: string
+  }
+
+  interface User {
+    name: string
+    age: number
+  }
+
+  export let items: string[] = []
+  export let tags: Tag[] = []
+  export let user: User | undefined = undefined
+  export let count = 0
+  export let singleValue: string | string[] | undefined = undefined
+  export let undefinedValue: string | string[] | undefined = undefined
+
+  const replacePropString = () => {
+    router.replaceProp('user.name', 'Jane Smith')
+  }
+
+  const replacePropNumber = () => {
+    router.replaceProp('count', 10)
+  }
+
+  const replacePropFunction = () => {
+    router.replaceProp('count', (oldValue) => (oldValue as number) * 2)
+  }
+
+  const appendToPropArray = () => {
+    router.appendToProp('items', 'item3')
+  }
+
+  const appendToPropMultiple = () => {
+    router.appendToProp('items', ['item4', 'item5'])
+  }
+
+  const appendToPropFunction = () => {
+    router.appendToProp('tags', () => [{ id: 3, name: 'tag3' }])
+  }
+
+  const prependToPropArray = () => {
+    router.prependToProp('items', 'item0')
+  }
+
+  const prependToPropMultiple = () => {
+    router.prependToProp('items', ['itemA', 'itemB'])
+  }
+
+  const prependToPropFunction = () => {
+    router.prependToProp('tags', () => [{ id: 0, name: 'tag0' }])
+  }
+
+  // Edge case tests for mergeArrays behavior
+  const appendToNonArray = () => {
+    router.appendToProp('singleValue', 'world')
+  }
+
+  const prependToNonArray = () => {
+    router.prependToProp('singleValue', 'hey')
+  }
+
+  const appendArrayToNonArray = () => {
+    router.appendToProp('singleValue', ['there', 'world'])
+  }
+
+  const prependArrayToNonArray = () => {
+    router.prependToProp('singleValue', ['hey', 'hi'])
+  }
+
+  const appendToUndefined = () => {
+    router.appendToProp('undefinedValue', 'new value')
+  }
+
+  const prependToUndefined = () => {
+    router.prependToProp('undefinedValue', 'start value')
+  }
+
+  const renderValue = (value: string | string[] | undefined): string => {
+    if (Array.isArray(value)) {
+      return value.join(', ')
+    }
+    return value || 'undefined'
+  }
+</script>
+
+<div>
+  <h1>Client Side Visit Props Testing</h1>
+
+  <div>User: {user?.name || 'Unknown'} (Age: {user?.age || 'Unknown'})</div>
+  <div>Count: {count}</div>
+
+  <div>Items: {items.join(', ')}</div>
+  <div>Tags: {tags.map((tag) => tag.name).join(', ')}</div>
+  <div>Single Value: {renderValue(singleValue)}</div>
+  <div>Undefined Value: {renderValue(undefinedValue)}</div>
+
+  <hr />
+
+  <h2>Replace Prop Tests</h2>
+  <button on:click={replacePropString}>Replace user.name</button>
+  <button on:click={replacePropNumber}>Replace count</button>
+  <button on:click={replacePropFunction}>Replace count (function)</button>
+
+  <h2>Append To Prop Tests</h2>
+  <button on:click={appendToPropArray}>Append to items (single)</button>
+  <button on:click={appendToPropMultiple}>Append to items (multiple)</button>
+  <button on:click={appendToPropFunction}>Append to tags (function)</button>
+
+  <h2>Prepend To Prop Tests</h2>
+  <button on:click={prependToPropArray}>Prepend to items (single)</button>
+  <button on:click={prependToPropMultiple}>Prepend to items (multiple)</button>
+  <button on:click={prependToPropFunction}>Prepend to tags (function)</button>
+
+  <h2>Edge Case Tests (mergeArrays behavior)</h2>
+  <button on:click={appendToNonArray}>Append to non-array (single + single)</button>
+  <button on:click={prependToNonArray}>Prepend to non-array (single + single)</button>
+  <button on:click={appendArrayToNonArray}>Append array to non-array (single + array)</button>
+  <button on:click={prependArrayToNonArray}>Prepend array to non-array (array + single)</button>
+  <button on:click={appendToUndefined}>Append to undefined</button>
+  <button on:click={prependToUndefined}>Prepend to undefined</button>
+</div>

--- a/packages/svelte/test-app/Pages/ClientSideVisit/Props.svelte
+++ b/packages/svelte/test-app/Pages/ClientSideVisit/Props.svelte
@@ -39,7 +39,14 @@
   }
 
   const appendToPropFunction = () => {
-    router.appendToProp('tags', () => [{ id: 3, name: 'tag3' }])
+    router.appendToProp('tags', () => ({ id: 3, name: 'tag3' }))
+  }
+
+  const appendArrayToArray = () => {
+    router.appendToProp('tags', [
+      { id: 3, name: 'tag3' },
+      { id: 4, name: 'tag4' },
+    ])
   }
 
   const prependToPropArray = () => {
@@ -51,7 +58,7 @@
   }
 
   const prependToPropFunction = () => {
-    router.prependToProp('tags', () => [{ id: 0, name: 'tag0' }])
+    router.prependToProp('tags', () => ({ id: 0, name: 'tag0' }))
   }
 
   // Edge case tests for mergeArrays behavior
@@ -78,13 +85,6 @@
   const prependToUndefined = () => {
     router.prependToProp('undefinedValue', 'start value')
   }
-
-  const renderValue = (value: string | string[] | undefined): string => {
-    if (Array.isArray(value)) {
-      return value.join(', ')
-    }
-    return value || 'undefined'
-  }
 </script>
 
 <div>
@@ -93,10 +93,10 @@
   <div>User: {user?.name || 'Unknown'} (Age: {user?.age || 'Unknown'})</div>
   <div>Count: {count}</div>
 
-  <div>Items: {items.join(', ')}</div>
-  <div>Tags: {tags.map((tag) => tag.name).join(', ')}</div>
-  <div>Single Value: {renderValue(singleValue)}</div>
-  <div>Undefined Value: {renderValue(undefinedValue)}</div>
+  <div>Items: {JSON.stringify(items)}</div>
+  <div>Tags: {JSON.stringify(tags)}</div>
+  <div>Single Value: {JSON.stringify(singleValue)}</div>
+  <div>Undefined Value: {JSON.stringify(undefinedValue)}</div>
 
   <hr />
 
@@ -109,6 +109,7 @@
   <button on:click={appendToPropArray}>Append to items (single)</button>
   <button on:click={appendToPropMultiple}>Append to items (multiple)</button>
   <button on:click={appendToPropFunction}>Append to tags (function)</button>
+  <button on:click={appendArrayToArray}>Append array to array (objects)</button>
 
   <h2>Prepend To Prop Tests</h2>
   <button on:click={prependToPropArray}>Prepend to items (single)</button>

--- a/packages/vue3/test-app/Pages/ClientSideVisit/Props.vue
+++ b/packages/vue3/test-app/Pages/ClientSideVisit/Props.vue
@@ -31,7 +31,14 @@ const appendToPropMultiple = () => {
 }
 
 const appendToPropFunction = () => {
-  router.appendToProp('tags', (oldValue) => [{ id: 3, name: 'tag3' }])
+  router.appendToProp('tags', (oldValue) => ({ id: 3, name: 'tag3' }))
+}
+
+const appendArrayToArray = () => {
+  router.appendToProp('tags', [
+    { id: 3, name: 'tag3' },
+    { id: 4, name: 'tag4' },
+  ])
 }
 
 const prependToPropArray = () => {
@@ -43,7 +50,7 @@ const prependToPropMultiple = () => {
 }
 
 const prependToPropFunction = () => {
-  router.prependToProp('tags', (oldValue) => [{ id: 0, name: 'tag0' }])
+  router.prependToProp('tags', (oldValue) => ({ id: 0, name: 'tag0' }))
 }
 
 // Edge case tests for mergeArrays behavior
@@ -79,12 +86,10 @@ const prependToUndefined = () => {
     <div>User: {{ user?.name || 'Unknown' }} (Age: {{ user?.age || 'Unknown' }})</div>
     <div>Count: {{ count }}</div>
 
-    <div>Items: {{ items?.join(', ') }}</div>
-    <div>Tags: {{ tags?.map((tag) => tag.name).join(', ') }}</div>
-    <div>Single Value: {{ Array.isArray(singleValue) ? singleValue.join(', ') : singleValue || 'undefined' }}</div>
-    <div>
-      Undefined Value: {{ Array.isArray(undefinedValue) ? undefinedValue.join(', ') : undefinedValue || 'undefined' }}
-    </div>
+    <div>Items: {{ JSON.stringify(items) }}</div>
+    <div>Tags: {{ JSON.stringify(tags) }}</div>
+    <div>Single Value: {{ JSON.stringify(singleValue) }}</div>
+    <div>Undefined Value: {{ JSON.stringify(undefinedValue) }}</div>
 
     <hr />
 
@@ -97,6 +102,7 @@ const prependToUndefined = () => {
     <button @click="appendToPropArray">Append to items (single)</button>
     <button @click="appendToPropMultiple">Append to items (multiple)</button>
     <button @click="appendToPropFunction">Append to tags (function)</button>
+    <button @click="appendArrayToArray">Append array to array (objects)</button>
 
     <h2>Prepend To Prop Tests</h2>
     <button @click="prependToPropArray">Prepend to items (single)</button>

--- a/packages/vue3/test-app/Pages/ClientSideVisit/Props.vue
+++ b/packages/vue3/test-app/Pages/ClientSideVisit/Props.vue
@@ -1,0 +1,114 @@
+<script setup>
+import { router } from '@inertiajs/vue3'
+
+const props = defineProps({
+  items: Array,
+  tags: Array,
+  user: Object,
+  count: Number,
+  singleValue: String,
+  undefinedValue: undefined,
+})
+
+const replacePropString = () => {
+  router.replaceProp('user.name', 'Jane Smith')
+}
+
+const replacePropNumber = () => {
+  router.replaceProp('count', 10)
+}
+
+const replacePropFunction = () => {
+  router.replaceProp('count', (oldValue) => oldValue * 2)
+}
+
+const appendToPropArray = () => {
+  router.appendToProp('items', 'item3')
+}
+
+const appendToPropMultiple = () => {
+  router.appendToProp('items', ['item4', 'item5'])
+}
+
+const appendToPropFunction = () => {
+  router.appendToProp('tags', (oldValue) => [{ id: 3, name: 'tag3' }])
+}
+
+const prependToPropArray = () => {
+  router.prependToProp('items', 'item0')
+}
+
+const prependToPropMultiple = () => {
+  router.prependToProp('items', ['itemA', 'itemB'])
+}
+
+const prependToPropFunction = () => {
+  router.prependToProp('tags', (oldValue) => [{ id: 0, name: 'tag0' }])
+}
+
+// Edge case tests for mergeArrays behavior
+const appendToNonArray = () => {
+  router.appendToProp('singleValue', 'world')
+}
+
+const prependToNonArray = () => {
+  router.prependToProp('singleValue', 'hey')
+}
+
+const appendArrayToNonArray = () => {
+  router.appendToProp('singleValue', ['there', 'world'])
+}
+
+const prependArrayToNonArray = () => {
+  router.prependToProp('singleValue', ['hey', 'hi'])
+}
+
+const appendToUndefined = () => {
+  router.appendToProp('undefinedValue', 'new value')
+}
+
+const prependToUndefined = () => {
+  router.prependToProp('undefinedValue', 'start value')
+}
+</script>
+
+<template>
+  <div>
+    <h1>Client Side Visit Props Testing</h1>
+
+    <div>User: {{ user?.name || 'Unknown' }} (Age: {{ user?.age || 'Unknown' }})</div>
+    <div>Count: {{ count }}</div>
+
+    <div>Items: {{ items?.join(', ') }}</div>
+    <div>Tags: {{ tags?.map((tag) => tag.name).join(', ') }}</div>
+    <div>Single Value: {{ Array.isArray(singleValue) ? singleValue.join(', ') : singleValue || 'undefined' }}</div>
+    <div>
+      Undefined Value: {{ Array.isArray(undefinedValue) ? undefinedValue.join(', ') : undefinedValue || 'undefined' }}
+    </div>
+
+    <hr />
+
+    <h2>Replace Prop Tests</h2>
+    <button @click="replacePropString">Replace user.name</button>
+    <button @click="replacePropNumber">Replace count</button>
+    <button @click="replacePropFunction">Replace count (function)</button>
+
+    <h2>Append To Prop Tests</h2>
+    <button @click="appendToPropArray">Append to items (single)</button>
+    <button @click="appendToPropMultiple">Append to items (multiple)</button>
+    <button @click="appendToPropFunction">Append to tags (function)</button>
+
+    <h2>Prepend To Prop Tests</h2>
+    <button @click="prependToPropArray">Prepend to items (single)</button>
+    <button @click="prependToPropMultiple">Prepend to items (multiple)</button>
+    <button @click="prependToPropFunction">Prepend to tags (function)</button>
+
+    <h2>Edge Case Tests (mergeArrays behavior)</h2>
+    <button @click="appendToNonArray">Append to non-array (single + single)</button>
+    <button @click="prependToNonArray">Prepend to non-array (single + single)</button>
+    <button @click="appendArrayToNonArray">Append array to non-array (single + array)</button>
+    <button @click="prependArrayToNonArray">Prepend array to non-array (array + single)</button>
+    <button @click="appendToUndefined">Append to undefined</button>
+    <button @click="prependToUndefined">Prepend to undefined</button>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -112,6 +112,23 @@ app.get('/client-side-visit', (req, res) =>
   }),
 )
 
+app.get('/client-side-visit/props', (req, res) =>
+  inertia.render(req, res, {
+    component: 'ClientSideVisit/Props',
+    props: {
+      items: ['item1', 'item2'],
+      tags: [
+        { id: 1, name: 'tag1' },
+        { id: 2, name: 'tag2' },
+      ],
+      user: { name: 'John Doe', age: 30 },
+      count: 5,
+      singleValue: 'hello',
+      undefinedValue: undefined,
+    },
+  }),
+)
+
 app.get('/visits/partial-reloads', (req, res) =>
   inertia.render(req, res, {
     component: 'Visits/PartialReloads',

--- a/tests/client-side-visits-props.spec.ts
+++ b/tests/client-side-visits-props.spec.ts
@@ -4,144 +4,150 @@ import { requests } from './support'
 test.describe('Client-side visits with props manipulation', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/client-side-visit/props')
+    requests.listen(page)
   })
 
-  test('replaceProp replaces a string prop', async ({ page }) => {
-    await expect(page.getByText('User: John Doe (Age: 30)')).toBeVisible()
+  test.describe('replaceProp', () => {
+    test('replaceProp replaces a string prop', async ({ page }) => {
+      await expect(page.getByText('User: John Doe (Age: 30)')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Replace user.name' }).click()
-    await expect(page.getByText('User: Jane Smith (Age: 30)')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
+      await page.getByRole('button', { name: 'Replace user.name' }).click()
+      await expect(page.getByText('User: Jane Smith (Age: 30)')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
+
+    test('replaceProp replaces a number prop', async ({ page }) => {
+      await expect(page.getByText('Count: 5')).toBeVisible()
+
+      await page.getByRole('button', { name: 'Replace count', exact: true }).click()
+      await expect(page.getByText('Count: 10')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
+
+    test('replaceProp works with functions', async ({ page }) => {
+      await expect(page.getByText('Count: 5')).toBeVisible()
+
+      await page.getByRole('button', { name: 'Replace count (function)' }).click()
+      await expect(page.getByText('Count: 10')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
   })
 
-  test('replaceProp replaces a number prop', async ({ page }) => {
-    await expect(page.getByText('Count: 5')).toBeVisible()
+  test.describe('appendToProp', () => {
+    test('appendToProp appends single item to array', async ({ page }) => {
+      await expect(page.getByText('Items: ["item1","item2"]')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Replace count', exact: true }).click()
-    await expect(page.getByText('Count: 10')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
+      await page.getByRole('button', { name: 'Append to items (single)' }).click()
+      await expect(page.getByText('Items: ["item1","item2","item3"]')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
+
+    test('appendToProp appends multiple items to array', async ({ page }) => {
+      await expect(page.getByText('Items: ["item1","item2"]')).toBeVisible()
+
+      await page.getByRole('button', { name: 'Append to items (multiple)' }).click()
+      await expect(page.getByText('Items: ["item1","item2",["item4","item5"]]')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
+
+    test('appendToProp works with functions', async ({ page }) => {
+      await expect(page.getByText('Tags: [{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}]')).toBeVisible()
+
+      await page.getByRole('button', { name: 'Append to tags (function)' }).click()
+      await expect(
+        page.getByText('Tags: [{"id":1,"name":"tag1"},{"id":2,"name":"tag2"},{"id":3,"name":"tag3"}]'),
+      ).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
+
+    test('appendToProp handles array to array', async ({ page }) => {
+      await expect(page.getByText('Tags: [{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}]')).toBeVisible()
+
+      await page.getByRole('button', { name: 'Append array to array (objects)' }).click()
+      await expect(
+        page.getByText(
+          'Tags: [{"id":1,"name":"tag1"},{"id":2,"name":"tag2"},[{"id":3,"name":"tag3"},{"id":4,"name":"tag4"}]]',
+        ),
+      ).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
   })
 
-  test('replaceProp works with functions', async ({ page }) => {
-    await expect(page.getByText('Count: 5')).toBeVisible()
+  test.describe('prependToProp', () => {
+    test('prependToProp prepends single item to array', async ({ page }) => {
+      await expect(page.getByText('Items: ["item1","item2"]')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Replace count (function)' }).click()
-    await expect(page.getByText('Count: 10')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
+      await page.getByRole('button', { name: 'Prepend to items (single)' }).click()
+      await expect(page.getByText('Items: ["item0","item1","item2"]')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
+
+    test('prependToProp prepends multiple items to array', async ({ page }) => {
+      await expect(page.getByText('Items: ["item1","item2"]')).toBeVisible()
+
+      await page.getByRole('button', { name: 'Prepend to items (multiple)' }).click()
+      await expect(page.getByText('Items: [["itemA","itemB"],"item1","item2"]')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
+
+    test('prependToProp works with functions', async ({ page }) => {
+      await expect(page.getByText('Tags: [{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}]')).toBeVisible()
+
+      await page.getByRole('button', { name: 'Prepend to tags (function)' }).click()
+      await expect(
+        page.getByText('Tags: [{"id":0,"name":"tag0"},{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}]'),
+      ).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
   })
 
-  test('appendToProp appends a single item to array', async ({ page }) => {
-    await expect(page.getByText('Items: item1, item2')).toBeVisible()
+  test.describe('edge cases', () => {
+    test('appendToProp handles single + single values (mergeArrays)', async ({ page }) => {
+      await expect(page.getByText('Single Value: "hello"')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Append to items (single)' }).click()
-    await expect(page.getByText('Items: item1, item2, item3')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
+      await page.getByRole('button', { name: 'Append to non-array (single + single)' }).click()
+      await expect(page.getByText('Single Value: ["hello","world"]')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
 
-  test('appendToProp appends multiple items to array', async ({ page }) => {
-    await expect(page.getByText('Items: item1, item2')).toBeVisible()
+    test('prependToProp handles single + single values (mergeArrays)', async ({ page }) => {
+      await expect(page.getByText('Single Value: "hello"')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Append to items (multiple)' }).click()
-    await expect(page.getByText('Items: item1, item2, item4, item5')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
+      await page.getByRole('button', { name: 'Prepend to non-array (single + single)' }).click()
+      await expect(page.getByText('Single Value: ["hey","hello"]')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
 
-  test('appendToProp works with functions', async ({ page }) => {
-    await expect(page.getByText('Tags: tag1, tag2')).toBeVisible()
+    test('appendToProp handles array to non-array', async ({ page }) => {
+      await expect(page.getByText('Single Value: "hello"')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Append to tags (function)' }).click()
-    await expect(page.getByText('Tags: tag1, tag2, tag3')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
+      await page.getByRole('button', { name: 'Append array to non-array (single + array)' }).click()
+      await expect(page.getByText('Single Value: ["hello",["there","world"]]')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
 
-  test('prependToProp prepends a single item to array', async ({ page }) => {
-    await expect(page.getByText('Items: item1, item2')).toBeVisible()
+    test('prependToProp handles array to non-array', async ({ page }) => {
+      await expect(page.getByText('Single Value: "hello"')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Prepend to items (single)' }).click()
-    await expect(page.getByText('Items: item0, item1, item2')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
+      await page.getByRole('button', { name: 'Prepend array to non-array (array + single)' }).click()
+      await expect(page.getByText('Single Value: [["hey","hi"],"hello"]')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
 
-  test('prependToProp prepends multiple items to array', async ({ page }) => {
-    await expect(page.getByText('Items: item1, item2')).toBeVisible()
+    test('appendToProp handles undefined values', async ({ page }) => {
+      await expect(page.locator('text=Undefined Value:')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Prepend to items (multiple)' }).click()
-    await expect(page.getByText('Items: itemA, itemB, item1, item2')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
+      await page.getByRole('button', { name: 'Append to undefined' }).click()
+      await expect(page.getByText('Undefined Value: ["new value"]')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
 
-  test('prependToProp works with functions', async ({ page }) => {
-    await expect(page.getByText('Tags: tag1, tag2')).toBeVisible()
+    test('prependToProp handles undefined values', async ({ page }) => {
+      await expect(page.locator('text=Undefined Value:')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Prepend to tags (function)' }).click()
-    await expect(page.getByText('Tags: tag0, tag1, tag2')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
-
-  test('mergeArrays behavior with various input types', async ({ page }) => {
-    // Test sequence: append single, then multiple, then prepend
-    await expect(page.getByText('Items: item1, item2')).toBeVisible()
-
-    // Append single
-    await page.getByRole('button', { name: 'Append to items (single)' }).click()
-    await expect(page.getByText('Items: item1, item2, item3')).toBeVisible()
-
-    // Append multiple
-    await page.getByRole('button', { name: 'Append to items (multiple)' }).click()
-    await expect(page.getByText('Items: item1, item2, item3, item4, item5')).toBeVisible()
-
-    // Prepend single
-    await page.getByRole('button', { name: 'Prepend to items (single)' }).click()
-    await expect(page.getByText('Items: item0, item1, item2, item3, item4, item5')).toBeVisible()
-
-    await expect(requests.requests.length).toBe(0)
-  })
-
-  test('appendToProp handles non-array values (single + single)', async ({ page }) => {
-    await expect(page.getByText('Single Value: hello')).toBeVisible()
-
-    await page.getByRole('button', { name: 'Append to non-array (single + single)' }).click()
-    await expect(page.getByText('Single Value: hello, world')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
-
-  test('prependToProp handles non-array values (single + single)', async ({ page }) => {
-    await expect(page.getByText('Single Value: hello')).toBeVisible()
-
-    await page.getByRole('button', { name: 'Prepend to non-array (single + single)' }).click()
-    await expect(page.getByText('Single Value: hey, hello')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
-
-  test('appendToProp handles array to non-array (single + array)', async ({ page }) => {
-    await expect(page.getByText('Single Value: hello')).toBeVisible()
-
-    await page.getByRole('button', { name: 'Append array to non-array (single + array)' }).click()
-    await expect(page.getByText('Single Value: hello, there, world')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
-
-  test('prependToProp handles array to non-array (array + single)', async ({ page }) => {
-    await expect(page.getByText('Single Value: hello')).toBeVisible()
-
-    await page.getByRole('button', { name: 'Prepend array to non-array (array + single)' }).click()
-    await expect(page.getByText('Single Value: hey, hi, hello')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
-
-  test('appendToProp handles undefined value', async ({ page }) => {
-    await expect(page.getByText('Undefined Value: undefined')).toBeVisible()
-
-    await page.getByRole('button', { name: 'Append to undefined' }).click()
-    await expect(page.getByText('Undefined Value: new value')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
-  })
-
-  test('prependToProp handles undefined value', async ({ page }) => {
-    await expect(page.getByText('Undefined Value: undefined')).toBeVisible()
-
-    await page.getByRole('button', { name: 'Prepend to undefined' }).click()
-    await expect(page.getByText('Undefined Value: start value')).toBeVisible()
-    await expect(requests.requests.length).toBe(0)
+      await page.getByRole('button', { name: 'Prepend to undefined' }).click()
+      await expect(page.getByText('Undefined Value: ["start value"]')).toBeVisible()
+      expect(requests.requests.length).toBe(0)
+    })
   })
 })

--- a/tests/client-side-visits-props.spec.ts
+++ b/tests/client-side-visits-props.spec.ts
@@ -1,0 +1,147 @@
+import test, { expect } from '@playwright/test'
+import { requests } from './support'
+
+test.describe('Client-side visits with props manipulation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/client-side-visit/props')
+  })
+
+  test('replaceProp replaces a string prop', async ({ page }) => {
+    await expect(page.getByText('User: John Doe (Age: 30)')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Replace user.name' }).click()
+    await expect(page.getByText('User: Jane Smith (Age: 30)')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('replaceProp replaces a number prop', async ({ page }) => {
+    await expect(page.getByText('Count: 5')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Replace count', exact: true }).click()
+    await expect(page.getByText('Count: 10')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('replaceProp works with functions', async ({ page }) => {
+    await expect(page.getByText('Count: 5')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Replace count (function)' }).click()
+    await expect(page.getByText('Count: 10')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('appendToProp appends a single item to array', async ({ page }) => {
+    await expect(page.getByText('Items: item1, item2')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Append to items (single)' }).click()
+    await expect(page.getByText('Items: item1, item2, item3')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('appendToProp appends multiple items to array', async ({ page }) => {
+    await expect(page.getByText('Items: item1, item2')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Append to items (multiple)' }).click()
+    await expect(page.getByText('Items: item1, item2, item4, item5')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('appendToProp works with functions', async ({ page }) => {
+    await expect(page.getByText('Tags: tag1, tag2')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Append to tags (function)' }).click()
+    await expect(page.getByText('Tags: tag1, tag2, tag3')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('prependToProp prepends a single item to array', async ({ page }) => {
+    await expect(page.getByText('Items: item1, item2')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Prepend to items (single)' }).click()
+    await expect(page.getByText('Items: item0, item1, item2')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('prependToProp prepends multiple items to array', async ({ page }) => {
+    await expect(page.getByText('Items: item1, item2')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Prepend to items (multiple)' }).click()
+    await expect(page.getByText('Items: itemA, itemB, item1, item2')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('prependToProp works with functions', async ({ page }) => {
+    await expect(page.getByText('Tags: tag1, tag2')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Prepend to tags (function)' }).click()
+    await expect(page.getByText('Tags: tag0, tag1, tag2')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('mergeArrays behavior with various input types', async ({ page }) => {
+    // Test sequence: append single, then multiple, then prepend
+    await expect(page.getByText('Items: item1, item2')).toBeVisible()
+
+    // Append single
+    await page.getByRole('button', { name: 'Append to items (single)' }).click()
+    await expect(page.getByText('Items: item1, item2, item3')).toBeVisible()
+
+    // Append multiple
+    await page.getByRole('button', { name: 'Append to items (multiple)' }).click()
+    await expect(page.getByText('Items: item1, item2, item3, item4, item5')).toBeVisible()
+
+    // Prepend single
+    await page.getByRole('button', { name: 'Prepend to items (single)' }).click()
+    await expect(page.getByText('Items: item0, item1, item2, item3, item4, item5')).toBeVisible()
+
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('appendToProp handles non-array values (single + single)', async ({ page }) => {
+    await expect(page.getByText('Single Value: hello')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Append to non-array (single + single)' }).click()
+    await expect(page.getByText('Single Value: hello, world')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('prependToProp handles non-array values (single + single)', async ({ page }) => {
+    await expect(page.getByText('Single Value: hello')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Prepend to non-array (single + single)' }).click()
+    await expect(page.getByText('Single Value: hey, hello')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('appendToProp handles array to non-array (single + array)', async ({ page }) => {
+    await expect(page.getByText('Single Value: hello')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Append array to non-array (single + array)' }).click()
+    await expect(page.getByText('Single Value: hello, there, world')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('prependToProp handles array to non-array (array + single)', async ({ page }) => {
+    await expect(page.getByText('Single Value: hello')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Prepend array to non-array (array + single)' }).click()
+    await expect(page.getByText('Single Value: hey, hi, hello')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('appendToProp handles undefined value', async ({ page }) => {
+    await expect(page.getByText('Undefined Value: undefined')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Append to undefined' }).click()
+    await expect(page.getByText('Undefined Value: new value')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+
+  test('prependToProp handles undefined value', async ({ page }) => {
+    await expect(page.getByText('Undefined Value: undefined')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Prepend to undefined' }).click()
+    await expect(page.getByText('Undefined Value: start value')).toBeVisible()
+    await expect(requests.requests.length).toBe(0)
+  })
+})


### PR DESCRIPTION
This PR introduces three new helper methods to the router as shortcuts for `router.replace()`.

```js
router.replaceProp('user.name', 'Jane Smith')
router.appendToProp('messages', { content: 'New Message' })
router.prependToProp('tags', 'Laravel')
```

You may also pass a callback which gives you the current value.

```js
router.replaceProp('count', (oldValue) => oldValue * 2)
```