### PR TITLE
Don't restore remembered state after a refresh

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -211,6 +211,12 @@ class History {
     }
   }
 
+  public clearInitialState(key: keyof Page) {
+    if (this.initialState && this.initialState[key] !== undefined) {
+      delete this.initialState[key]
+    }
+  }
+
   public hasAnyState(): boolean {
     return !!this.getAllState()
   }

--- a/packages/core/src/initialVisit.ts
+++ b/packages/core/src/initialVisit.ts
@@ -92,8 +92,10 @@ export class InitialVisit {
       currentPage.setUrlHash(window.location.hash)
     }
 
-    currentPage.set(currentPage.get(), { preserveScroll: true, preserveState: true }).then(() => {
-      if (navigationType.isReload()) {
+    const isReload = navigationType.isReload()
+
+    currentPage.set(currentPage.get(), { preserveScroll: true, preserveState: !isReload }).then(() => {
+      if (isReload) {
         Scroll.restore(history.getScrollRegions())
       }
       fireNavigateEvent(currentPage.get())

--- a/packages/core/src/initialVisit.ts
+++ b/packages/core/src/initialVisit.ts
@@ -19,6 +19,7 @@ export class InitialVisit {
   protected static clearRememberedStateOnReload(): void {
     if (navigationType.isReload()) {
       history.deleteState(history.rememberedState)
+      history.clearInitialState(history.rememberedState)
     }
   }
 
@@ -92,10 +93,8 @@ export class InitialVisit {
       currentPage.setUrlHash(window.location.hash)
     }
 
-    const isReload = navigationType.isReload()
-
-    currentPage.set(currentPage.get(), { preserveScroll: true, preserveState: !isReload }).then(() => {
-      if (isReload) {
+    currentPage.set(currentPage.get(), { preserveScroll: true, preserveState: true }).then(() => {
+      if (navigationType.isReload()) {
         Scroll.restore(history.getScrollRegions())
       }
       fireNavigateEvent(currentPage.get())

--- a/tests/remember.spec.ts
+++ b/tests/remember.spec.ts
@@ -158,6 +158,30 @@ test.describe('Remember (local state caching)', () => {
     // await expect(page.locator('#untracked')).toHaveValue('')
   })
 
+  test('does not restore remembered data after browser refresh', async ({ page }) => {
+    await page.goto('remember/object')
+
+    await page.fill('#name', 'RefreshTest')
+    await page.check('#remember')
+    await page.fill('#untracked', 'ShouldNotRemember')
+
+    await page.getByRole('link', { name: 'Navigate away' }).click()
+    await shouldBeDumpPage(page, 'get')
+
+    await page.goBack()
+    await expect(page).toHaveURL('remember/object')
+    await expect(page.locator('#name')).toHaveValue('RefreshTest')
+    await expect(page.locator('#remember')).toBeChecked()
+    await expect(page.locator('#untracked')).toHaveValue('')
+
+    await page.reload()
+
+    // After refresh, fields should be empty (not restored from remember state)
+    await expect(page.locator('#name')).toHaveValue('')
+    await expect(page.locator('#remember')).not.toBeChecked()
+    await expect(page.locator('#untracked')).toHaveValue('')
+  })
+
   test.describe('form helper', () => {
     test('does not remember form data as of default', async ({ page }) => {
       await page.goto('remember/form-helper/default')


### PR DESCRIPTION
This PR fixes an issue where Inertia restores the remembered state after a browser refresh. This should only happen when using the back/forward browser buttons.