### PR TITLE
Remember Infinite Scroll state

### DIFF
--- a/packages/core/src/infiniteScroll/data.ts
+++ b/packages/core/src/infiniteScroll/data.ts
@@ -47,6 +47,7 @@ export const useInfiniteScrollData = (options: {
   const rememberedState = router.restore(getRememberKey()) as InfiniteScrollState | undefined
 
   if (rememberedState && typeof rememberedState === 'object') {
+    // Restore the remembered state so the state matches the remembered prop data...
     state.previousPage = rememberedState.previousPage
     state.nextPage = rememberedState.nextPage
     state.lastLoadedPage = rememberedState.lastLoadedPage
@@ -72,7 +73,17 @@ export const useInfiniteScrollData = (options: {
 
     state.requestCount += 1
 
-    router.remember(state, getRememberKey())
+    // We save the state in the browser history so it can be restored
+    // if the user navigates away and then back to the page...
+    router.remember(
+      {
+        previousPage: state.previousPage,
+        nextPage: state.nextPage,
+        lastLoadedPage: state.lastLoadedPage,
+        requestCount: state.requestCount,
+      } as InfiniteScrollState,
+      getRememberKey(),
+    )
   }
 
   const getPageName = () => getScrollPropFromCurrentPage().pageName

--- a/packages/core/src/infiniteScroll/data.ts
+++ b/packages/core/src/infiniteScroll/data.ts
@@ -81,7 +81,7 @@ export const useInfiniteScrollData = (options: {
   }
 
   const getPageName = () => getScrollPropFromCurrentPage().pageName
-  const getRememberedRequestCount = () => state.requestCount
+  const getRequestCount = () => state.requestCount
 
   const fetchPage = (side: Side, reloadOptions: ReloadOptions = {}): void => {
     const page = findPageToLoad(side)
@@ -132,7 +132,7 @@ export const useInfiniteScrollData = (options: {
   return {
     getLastLoadedPage,
     getPageName,
-    getRememberedRequestCount,
+    getRequestCount,
     hasPrevious,
     hasNext,
     fetchNext,

--- a/packages/core/src/infiniteScroll/data.ts
+++ b/packages/core/src/infiniteScroll/data.ts
@@ -8,10 +8,9 @@ type Side = 'previous' | 'next'
 type ScrollPropPageNames = keyof Pick<ScrollProp, 'previousPage' | 'nextPage'>
 
 type InfiniteScrollState = {
-  loading: boolean
-  previousPage: string | number | undefined
-  nextPage: string | number | undefined
-  lastLoadedPage: string | number | undefined
+  previousPage?: number | string
+  nextPage?: number | string
+  lastLoadedPage?: number | string
   requestCount: number
 }
 
@@ -45,18 +44,14 @@ export const useInfiniteScrollData = (options: {
 
   const getRememberKey = () => `inertia:infinite-scroll-data:${options.getPropName()}`
 
-  const restoreState = () => {
-    const rememberedState = router.restore(getRememberKey()) as InfiniteScrollState | undefined
+  const rememberedState = router.restore(getRememberKey()) as InfiniteScrollState | undefined
 
-    if (rememberedState && typeof rememberedState === 'object') {
-      state.previousPage = rememberedState.previousPage
-      state.nextPage = rememberedState.nextPage
-      state.lastLoadedPage = rememberedState.lastLoadedPage
-      state.requestCount = rememberedState.requestCount || 0
-    }
+  if (rememberedState && typeof rememberedState === 'object') {
+    state.previousPage = rememberedState.previousPage
+    state.nextPage = rememberedState.nextPage
+    state.lastLoadedPage = rememberedState.lastLoadedPage
+    state.requestCount = rememberedState.requestCount || 0
   }
-
-  restoreState()
 
   const getScrollPropKeyForSide = (side: Side): ScrollPropPageNames => {
     return side === 'next' ? 'nextPage' : 'previousPage'

--- a/packages/core/src/infiniteScroll/data.ts
+++ b/packages/core/src/infiniteScroll/data.ts
@@ -45,25 +45,14 @@ export const useInfiniteScrollData = (options: {
 
   const getRememberKey = () => `inertia:infinite-scroll-data:${options.getPropName()}`
 
-  // Restore state from previous navigation
   const restoreState = () => {
-    try {
-      const rememberedState = router.restore(getRememberKey()) as InfiniteScrollState | undefined
+    const rememberedState = router.restore(getRememberKey()) as InfiniteScrollState | undefined
 
-      if (rememberedState && typeof rememberedState === 'object') {
-        // Only restore if the remembered state has valid structure
-        if ('previousPage' in rememberedState || 'nextPage' in rememberedState) {
-          state.previousPage = rememberedState.previousPage
-          state.nextPage = rememberedState.nextPage
-          state.lastLoadedPage = rememberedState.lastLoadedPage
-          state.requestCount = rememberedState.requestCount || 0
-          // Don't restore loading state to avoid UI inconsistencies
-          state.loading = false
-        }
-      }
-    } catch (error) {
-      // Ignore restore errors and use initial state
-      console.warn('Failed to restore infinite scroll state:', error)
+    if (rememberedState && typeof rememberedState === 'object') {
+      state.previousPage = rememberedState.previousPage
+      state.nextPage = rememberedState.nextPage
+      state.lastLoadedPage = rememberedState.lastLoadedPage
+      state.requestCount = rememberedState.requestCount || 0
     }
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -527,6 +527,7 @@ export interface UseInfiniteScrollOptions {
 export interface UseInfiniteScrollDataManager {
   getLastLoadedPage: () => number | string | undefined
   getPageName: () => string
+  getRememberedRequestCount: () => number
   hasPrevious: () => boolean
   hasNext: () => boolean
   fetchNext: (reloadOptions?: ReloadOptions) => void

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -527,7 +527,7 @@ export interface UseInfiniteScrollOptions {
 export interface UseInfiniteScrollDataManager {
   getLastLoadedPage: () => number | string | undefined
   getPageName: () => string
-  getRememberedRequestCount: () => number
+  getRequestCount: () => number
   hasPrevious: () => boolean
   hasNext: () => boolean
   fetchNext: (reloadOptions?: ReloadOptions) => void

--- a/packages/react/src/InfiniteScroll.ts
+++ b/packages/react/src/InfiniteScroll.ts
@@ -130,12 +130,6 @@ const InfiniteScroll = forwardRef<InfiniteScrollRef, ComponentProps>(
 
     const scrollableParent = useMemo(() => getScrollableParent(resolvedItemsElement), [resolvedItemsElement])
 
-    const manualMode = useMemo(
-      () => manual || (manualAfter > 0 && requestCount >= manualAfter),
-      [manual, manualAfter, requestCount],
-    )
-    const autoLoad = useMemo(() => !manualMode, [manualMode])
-
     const callbackPropsRef = useRef({
       buffer,
       onlyNext,
@@ -197,16 +191,18 @@ const InfiniteScroll = forwardRef<InfiniteScrollRef, ComponentProps>(
         onBeforeNextRequest: () => setLoadingNext(true),
         onCompletePreviousRequest: () => {
           setLoadingPrevious(false)
-          setRequestCount((count) => count + 1)
+          setRequestCount(infiniteScrollInstance.dataManager.getRememberedRequestCount())
         },
         onCompleteNextRequest: () => {
           setLoadingNext(false)
-          setRequestCount((count) => count + 1)
+          setRequestCount(infiniteScrollInstance.dataManager.getRememberedRequestCount())
         },
       })
 
       setInfiniteScroll(infiniteScrollInstance)
       const { dataManager, elementManager } = infiniteScrollInstance
+
+      setRequestCount(dataManager.getRememberedRequestCount())
 
       elementManager.setupObservers()
       elementManager.processServerLoadedElements(dataManager.getLastLoadedPage())
@@ -220,6 +216,12 @@ const InfiniteScroll = forwardRef<InfiniteScrollRef, ComponentProps>(
         setInfiniteScroll(null)
       }
     }, [data, resolvedItemsElement, resolvedStartElement, resolvedEndElement, scrollableParent])
+
+    const manualMode = useMemo(
+      () => manual || (manualAfter > 0 && requestCount >= manualAfter),
+      [manual, manualAfter, requestCount],
+    )
+    const autoLoad = useMemo(() => !manualMode, [manualMode])
 
     useEffect(() => {
       autoLoad ? elementManager?.enableTriggers() : elementManager?.disableTriggers()

--- a/packages/react/src/InfiniteScroll.ts
+++ b/packages/react/src/InfiniteScroll.ts
@@ -191,18 +191,18 @@ const InfiniteScroll = forwardRef<InfiniteScrollRef, ComponentProps>(
         onBeforeNextRequest: () => setLoadingNext(true),
         onCompletePreviousRequest: () => {
           setLoadingPrevious(false)
-          setRequestCount(infiniteScrollInstance.dataManager.getRememberedRequestCount())
+          setRequestCount(infiniteScrollInstance.dataManager.getRequestCount())
         },
         onCompleteNextRequest: () => {
           setLoadingNext(false)
-          setRequestCount(infiniteScrollInstance.dataManager.getRememberedRequestCount())
+          setRequestCount(infiniteScrollInstance.dataManager.getRequestCount())
         },
       })
 
       setInfiniteScroll(infiniteScrollInstance)
       const { dataManager, elementManager } = infiniteScrollInstance
 
-      setRequestCount(dataManager.getRememberedRequestCount())
+      setRequestCount(dataManager.getRequestCount())
 
       elementManager.setupObservers()
       elementManager.processServerLoadedElements(dataManager.getLastLoadedPage())

--- a/packages/react/test-app/Pages/InfiniteScroll/RememberState.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/RememberState.tsx
@@ -1,0 +1,31 @@
+import { InfiniteScroll, Link } from '@inertiajs/react'
+import UserCard, { User } from './UserCard'
+
+export default ({ users }: { users: { data: User[] } }) => {
+  return (
+    <>
+      <InfiniteScroll
+        data="users"
+        style={{ display: 'grid', gap: '20px' }}
+        manualAfter={2}
+        next={({ fetch, manualMode, loading }) => (
+          <>
+            {loading && <p>Loading...</p>}
+
+            <p>Manual mode: {manualMode.toString()}</p>
+
+            {manualMode && <button onClick={fetch}>Load next items...</button>}
+          </>
+        )}
+      >
+        {users.data.map((user) => (
+          <UserCard key={user.id} user={user} />
+        ))}
+      </InfiniteScroll>
+
+      <div style={{ marginTop: '40px', padding: '20px', borderTop: '2px solid #ccc' }}>
+        <Link href="/home">Go to Home</Link>
+      </div>
+    </>
+  )
+}

--- a/packages/react/test-app/Pages/InfiniteScroll/RememberState.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/RememberState.tsx
@@ -1,9 +1,25 @@
-import { InfiniteScroll, Link } from '@inertiajs/react'
+import { InfiniteScroll, Link, router } from '@inertiajs/react'
 import UserCard, { User } from './UserCard'
 
 export default ({ users }: { users: { data: User[] } }) => {
+  function prependUser(id: number) {
+    router.prependToProp('users.data', { id, name: `User ${id}` })
+  }
+
   return (
     <>
+      <div style={{ marginBottom: '40px', padding: '20px', borderTop: '2px solid #ccc' }}>
+        <div style={{ marginBottom: '20px' }}>
+          <button onClick={() => prependUser(0)} style={{ marginRight: '10px' }}>
+            Prepend User '0'
+          </button>
+          <button onClick={() => prependUser(-1)} style={{ marginRight: '10px' }}>
+            Prepend User '-1'
+          </button>
+        </div>
+        <Link href="/home">Go Home</Link>
+      </div>
+
       <InfiniteScroll
         data="users"
         style={{ display: 'grid', gap: '20px' }}

--- a/packages/svelte/src/InfiniteScroll.svelte
+++ b/packages/svelte/src/InfiniteScroll.svelte
@@ -32,11 +32,6 @@
 
   $: resolvedItemsElement = resolveHTMLElement(itemsElement, itemsElementRef)
   $: scrollableParent = resolvedItemsElement ? getScrollableParent(resolvedItemsElement) : null
-  $: manualMode = manual || (manualAfter > 0 && requestCount >= manualAfter)
-  $: autoLoad = !manualMode
-
-  $: headerAutoMode = autoLoad && !onlyNext
-  $: footerAutoMode = autoLoad && !onlyPrevious
 
   $: sharedExposed = {
     loadingPrevious,
@@ -148,16 +143,18 @@
       onBeforePreviousRequest: () => (loadingPrevious = true),
       onBeforeNextRequest: () => (loadingNext = true),
       onCompletePreviousRequest: () => {
-        requestCount += 1
+        requestCount = infiniteScrollInstance.dataManager.getRememberedRequestCount()
         loadingPrevious = false
       },
       onCompleteNextRequest: () => {
-        requestCount += 1
+        requestCount = infiniteScrollInstance.dataManager.getRememberedRequestCount()
         loadingNext = false
       },
     })
 
     const { dataManager, elementManager } = infiniteScrollInstance
+
+    requestCount = dataManager.getRememberedRequestCount()
 
     elementManager.setupObservers()
     elementManager.processServerLoadedElements(dataManager.getLastLoadedPage())
@@ -169,6 +166,12 @@
       scrollToBottom()
     }
   }
+
+  $: manualMode = manual || (manualAfter > 0 && requestCount >= manualAfter)
+  $: autoLoad = !manualMode
+
+  $: headerAutoMode = autoLoad && !onlyNext
+  $: footerAutoMode = autoLoad && !onlyPrevious
 
   $: {
     // Make this block run whenever these change

--- a/packages/svelte/src/InfiniteScroll.svelte
+++ b/packages/svelte/src/InfiniteScroll.svelte
@@ -143,18 +143,18 @@
       onBeforePreviousRequest: () => (loadingPrevious = true),
       onBeforeNextRequest: () => (loadingNext = true),
       onCompletePreviousRequest: () => {
-        requestCount = infiniteScrollInstance.dataManager.getRememberedRequestCount()
+        requestCount = infiniteScrollInstance.dataManager.getRequestCount()
         loadingPrevious = false
       },
       onCompleteNextRequest: () => {
-        requestCount = infiniteScrollInstance.dataManager.getRememberedRequestCount()
+        requestCount = infiniteScrollInstance.dataManager.getRequestCount()
         loadingNext = false
       },
     })
 
     const { dataManager, elementManager } = infiniteScrollInstance
 
-    requestCount = dataManager.getRememberedRequestCount()
+    requestCount = dataManager.getRequestCount()
 
     elementManager.setupObservers()
     elementManager.processServerLoadedElements(dataManager.getLastLoadedPage())

--- a/packages/svelte/test-app/Pages/InfiniteScroll/RememberState.svelte
+++ b/packages/svelte/test-app/Pages/InfiniteScroll/RememberState.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { InfiniteScroll, Link } from '@inertiajs/svelte'
+  import UserCard, { type User } from './UserCard.svelte'
+
+  export let users: { data: User[] }
+</script>
+
+<InfiniteScroll data="users" style="display: grid; gap: 20px" manualAfter={2}>
+  {#each users.data as user (user.id)}
+    <UserCard {user} />
+  {/each}
+
+  <div slot="next" let:exposedNext>
+    {#if exposedNext.loading}
+      <p>Loading...</p>
+    {/if}
+
+    <p>Manual mode: {exposedNext.manualMode}</p>
+
+    {#if exposedNext.manualMode}
+      <button on:click={exposedNext.fetch}>Load next items...</button>
+    {/if}
+  </div>
+</InfiniteScroll>
+
+<div style="margin-top: 40px; padding: 20px; border-top: 2px solid #ccc">
+  <Link href="/home">Go to Home</Link>
+</div>

--- a/packages/svelte/test-app/Pages/InfiniteScroll/RememberState.svelte
+++ b/packages/svelte/test-app/Pages/InfiniteScroll/RememberState.svelte
@@ -1,9 +1,21 @@
 <script lang="ts">
-  import { InfiniteScroll, Link } from '@inertiajs/svelte'
+  import { InfiniteScroll, Link, router } from '@inertiajs/svelte'
   import UserCard, { type User } from './UserCard.svelte'
 
   export let users: { data: User[] }
+
+  function prependUser(id: number) {
+    router.prependToProp('users.data', { id, name: `User ${id}` })
+  }
 </script>
+
+<div style="margin-bottom: 40px; padding: 20px; border-top: 2px solid #ccc">
+  <div style="margin-bottom: 20px">
+    <button on:click={() => prependUser(0)} style="margin-right: 10px">Prepend User '0'</button>
+    <button on:click={() => prependUser(-1)} style="margin-right: 10px">Prepend User '-1'</button>
+  </div>
+  <Link href="/home">Go Home</Link>
+</div>
 
 <InfiniteScroll data="users" style="display: grid; gap: 20px" manualAfter={2}>
   {#each users.data as user (user.id)}
@@ -18,7 +30,7 @@
     <p>Manual mode: {exposedNext.manualMode}</p>
 
     {#if exposedNext.manualMode}
-      <button on:click={exposedNext.fetch}>Load next items...</button>
+      <button on:click|preventDefault={exposedNext.fetch}>Load next items...</button>
     {/if}
   </div>
 </InfiniteScroll>

--- a/packages/vue3/src/infiniteScroll.ts
+++ b/packages/vue3/src/infiniteScroll.ts
@@ -101,11 +101,6 @@ const InfiniteScroll = defineComponent({
     const loadingNext = ref(false)
     const requestCount = ref(0)
 
-    const autoLoad = computed<boolean>(() => !manualMode.value)
-    const manualMode = computed<boolean>(
-      () => props.manual || (props.manualAfter > 0 && requestCount.value >= props.manualAfter),
-    )
-
     const { dataManager, elementManager } = useInfiniteScroll({
       // Data
       getPropName: () => props.data,
@@ -125,14 +120,21 @@ const InfiniteScroll = defineComponent({
       onBeforePreviousRequest: () => (loadingPrevious.value = true),
       onBeforeNextRequest: () => (loadingNext.value = true),
       onCompletePreviousRequest: () => {
-        requestCount.value += 1
+        requestCount.value = dataManager.getRememberedRequestCount()
         loadingPrevious.value = false
       },
       onCompleteNextRequest: () => {
-        requestCount.value += 1
+        requestCount.value = dataManager.getRememberedRequestCount()
         loadingNext.value = false
       },
     })
+
+    requestCount.value = dataManager.getRememberedRequestCount()
+
+    const autoLoad = computed<boolean>(() => !manualMode.value)
+    const manualMode = computed<boolean>(
+      () => props.manual || (props.manualAfter > 0 && requestCount.value >= props.manualAfter),
+    )
 
     const scrollToBottom = () => {
       if (scrollableParent.value) {

--- a/packages/vue3/src/infiniteScroll.ts
+++ b/packages/vue3/src/infiniteScroll.ts
@@ -120,16 +120,16 @@ const InfiniteScroll = defineComponent({
       onBeforePreviousRequest: () => (loadingPrevious.value = true),
       onBeforeNextRequest: () => (loadingNext.value = true),
       onCompletePreviousRequest: () => {
-        requestCount.value = dataManager.getRememberedRequestCount()
+        requestCount.value = dataManager.getRequestCount()
         loadingPrevious.value = false
       },
       onCompleteNextRequest: () => {
-        requestCount.value = dataManager.getRememberedRequestCount()
+        requestCount.value = dataManager.getRequestCount()
         loadingNext.value = false
       },
     })
 
-    requestCount.value = dataManager.getRememberedRequestCount()
+    requestCount.value = dataManager.getRequestCount()
 
     const autoLoad = computed<boolean>(() => !manualMode.value)
     const manualMode = computed<boolean>(

--- a/packages/vue3/test-app/Pages/InfiniteScroll/RememberState.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/RememberState.vue
@@ -1,13 +1,25 @@
 <script setup lang="ts">
-import { InfiniteScroll, Link } from '@inertiajs/vue3'
+import { InfiniteScroll, Link, router } from '@inertiajs/vue3'
 import { User, default as UserCard } from './UserCard.vue'
 
 defineProps<{
   users: { data: User[] }
 }>()
+
+function prependUser(id: number) {
+  router.prependToProp('users.data', { id, name: `User ${id}` })
+}
 </script>
 
 <template>
+  <div style="margin-bottom: 40px; padding: 20px; border-top: 2px solid #ccc">
+    <div style="margin-bottom: 20px">
+      <button @click.prevent="prependUser(0)" style="margin-right: 10px">Prepend User '0'</button>
+      <button @click.prevent="prependUser(-1)" style="margin-right: 10px">Prepend User '-1'</button>
+    </div>
+    <Link href="/home">Go Home</Link>
+  </div>
+
   <InfiniteScroll data="users" style="display: grid; gap: 20px" :manual-after="2">
     <UserCard v-for="user in users.data" :key="user.id" :user="user" />
 
@@ -16,7 +28,7 @@ defineProps<{
 
       <p>Manual mode: {{ manualMode }}</p>
 
-      <button v-if="manualMode" @click="fetch">Load next items...</button>
+      <button v-if="manualMode" @click.prevent="fetch">Load next items...</button>
     </template>
   </InfiniteScroll>
 

--- a/packages/vue3/test-app/Pages/InfiniteScroll/RememberState.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/RememberState.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { InfiniteScroll, Link } from '@inertiajs/vue3'
+import { User, default as UserCard } from './UserCard.vue'
+
+defineProps<{
+  users: { data: User[] }
+}>()
+</script>
+
+<template>
+  <InfiniteScroll data="users" style="display: grid; gap: 20px" :manual-after="2">
+    <UserCard v-for="user in users.data" :key="user.id" :user="user" />
+
+    <template #next="{ fetch, manualMode, loading }">
+      <p v-if="loading">Loading...</p>
+
+      <p>Manual mode: {{ manualMode }}</p>
+
+      <button v-if="manualMode" @click="fetch">Load next items...</button>
+    </template>
+  </InfiniteScroll>
+
+  <div style="margin-top: 40px; padding: 20px; border-top: 2px solid #ccc">
+    <Link href="/home">Go to Home</Link>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -878,6 +878,9 @@ function renderInfiniteScroll(req, res, component, total = 40, orderByDesc = fal
 
 app.get('/infinite-scroll/manual', (req, res) => renderInfiniteScroll(req, res, 'InfiniteScroll/Manual'))
 app.get('/infinite-scroll/manual-after', (req, res) => renderInfiniteScroll(req, res, 'InfiniteScroll/ManualAfter', 60))
+app.get('/infinite-scroll/remember-state', (req, res) =>
+  renderInfiniteScroll(req, res, 'InfiniteScroll/RememberState', 60),
+)
 app.get('/infinite-scroll/toggles', (req, res) => renderInfiniteScroll(req, res, 'InfiniteScroll/Toggles'))
 app.get('/infinite-scroll/trigger-both', (req, res) => renderInfiniteScroll(req, res, 'InfiniteScroll/TriggerBoth'))
 app.get('/infinite-scroll/trigger-end-buffer', (req, res) =>


### PR DESCRIPTION
This PR fixes an issue where the `<InfiniteScroll>` component's state would not be remembered correctly when navigating away to another page, and coming back to it with the browser's *back button*.