### PR TITLE
Preserve `ScrollProp` on Partial Reloads

### DIFF
--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -293,6 +293,14 @@ export class Response {
     })
 
     pageResponse.props = { ...currentPage.get().props, ...pageResponse.props }
+
+    // Preserve the existing scrollProps
+    if (pageResponse.scrollProps) {
+      pageResponse.scrollProps = {
+        ...(currentPage.get().scrollProps || {}),
+        ...(pageResponse.scrollProps || {}),
+      }
+    }
   }
 
   protected mergeOrMatchItems(

--- a/packages/react/test-app/Pages/InfiniteScroll/DualContainers.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/DualContainers.tsx
@@ -1,0 +1,73 @@
+import { InfiniteScroll } from '@inertiajs/react'
+import UserCard, { User } from './UserCard'
+
+interface Props {
+  users1: { data: User[] }
+  users2: { data: User[] }
+}
+
+export default ({ users1, users2 }: Props) => {
+  return (
+    <div style={{ padding: '20px' }}>
+      <div style={{ display: 'flex', gap: '20px' }}>
+        {/* First scroll container */}
+        <div style={{ flex: 1 }}>
+          <h2>Users1 Container</h2>
+          <div
+            data-testid="scroll-container-1"
+            style={{
+              height: '400px',
+              width: '100%',
+              border: '2px solid #3b82f6',
+              overflowY: 'auto',
+              background: '#f0f9ff',
+              padding: '10px',
+            }}
+          >
+            <InfiniteScroll
+              data="users1"
+              style={{ display: 'grid', gap: '10px' }}
+              loading={() => (
+                <div style={{ textAlign: 'center', padding: '20px', color: '#3b82f6' }}>Loading more users1...</div>
+              )}
+            >
+              {users1.data.map((user) => (
+                <UserCard key={user.id} user={user} />
+              ))}
+            </InfiniteScroll>
+          </div>
+        </div>
+
+        {/* Second scroll container */}
+        <div style={{ flex: 1 }}>
+          <h2>Users2 Container</h2>
+          <div
+            data-testid="scroll-container-2"
+            style={{
+              height: '400px',
+              width: '100%',
+              border: '2px solid #ef4444',
+              overflowY: 'auto',
+              background: '#fef2f2',
+              padding: '10px',
+            }}
+          >
+            <InfiniteScroll
+              data="users2"
+              style={{ display: 'grid', gap: '10px' }}
+              loading={() => (
+                <div style={{ textAlign: 'center', padding: '20px', color: '#ef4444' }}>Loading more users2...</div>
+              )}
+            >
+              {users2.data.map((user) => (
+                <UserCard key={user.id} user={user} />
+              ))}
+            </InfiniteScroll>
+          </div>
+        </div>
+      </div>
+
+      <p style={{ marginTop: '20px' }}>Content below the scroll containers to verify page doesn't scroll.</p>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/InfiniteScroll/DualContainers.svelte
+++ b/packages/svelte/test-app/Pages/InfiniteScroll/DualContainers.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { InfiniteScroll } from '@inertiajs/svelte'
+  import UserCard, { type User } from './UserCard.svelte'
+
+  export let users1: { data: User[] }
+  export let users2: { data: User[] }
+</script>
+
+<div style="padding: 20px">
+  <div style="display: flex; gap: 20px">
+    <!-- First scroll container -->
+    <div style="flex: 1">
+      <h2>Users1 Container</h2>
+      <div
+        data-testid="scroll-container-1"
+        style="height: 400px; width: 100%; border: 2px solid #3b82f6; overflow-y: auto; background: #f0f9ff; padding: 10px"
+      >
+        <InfiniteScroll data="users1" style="display: grid; gap: 10px">
+          <div slot="loading" style="text-align: center; padding: 20px; color: #3b82f6">Loading more users1...</div>
+
+          {#each users1.data as user (user.id)}
+            <UserCard {user} />
+          {/each}
+        </InfiniteScroll>
+      </div>
+    </div>
+
+    <!-- Second scroll container -->
+    <div style="flex: 1">
+      <h2>Users2 Container</h2>
+      <div
+        data-testid="scroll-container-2"
+        style="height: 400px; width: 100%; border: 2px solid #ef4444; overflow-y: auto; background: #fef2f2; padding: 10px"
+      >
+        <InfiniteScroll data="users2" style="display: grid; gap: 10px">
+          <div slot="loading" style="text-align: center; padding: 20px; color: #ef4444">Loading more users2...</div>
+
+          {#each users2.data as user (user.id)}
+            <UserCard {user} />
+          {/each}
+        </InfiniteScroll>
+      </div>
+    </div>
+  </div>
+
+  <p style="margin-top: 20px">Content below the scroll containers to verify page doesn't scroll.</p>
+</div>

--- a/packages/vue3/test-app/Pages/InfiniteScroll/DualContainers.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/DualContainers.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { InfiniteScroll } from '@inertiajs/vue3'
+import { User, default as UserCard } from './UserCard.vue'
+
+defineProps<{
+  users1: { data: User[] }
+  users2: { data: User[] }
+}>()
+</script>
+
+<template>
+  <div style="padding: 20px">
+    <div style="display: flex; gap: 20px">
+      <!-- First scroll container -->
+      <div style="flex: 1">
+        <h2>Users1 Container</h2>
+        <div
+          data-testid="scroll-container-1"
+          style="
+            height: 400px;
+            width: 100%;
+            border: 2px solid #3b82f6;
+            overflow-y: auto;
+            background: #f0f9ff;
+            padding: 10px;
+          "
+        >
+          <InfiniteScroll data="users1" style="display: grid; gap: 10px">
+            <UserCard v-for="user in users1.data" :key="user.id" :user="user" />
+
+            <template #loading>
+              <div style="text-align: center; padding: 20px; color: #3b82f6">Loading more users1...</div>
+            </template>
+          </InfiniteScroll>
+        </div>
+      </div>
+
+      <!-- Second scroll container -->
+      <div style="flex: 1">
+        <h2>Users2 Container</h2>
+        <div
+          data-testid="scroll-container-2"
+          style="
+            height: 400px;
+            width: 100%;
+            border: 2px solid #ef4444;
+            overflow-y: auto;
+            background: #fef2f2;
+            padding: 10px;
+          "
+        >
+          <InfiniteScroll data="users2" style="display: grid; gap: 10px">
+            <UserCard v-for="user in users2.data" :key="user.id" :user="user" />
+
+            <template #loading>
+              <div style="text-align: center; padding: 20px; color: #ef4444">Loading more users2...</div>
+            </template>
+          </InfiniteScroll>
+        </div>
+      </div>
+    </div>
+
+    <p style="margin-top: 20px">Content below the scroll containers to verify page doesn't scroll.</p>
+  </div>
+</template>

--- a/tests/app/eloquent.js
+++ b/tests/app/eloquent.js
@@ -131,7 +131,7 @@ function getUsers(page = 1, perPage = 15, total = 40, orderByDesc = false) {
   }
 }
 
-export function paginateUsers(page = 1, perPage = 15, total = 40, orderByDesc = false) {
+export function paginateUsers(page = 1, perPage = 15, total = 40, orderByDesc = false, pageName = 'page') {
   const users = getUsers(page, perPage, total, orderByDesc)
   const hasMore = getUsers(page + 1, perPage, total, orderByDesc).length > 0
 
@@ -144,7 +144,7 @@ export function paginateUsers(page = 1, perPage = 15, total = 40, orderByDesc = 
       total,
     },
     scrollProp: {
-      pageName: 'page',
+      pageName,
       previousPage: page > 1 ? page - 1 : null,
       nextPage: hasMore ? page + 1 : null,
       currentPage: page,

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -924,6 +924,26 @@ app.get('/infinite-scroll/programmatic-ref', (req, res) =>
 app.get('/infinite-scroll/short-content', (req, res) =>
   renderInfiniteScroll(req, res, 'InfiniteScroll/ShortContent', 100, false, 5),
 )
+app.get('/infinite-scroll/dual-containers', (req, res) => {
+  const users1Page = req.query.users1 ? parseInt(req.query.users1) : 1
+  const users2Page = req.query.users2 ? parseInt(req.query.users2) : 1
+  const partialReload = !!req.headers['x-inertia-partial-data']
+  const shouldAppend = req.headers['x-inertia-infinite-scroll-merge-intent'] !== 'prepend'
+
+  const { paginated: users1Paginated, scrollProp: users1ScrollProp } = paginateUsers(users1Page, 15, 40, false, 'users1')
+  const { paginated: users2Paginated, scrollProp: users2ScrollProp } = paginateUsers(users2Page, 15, 60, false, 'users2')
+
+  setTimeout(
+    () =>
+      inertia.render(req, res, {
+        component: 'InfiniteScroll/DualContainers',
+        props: { users1: users1Paginated, users2: users2Paginated },
+        [shouldAppend ? 'mergeProps' : 'prependProps']: ['users1.data', 'users2.data'],
+        scrollProps: { users1: users1ScrollProp, users2: users2ScrollProp },
+      }),
+    partialReload ? 250 : 0,
+  )
+})
 
 function renderInfiniteScrollWithTag(req, res, component, total = 40, orderByDesc = false, perPage = 15) {}
 

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -930,8 +930,20 @@ app.get('/infinite-scroll/dual-containers', (req, res) => {
   const partialReload = !!req.headers['x-inertia-partial-data']
   const shouldAppend = req.headers['x-inertia-infinite-scroll-merge-intent'] !== 'prepend'
 
-  const { paginated: users1Paginated, scrollProp: users1ScrollProp } = paginateUsers(users1Page, 15, 40, false, 'users1')
-  const { paginated: users2Paginated, scrollProp: users2ScrollProp } = paginateUsers(users2Page, 15, 60, false, 'users2')
+  const { paginated: users1Paginated, scrollProp: users1ScrollProp } = paginateUsers(
+    users1Page,
+    15,
+    40,
+    false,
+    'users1',
+  )
+  const { paginated: users2Paginated, scrollProp: users2ScrollProp } = paginateUsers(
+    users2Page,
+    15,
+    60,
+    false,
+    'users2',
+  )
 
   setTimeout(
     () =>


### PR DESCRIPTION
The PR makes sure the `ScrollProp` metadata is preserved on pages with `<InfiniteScroll>` components when making Partial Reloads.