### PR TITLE
Improve testing of scroll restoration

### DIFF
--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -96,9 +96,7 @@ class EventHandler {
         router.cancelAll()
 
         currentPage.setQuietly(data, { preserveState: false }).then(() => {
-          window.requestAnimationFrame(() => {
-            Scroll.restore(history.getScrollRegions())
-          })
+          Scroll.restore(history.getScrollRegions())
           fireNavigateEvent(currentPage.get())
         })
       })

--- a/packages/core/src/scroll.ts
+++ b/packages/core/src/scroll.ts
@@ -45,30 +45,33 @@ export class Scroll {
   }
 
   public static restore(scrollRegions: ScrollRegion[]): void {
-    this.restoreDocument()
+    if (typeof window === 'undefined') {
+      return
+    }
 
-    this.regions().forEach((region: Element, index: number) => {
-      const scrollPosition = scrollRegions[index]
+    window.requestAnimationFrame(() => {
+      this.restoreDocument()
 
-      if (!scrollPosition) {
-        return
-      }
+      this.regions().forEach((region: Element, index: number) => {
+        const scrollPosition = scrollRegions[index]
 
-      if (typeof region.scrollTo === 'function') {
-        region.scrollTo(scrollPosition.left, scrollPosition.top)
-      } else {
-        region.scrollTop = scrollPosition.top
-        region.scrollLeft = scrollPosition.left
-      }
+        if (!scrollPosition) {
+          return
+        }
+
+        if (typeof region.scrollTo === 'function') {
+          region.scrollTo(scrollPosition.left, scrollPosition.top)
+        } else {
+          region.scrollTop = scrollPosition.top
+          region.scrollLeft = scrollPosition.left
+        }
+      })
     })
   }
 
   public static restoreDocument(): void {
     const scrollPosition = history.getDocumentScrollPosition()
-
-    if (typeof window !== 'undefined') {
-      window.scrollTo(scrollPosition.left, scrollPosition.top)
-    }
+    window.scrollTo(scrollPosition.left, scrollPosition.top)
   }
 
   public static onScroll(event: Event): void {

--- a/packages/react/test-app/Layouts/WithScrollRegion.tsx
+++ b/packages/react/test-app/Layouts/WithScrollRegion.tsx
@@ -27,6 +27,7 @@ export default ({ children }: { children: React.ReactNode }) => {
   return (
     <div style={{ width: '200vw' }}>
       <span className="layout-text">With scroll regions</span>
+      <button onClick={handleScrollEvent}>Update scroll positions</button>
       <div className="document-position">
         Document scroll position is {documentScrollLeft} & {documentScrollTop}
       </div>

--- a/packages/react/test-app/Layouts/WithoutScrollRegion.tsx
+++ b/packages/react/test-app/Layouts/WithoutScrollRegion.tsx
@@ -27,6 +27,7 @@ export default ({ children }: { children: React.ReactNode }) => {
   return (
     <div style={{ width: '200vw' }}>
       <span className="layout-text">Without scroll regions</span>
+      <button onClick={handleScrollEvent}>Update scroll positions</button>
       <div className="document-position">
         Document scroll position is {documentScrollLeft} & {documentScrollTop}
       </div>

--- a/packages/react/test-app/Pages/Links/UrlFragments.tsx
+++ b/packages/react/test-app/Pages/Links/UrlFragments.tsx
@@ -18,6 +18,7 @@ export default () => {
     <div>
       <span className="text">This is the links page that demonstrates url fragment behaviour</span>
       <div style={{ width: '200vw', height: '200vh', marginTop: '50vh' }}>
+        <button onClick={handleScrollEvent}>Update scroll positions</button>
         {/* prettier-ignore */}
         <div className="document-position">
           Document scroll position is {documentScrollLeft} & {documentScrollTop}

--- a/packages/react/test-app/Pages/Visits/UrlFragments.tsx
+++ b/packages/react/test-app/Pages/Visits/UrlFragments.tsx
@@ -58,6 +58,7 @@ export default () => {
           marginTop: '50vh',
         }}
       >
+        <button onClick={handleScrollEvent}>Update scroll positions</button>
         {/* prettier-ignore */}
         <div className="document-position">Document scroll position is {documentScrollLeft} & {documentScrollTop}</div>
         <a href="#" onClick={basicVisit} className="basic">

--- a/packages/svelte/test-app/Layouts/WithScrollRegion.svelte
+++ b/packages/svelte/test-app/Layouts/WithScrollRegion.svelte
@@ -27,6 +27,7 @@
 
 <div style="width: 200vw">
   <span class="layout-text">With scroll regions</span>
+  <button on:click={handleScrollEvent}>Update scroll positions</button>
   <div class="document-position">Document scroll position is {documentScrollLeft} & {documentScrollTop}</div>
   <div style="height: 200vh">
     <span class="slot-position">Slot scroll position is {slotScrollLeft} & {slotScrollTop}</span>

--- a/packages/svelte/test-app/Layouts/WithoutScrollRegion.svelte
+++ b/packages/svelte/test-app/Layouts/WithoutScrollRegion.svelte
@@ -17,6 +17,7 @@
 
 <div style="width: 200vw">
   <span class="layout-text">Without scroll regions</span>
+  <button on:click={handleScrollEvent}>Update scroll positions</button>
   <div class="document-position">Document scroll position is {documentScrollLeft} & {documentScrollTop}</div>
   <div style="height: 200vh">
     <span class="slot-position">Slot scroll position is {slotScrollLeft} & {slotScrollTop}</span>

--- a/packages/svelte/test-app/Pages/Links/UrlFragments.svelte
+++ b/packages/svelte/test-app/Pages/Links/UrlFragments.svelte
@@ -16,6 +16,7 @@
   <span class="text">This is the links page that demonstrates url fragment behaviour</span>
   <div style="width: 200vw; height: 200vh; margin-top: 50vh">
     <!-- prettier-ignore -->
+    <button on:click={handleScrollEvent}>Update scroll positions</button>
     <div class="document-position">Document scroll position is {documentScrollLeft} & {documentScrollTop}</div>
     <a href="/links/url-fragments#target" use:inertia class="basic">Basic link</a>
     <a href="#target" use:inertia class="fragment">Fragment link</a>

--- a/packages/svelte/test-app/Pages/Visits/UrlFragments.svelte
+++ b/packages/svelte/test-app/Pages/Visits/UrlFragments.svelte
@@ -41,6 +41,7 @@
   <span class="text">This is the page that demonstrates url fragment behaviour using manual visits</span>
   <div style="width: 200vw; height: 200vh; margin-top: 50vh">
     <!-- prettier-ignore -->
+    <button on:click={handleScrollEvent}>Update scroll positions</button>
     <div class="document-position">Document scroll position is {documentScrollLeft} & {documentScrollTop}</div>
     <a href={'#'} on:click={basicVisit} class="basic">Basic visit</a>
     <a href={'#'} on:click={fragmentVisit} class="fragment">Fragment visit</a>

--- a/packages/vue3/test-app/Layouts/WithScrollRegion.vue
+++ b/packages/vue3/test-app/Layouts/WithScrollRegion.vue
@@ -25,6 +25,7 @@ onUnmounted(() => {
 <template>
   <div style="width: 200vw">
     <span class="layout-text">With scroll regions</span>
+    <button @click="handleScrollEvent">Update scroll positions</button>
     <div class="document-position">Document scroll position is {{ documentScrollLeft }} & {{ documentScrollTop }}</div>
     <div style="height: 200vh">
       <span class="slot-position">Slot scroll position is {{ slotScrollLeft }} & {{ slotScrollTop }}</span>

--- a/packages/vue3/test-app/Layouts/WithoutScrollRegion.vue
+++ b/packages/vue3/test-app/Layouts/WithoutScrollRegion.vue
@@ -25,6 +25,7 @@ onUnmounted(() => {
 <template>
   <div style="width: 200vw">
     <span class="layout-text">Without scroll regions</span>
+    <button @click="handleScrollEvent">Update scroll positions</button>
     <div class="document-position">Document scroll position is {{ documentScrollLeft }} & {{ documentScrollTop }}</div>
     <div style="height: 200vh">
       <span class="slot-position">Slot scroll position is {{ slotScrollLeft }} & {{ slotScrollTop }}</span>

--- a/packages/vue3/test-app/Pages/Links/UrlFragments.vue
+++ b/packages/vue3/test-app/Pages/Links/UrlFragments.vue
@@ -19,6 +19,7 @@ const handleScrollEvent = () => {
   <div>
     <span class="text">This is the links page that demonstrates url fragment behaviour</span>
     <div style="width: 200vw; height: 200vh; margin-top: 50vh">
+      <button @click="handleScrollEvent">Update scroll positions</button>
       <!-- prettier-ignore -->
       <div class="document-position">Document scroll position is {{ documentScrollLeft }} & {{ documentScrollTop }}</div>
       <Link href="/links/url-fragments#target" class="basic">Basic link</Link>

--- a/packages/vue3/test-app/Pages/Visits/UrlFragments.vue
+++ b/packages/vue3/test-app/Pages/Visits/UrlFragments.vue
@@ -47,6 +47,7 @@ const nonExistentFragmentGetVisit = () => {
   <div>
     <span class="text">This is the page that demonstrates url fragment behaviour using manual visits</span>
     <div style="width: 200vw; height: 200vh; margin-top: 50vh">
+      <button @click="handleScrollEvent">Update scroll positions</button>
       <!-- prettier-ignore -->
       <div class="document-position">Document scroll position is {{ documentScrollLeft }} & {{ documentScrollTop }}</div>
       <a href="#" @click="basicVisit" class="basic">Basic visit</a>

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -392,6 +392,7 @@ test.describe('preserve scroll', () => {
       page.evaluate(() => document.querySelector('#slot')?.scrollTo(10, 15)),
     )
 
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
   })
@@ -400,6 +401,7 @@ test.describe('preserve scroll', () => {
     await page.getByRole('link', { exact: true, name: 'Reset Scroll' }).click()
     await expect(page).toHaveURL('/links/preserve-scroll-false-page-two')
     await expect(page.getByText('Foo is now bar')).toBeVisible()
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
   })
@@ -412,6 +414,7 @@ test.describe('preserve scroll', () => {
     await page.getByRole('link', { exact: true, name: 'Reset Scroll (Callback)' }).click({ position: { x: 0, y: 0 } })
     await expect(page).toHaveURL('/links/preserve-scroll-false-page-two')
     await expect(page.getByText('Foo is now foo')).toBeVisible()
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
 
@@ -441,6 +444,7 @@ test.describe('preserve scroll', () => {
 
     await expect(page).toHaveURL('/links/preserve-scroll-false')
     await expect(page.getByText('Foo is now default')).toBeVisible()
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
   })
@@ -473,6 +477,7 @@ test.describe('preserve scroll', () => {
 
     await expect(page).toHaveURL('/links/preserve-scroll-false')
     await expect(page.getByText('Foo is now default')).toBeVisible()
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
   })
@@ -488,6 +493,7 @@ test.describe('preserve scroll', () => {
 
     await expect(page).toHaveURL('/links/preserve-scroll-false')
     await expect(page.getByText('Foo is now default')).toBeVisible()
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click() //
     await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
   })
@@ -515,6 +521,7 @@ test.describe('enabled', () => {
     await page.getByText('Reset Scroll', { exact: true }).click()
     await expect(page).toHaveURL('/links/preserve-scroll-page-two')
     await expect(page.getByText('Foo is now bar')).toBeVisible()
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
   })
@@ -525,6 +532,7 @@ test.describe('enabled', () => {
 
     await expect(page).toHaveURL('/links/preserve-scroll-page-two')
     await expect(page.getByText('Foo is now foo')).toBeVisible()
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
 
@@ -542,6 +550,7 @@ test.describe('enabled', () => {
 
     await expect(page).toHaveURL('/links/preserve-scroll-page-two')
     await expect(page.getByText('Foo is now baz')).toBeVisible()
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
   })
@@ -552,6 +561,7 @@ test.describe('enabled', () => {
 
     await expect(page).toHaveURL('/links/preserve-scroll-page-two')
     await expect(page.getByText('Foo is now baz')).toBeVisible()
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
 
@@ -579,6 +589,7 @@ test.describe('enabled', () => {
 
     await expect(page).toHaveURL('/links/preserve-scroll')
     await expect(page.getByText('Foo is now default')).toBeVisible()
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
 
     // Wait for scroll restoration to complete - use longer timeout for flaky CI
@@ -631,6 +642,7 @@ test.describe('enabled', () => {
     await page.goBack()
 
     await expect(page).toHaveURL('/links/preserve-scroll')
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
     await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
   })
@@ -642,24 +654,28 @@ test.describe('URL fragment navigation (& automatic scrolling)', () => {
   test.beforeEach(async ({ page }) => {
     pageLoads.watch(page)
     await page.goto('/links/url-fragments')
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
   })
 
   test('scrolls to the fragment element when making a visit to a different page', async ({ page }) => {
     await page.getByRole('link', { name: 'Basic link' }).click()
     await expect(page).toHaveURL('/links/url-fragments#target')
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 0 & 0')).not.toBeVisible()
   })
 
   test('scrolls to the fragment element when making a visit to the same page', async ({ page }) => {
     await page.getByRole('link', { exact: true, name: 'Fragment link' }).click()
     await expect(page).toHaveURL('/links/url-fragments#target')
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 0 & 0')).not.toBeVisible()
   })
 
   test('does not scroll to the fragment element when it does not exist on the page', async ({ page }) => {
     await page.getByRole('link', { exact: true, name: 'Non-existent fragment link' }).click()
     await expect(page).toHaveURL('/links/url-fragments#non-existent-fragment')
+    await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
     await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
   })
 })

--- a/tests/manual-visits.spec.ts
+++ b/tests/manual-visits.spec.ts
@@ -445,6 +445,7 @@ test.describe('Preserve scroll', () => {
         page,
         page.evaluate(() => document.querySelector('#slot')?.scrollTo(10, 15)),
       )
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
     })
@@ -453,6 +454,7 @@ test.describe('Preserve scroll', () => {
       await page.getByRole('link', { exact: true, name: 'Reset Scroll' }).click()
       await expect(page).toHaveURL('/visits/preserve-scroll-false-page-two')
       await expect(page.getByText('Foo is now bar')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
     })
@@ -461,6 +463,7 @@ test.describe('Preserve scroll', () => {
       await page.getByRole('link', { exact: true, name: 'Reset Scroll (GET)' }).click()
       await expect(page).toHaveURL('/visits/preserve-scroll-false-page-two')
       await expect(page.getByText('Foo is now baz')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
     })
@@ -475,6 +478,7 @@ test.describe('Preserve scroll', () => {
         .click({ position: { x: 20, y: 0 } })
       await expect(page).toHaveURL('/visits/preserve-scroll-false-page-two')
       await expect(page.getByText('Foo is now foo')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
 
@@ -500,10 +504,13 @@ test.describe('Preserve scroll', () => {
       )
       await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
 
+      await page.waitForTimeout(100)
       await page.goBack()
+      await page.waitForTimeout(100)
 
       await expect(page).toHaveURL('/visits/preserve-scroll-false')
       await expect(page.getByText('Foo is now default')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
     })
@@ -520,10 +527,13 @@ test.describe('Preserve scroll', () => {
       )
       await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
 
+      await page.waitForTimeout(100)
       await page.goBack()
+      await page.waitForTimeout(100)
 
       await expect(page).toHaveURL('/visits/preserve-scroll-false')
       await expect(page.getByText('Foo is now default')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
     })
@@ -551,10 +561,13 @@ test.describe('Preserve scroll', () => {
       await expect(message.url).not.toBeUndefined()
       await expect(message.version).not.toBeUndefined()
 
+      await page.waitForTimeout(100)
       await page.goBack()
+      await page.waitForTimeout(100)
 
       await expect(page).toHaveURL('/visits/preserve-scroll-false')
       await expect(page.getByText('Foo is now default')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
     })
@@ -566,10 +579,13 @@ test.describe('Preserve scroll', () => {
 
       await expect(page).toHaveURL('non-inertia')
 
+      await page.waitForTimeout(100)
       await page.goBack()
+      await page.waitForTimeout(100)
 
       await expect(page).toHaveURL('/visits/preserve-scroll-false')
       await expect(page.getByText('Foo is now default')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
     })
@@ -588,6 +604,7 @@ test.describe('Preserve scroll', () => {
         page,
         page.evaluate(() => document.querySelector('#slot')?.scrollTo(10, 15)),
       )
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
     })
@@ -596,6 +613,7 @@ test.describe('Preserve scroll', () => {
       await page.getByRole('link', { exact: true, name: 'Reset Scroll' }).click()
       await expect(page).toHaveURL('/visits/preserve-scroll-page-two')
       await expect(page.getByText('Foo is now bar')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
     })
@@ -604,6 +622,7 @@ test.describe('Preserve scroll', () => {
       await page.getByRole('link', { exact: true, name: 'Reset Scroll (GET)' }).click()
       await expect(page).toHaveURL('/visits/preserve-scroll-page-two')
       await expect(page.getByText('Foo is now baz')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
     })
@@ -616,6 +635,7 @@ test.describe('Preserve scroll', () => {
 
       await expect(page).toHaveURL('/visits/preserve-scroll-page-two')
       await expect(page.getByText('Foo is now foo')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 0 & 0')).toBeVisible()
 
@@ -633,6 +653,7 @@ test.describe('Preserve scroll', () => {
 
       await expect(page).toHaveURL('/visits/preserve-scroll-page-two')
       await expect(page.getByText('Foo is now foo')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
     })
@@ -642,6 +663,7 @@ test.describe('Preserve scroll', () => {
 
       await expect(page).toHaveURL('/visits/preserve-scroll-page-two')
       await expect(page.getByText('Foo is now bar')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
     })
@@ -654,6 +676,7 @@ test.describe('Preserve scroll', () => {
 
       await expect(page).toHaveURL('/visits/preserve-scroll-page-two')
       await expect(page.getByText('Foo is now baz')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
 
@@ -681,6 +704,7 @@ test.describe('Preserve scroll', () => {
 
       await expect(page).toHaveURL('/visits/preserve-scroll')
       await expect(page.getByText('Foo is now default')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
     })
@@ -701,6 +725,7 @@ test.describe('Preserve scroll', () => {
 
       await expect(page).toHaveURL('/visits/preserve-scroll')
       await expect(page.getByText('Foo is now default')).toBeVisible()
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
     })
@@ -716,6 +741,7 @@ test.describe('Preserve scroll', () => {
 
       await page.waitForTimeout(50)
 
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 5 & 7')).toBeVisible()
       await expect(page.getByText('Slot scroll position is 10 & 15')).toBeVisible()
     })
@@ -737,18 +763,21 @@ test.describe('URL fragment navigation (& automatic scrolling)', () => {
     test(`Scrolls to the fragment element when making a ${label} to a different page`, async ({ page }) => {
       await page.getByRole('link', { name: `Basic ${label}` }).click()
       await expect(page).toHaveURL('/visits/url-fragments#target')
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 0 & 0')).not.toBeVisible()
     })
 
     test(`Scrolls to the fragment element when making a ${label} to the same page`, async ({ page }) => {
       await page.getByRole('link', { exact: true, name: `Fragment ${label}` }).click()
       await expect(page).toHaveURL('/visits/url-fragments#target')
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 0 & 0')).not.toBeVisible()
     })
 
     test(`Does not scroll to the fragment element when it does not exist on the page (${label})`, async ({ page }) => {
       await page.getByRole('link', { exact: true, name: `Non-existent fragment ${label}` }).click()
       await expect(page).toHaveURL('/visits/url-fragments#non-existent-fragment')
+      await page.getByRole('button', { exact: true, name: 'Update scroll positions' }).click()
       await expect(page.getByText('Document scroll position is 0 & 0')).toBeVisible()
     })
   })


### PR DESCRIPTION
This PR fixes the flakiness we've been seeing when testing the React adapter in CI. There was a timing issue where the scroll positions were restored quicker than the test page had registered the scroll listener.

In the core adapter, the `window.requestAnimationFrame` wrapping has been moved from `eventHandler.ts` to `scroll.ts`. This ensures that the scroll restoration always runs in that callback.