### PR TITLE
Fix for reloading an unrelated prop affecting infinite scroll

### DIFF
--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -295,7 +295,7 @@ export class Response {
     pageResponse.props = { ...currentPage.get().props, ...pageResponse.props }
 
     // Preserve the existing scrollProps
-    if (pageResponse.scrollProps) {
+    if (currentPage.get().scrollProps) {
       pageResponse.scrollProps = {
         ...(currentPage.get().scrollProps || {}),
         ...(pageResponse.scrollProps || {}),

--- a/packages/react/test-app/Pages/InfiniteScroll/ReloadUnrelated.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/ReloadUnrelated.tsx
@@ -1,0 +1,25 @@
+import { InfiniteScroll, router } from '@inertiajs/react'
+import UserCard, { User } from './UserCard'
+
+export default ({ users, time }: { users: { data: User[] }; time: number }) => {
+  const reloadTime = () => {
+    router.reload({ only: ['time'] })
+  }
+
+  return (
+    <div>
+      <div>
+        <button onClick={reloadTime} id="reload-button">
+          Reload Time
+        </button>
+        <span id="time-display"> Current time: {time}</span>
+      </div>
+
+      <InfiniteScroll data="users">
+        {users.data.map((user) => (
+          <UserCard key={user.id} user={user} />
+        ))}
+      </InfiniteScroll>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/InfiniteScroll/ReloadUnrelated.svelte
+++ b/packages/svelte/test-app/Pages/InfiniteScroll/ReloadUnrelated.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { InfiniteScroll, router } from '@inertiajs/svelte'
+  import UserCard, { type User } from './UserCard.svelte'
+
+  export let users: { data: User[] }
+  export let time: number
+
+  const reloadTime = () => {
+    router.reload({ only: ['time'] })
+  }
+</script>
+
+<div>
+  <div>
+    <button on:click={reloadTime} id="reload-button">Reload Time</button>
+    <span id="time-display">Current time: {time}</span>
+  </div>
+
+  <InfiniteScroll data="users">
+    {#each users.data as user (user.id)}
+      <UserCard {user} />
+    {/each}
+  </InfiniteScroll>
+</div>

--- a/packages/vue3/test-app/Pages/InfiniteScroll/ReloadUnrelated.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/ReloadUnrelated.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { InfiniteScroll, router } from '@inertiajs/vue3'
+import UserCard, { User } from './UserCard.vue'
+
+defineProps<{
+  users: { data: User[] }
+  time: number
+}>()
+
+const reloadTime = () => {
+  router.reload({ only: ['time'] })
+}
+</script>
+
+<template>
+  <div>
+    <div>
+      <button @click="reloadTime" id="reload-button">Reload Time</button>
+      <span id="time-display">Current time: {{ time }}</span>
+    </div>
+
+    <InfiniteScroll data="users">
+      <UserCard v-for="user in users.data" :key="user.id" :user="user" />
+    </InfiniteScroll>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -924,6 +924,28 @@ app.get('/infinite-scroll/programmatic-ref', (req, res) =>
 app.get('/infinite-scroll/short-content', (req, res) =>
   renderInfiniteScroll(req, res, 'InfiniteScroll/ShortContent', 100, false, 5),
 )
+app.get('/infinite-scroll/reload-unrelated', (req, res) => {
+  const page = req.query.page ? parseInt(req.query.page) : 1
+  const partialReload = !!req.headers['x-inertia-partial-data']
+  const shouldAppend = req.headers['x-inertia-infinite-scroll-merge-intent'] !== 'prepend'
+  const { paginated, scrollProp } = paginateUsers(page, 15, 40, false)
+
+  setTimeout(
+    () =>
+      inertia.render(req, res, {
+        component: 'InfiniteScroll/ReloadUnrelated',
+        props: {
+          time: Date.now(),
+          users: paginated,
+        },
+        ...(req.headers['x-inertia-partial-data'] === 'users'
+          ? { [shouldAppend ? 'mergeProps' : 'prependProps']: ['users.data'] }
+          : {}),
+        ...(req.headers['x-inertia-partial-data'] === 'time' ? {} : { scrollProps: { users: scrollProp } }),
+      }),
+    partialReload ? 250 : 0,
+  )
+})
 app.get('/infinite-scroll/dual-containers', (req, res) => {
   const users1Page = req.query.users1 ? parseInt(req.query.users1) : 1
   const users2Page = req.query.users2 ? parseInt(req.query.users2) : 1

--- a/tests/infinite-scroll.spec.ts
+++ b/tests/infinite-scroll.spec.ts
@@ -1955,3 +1955,29 @@ Object.entries({
     })
   })
 })
+
+test('it can reload unrelated props without affecting infinite scroll', async ({ page }) => {
+  await page.goto('/infinite-scroll/reload-unrelated')
+
+  await expect(page.getByText('User 1', { exact: true })).toBeVisible()
+  await expect(page.getByText('User 15')).toBeVisible()
+  await expect(page.getByText('User 16')).toBeHidden()
+
+  const initialTime = await page.locator('#time-display').textContent()
+
+  await page.locator('#reload-button').click()
+
+  // Wait for reload to complete and verify timestamp changed
+  await page.waitForTimeout(300)
+  const updatedTime = await page.locator('#time-display').textContent()
+  expect(updatedTime).not.toBe(initialTime)
+
+  await expect(page.getByText('User 1', { exact: true })).toBeVisible()
+  await expect(page.getByText('User 15')).toBeVisible()
+  await expect(page.getByText('User 16')).toBeHidden()
+
+  await scrollToBottom(page)
+  await expect(page.getByText('User 16')).toBeVisible()
+  await expect(page.getByText('User 30')).toBeVisible()
+  await expect(page.getByText('User 31')).toBeHidden()
+})


### PR DESCRIPTION
This PR fixes an issue where reloading an unrelated prop would have the `ScrollProp` metadata being removed from the page object, causing the `<InfiniteScroll>` component to fail.