### PR TITLE
feat: give access to underlying data as object and as form data object

### DIFF
--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -183,6 +183,8 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
       reset,
       submit,
       defaults,
+      getData,
+      getFormData,
     })
 
     useImperativeHandle(ref, exposed, [form, isDirty, submit])

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -197,5 +197,7 @@
     {isDirty}
     {submit}
     {defaults}
+    {getData}
+    {getFormData}
   />
 </form>

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -240,6 +240,8 @@ const Form: InertiaForm = defineComponent({
       reset,
       submit,
       defaults,
+      getData,
+      getFormData,
     }
 
     expose<FormComponentRef>(exposed)


### PR DESCRIPTION
`<Form />` is a great addition to InertiaJS. But it would be greater if I could use it for sending manual requests to my api and benefit from the other features offered by `<Form />`. Currently there is no good way for accessing either the form element itself or the data managed by the Form component. I don't want to use `useForm()` and have to manually handle the state of my input fields. Getting access to the form data as FormData object or as an plain old JS object would be great.

I currently omitted the tests. If the feature is accepted I will add them.