### PR TITLE
Failing scrollProp when leaving to a page without scroll

### DIFF
--- a/packages/core/src/infiniteScroll/data.ts
+++ b/packages/core/src/infiniteScroll/data.ts
@@ -32,6 +32,10 @@ export const useInfiniteScrollData = (options: {
     throw new Error(`The page object does not contain a scroll prop named "${options.getPropName()}".`)
   }
 
+  const tryGetScrollPropFromCurrentPage = (): ScrollProp | undefined => {
+    return currentPage.get().scrollProps?.[options.getPropName()]
+  }
+
   const { previousPage, nextPage, currentPage: lastLoadedPage } = getScrollPropFromCurrentPage()
 
   const state = {
@@ -55,7 +59,11 @@ export const useInfiniteScrollData = (options: {
   }
 
   const removeEventListener = router.on('success', () => {
-    const scrollProp = getScrollPropFromCurrentPage()
+    const scrollProp = tryGetScrollPropFromCurrentPage()
+
+    if (!scrollProp) {
+      return
+    }
 
     if (scrollProp.reset) {
       state.previousPage = scrollProp.previousPage


### PR DESCRIPTION
I was using the new Infinite Scroll and atleast on 2.2.4 I was receiving some console errors when leaving a page using infinite scroll, to a page that don't use it.

<img width="1718" height="101" alt="Screenshot 2025-10-02 at 00 19 47" src="https://github.com/user-attachments/assets/109bf4cb-b75d-45c7-aa73-b2611d67b8f1" />

After some research, I realized the issue was in the `router.on('success')` event listener, which throws an error if the `scrollProps`doesn't exists on the current page - this seems to be attempted on every page navigation inclusing pages without infinite scroll.

I was not quite sure if I should do inline on the router.on('success') or create a new helper function that safely attempts without throwing an error - I've decided for the later, if it doesn't make sense I can adjust. 

Changes:
- Added `tryGetScrollPropFromCurrentPage()` - safely retrieves scroll prop or returns undefined
- Updated `router.on('success')` listener to use the new try function