### PR TITLE
Improve `<InfiniteScroll>` cleanup after navigating away

### DIFF
--- a/packages/core/src/infiniteScroll.ts
+++ b/packages/core/src/infiniteScroll.ts
@@ -91,5 +91,10 @@ export default function useInfiniteScroll(options: UseInfiniteScrollOptions): Us
   return {
     dataManager,
     elementManager,
+    flush: () => {
+      dataManager.removeEventListener()
+      elementManager.flushAll()
+      queryStringManager.cancel()
+    },
   }
 }

--- a/packages/core/src/infiniteScroll/data.ts
+++ b/packages/core/src/infiniteScroll/data.ts
@@ -35,6 +35,7 @@ export const useInfiniteScrollData = (options: {
   const { previousPage, nextPage, currentPage: lastLoadedPage } = getScrollPropFromCurrentPage()
 
   const state = {
+    component: currentPage.get().component,
     loading: false,
     previousPage,
     nextPage,
@@ -54,7 +55,12 @@ export const useInfiniteScrollData = (options: {
     state.requestCount = rememberedState.requestCount || 0
   }
 
-  const removeEventListener = router.on('success', () => {
+  const removeEventListener = router.on('success', (event) => {
+    if (state.component !== event.detail.page.component) {
+      // Only reset state if it's the same component
+      return
+    }
+
     const scrollProp = getScrollPropFromCurrentPage()
 
     if (scrollProp.reset) {

--- a/packages/core/src/infiniteScroll/elements.ts
+++ b/packages/core/src/infiniteScroll/elements.ts
@@ -57,9 +57,8 @@ export const useInfiniteScrollElementManager = (options: {
 
     // Track individual items entering/leaving viewport for URL synchronization
     // When items become visible, we update the URL to reflect the current page
-    itemsObserver = intersectionObservers.new(
-      (entry: IntersectionObserverEntry) => options.onItemIntersected(entry.target as HTMLElement),
-      { threshold: 0 },
+    itemsObserver = intersectionObservers.new((entry: IntersectionObserverEntry) =>
+      options.onItemIntersected(entry.target as HTMLElement),
     )
 
     // Set up trigger zones at start/end that load more content when intersected. The rootMargin
@@ -111,6 +110,7 @@ export const useInfiniteScrollElementManager = (options: {
   }
 
   const flushAll = () => {
+    disableTriggers()
     intersectionObservers.flushAll()
     itemsMutationObserver?.disconnect()
   }

--- a/packages/core/src/infiniteScroll/queryString.ts
+++ b/packages/core/src/infiniteScroll/queryString.ts
@@ -13,9 +13,11 @@ export const useInfiniteScrollQueryString = (options: {
   getItemsElement: () => HTMLElement
   shouldPreserveUrl: () => boolean
 }) => {
+  let enabled = true
+
   // Debounced to avoid excessive URL updates during fast scrolling
   const onItemIntersected = debounce((itemElement: HTMLElement) => {
-    if (options.shouldPreserveUrl() || !itemElement) {
+    if (!enabled || options.shouldPreserveUrl() || !itemElement) {
       return
     }
 
@@ -60,5 +62,6 @@ export const useInfiniteScrollQueryString = (options: {
 
   return {
     onItemIntersected,
+    cancel: () => (enabled = false),
   }
 }

--- a/packages/core/src/infiniteScroll/queryString.ts
+++ b/packages/core/src/infiniteScroll/queryString.ts
@@ -17,13 +17,15 @@ export const useInfiniteScrollQueryString = (options: {
 
   // Debounced to avoid excessive URL updates during fast scrolling
   const onItemIntersected = debounce((itemElement: HTMLElement) => {
-    if (!enabled || options.shouldPreserveUrl() || !itemElement) {
+    const itemsElement = options.getItemsElement()
+
+    if (!enabled || options.shouldPreserveUrl() || !itemElement || !itemsElement) {
       return
     }
 
     // Count how many items from each page are currently visible in the viewport
     const pageMap = new Map<string, number>()
-    const elements = [...options.getItemsElement().children] as HTMLElement[]
+    const elements = [...itemsElement.children] as HTMLElement[]
 
     getElementsInViewportFromCollection(itemElement, elements).forEach((element) => {
       const page = getPageFromElement(element) ?? '1'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -550,6 +550,7 @@ export interface UseInfiniteScrollElementManager {
 export interface UseInfiniteScrollProps {
   dataManager: UseInfiniteScrollDataManager
   elementManager: UseInfiniteScrollElementManager
+  flush: () => void
 }
 
 export interface InfiniteScrollSlotProps {

--- a/packages/react/src/InfiniteScroll.ts
+++ b/packages/react/src/InfiniteScroll.ts
@@ -212,8 +212,7 @@ const InfiniteScroll = forwardRef<InfiniteScrollRef, ComponentProps>(
       }
 
       return () => {
-        dataManager.removeEventListener()
-        elementManager.flushAll()
+        infiniteScrollInstance.flush()
         setInfiniteScroll(null)
       }
     }, [data, resolvedItemsElement, resolvedStartElement, resolvedEndElement, scrollableParent])

--- a/packages/react/test-app/Pages/InfiniteScroll/InfiniteScrollWithLink.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/InfiniteScrollWithLink.tsx
@@ -1,0 +1,19 @@
+import { InfiniteScroll, Link } from '@inertiajs/react'
+import UserCard, { User } from './UserCard'
+
+export default ({ users }: { users: { data: User[] } }) => {
+  return (
+    <div>
+      <Link href="/infinite-scroll">Go back to Links</Link>
+      <InfiniteScroll
+        data="users"
+        style={{ display: 'grid', gap: '20px' }}
+        loading={() => <div style={{ textAlign: 'center', padding: '20px' }}>Loading...</div>}
+      >
+        {users.data.map((user) => (
+          <UserCard key={user.id} user={user} />
+        ))}
+      </InfiniteScroll>
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/InfiniteScroll/Links.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/Links.tsx
@@ -1,0 +1,9 @@
+import { Link } from '@inertiajs/react'
+
+export default () => {
+  return (
+    <div>
+      <Link href="/infinite-scroll-with-link">Go to InfiniteScrollWithLink</Link>
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/InfiniteScroll/Links.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/Links.tsx
@@ -4,6 +4,9 @@ export default () => {
   return (
     <div>
       <Link href="/infinite-scroll-with-link">Go to InfiniteScrollWithLink</Link>
+      <Link href="/infinite-scroll-with-link" prefetch>
+        Go to InfiniteScrollWithLink (Prefetch)
+      </Link>
     </div>
   )
 }

--- a/packages/svelte/src/InfiniteScroll.svelte
+++ b/packages/svelte/src/InfiniteScroll.svelte
@@ -182,10 +182,7 @@
       : infiniteScrollInstance?.elementManager.disableTriggers()
   }
 
-  onDestroy(() => {
-    infiniteScrollInstance?.dataManager.removeEventListener()
-    infiniteScrollInstance?.elementManager.flushAll()
-  })
+  onDestroy(() => infiniteScrollInstance?.flush())
 </script>
 
 {#if !startElement && !reverse}

--- a/packages/svelte/test-app/Pages/InfiniteScroll/InfiniteScrollWithLink.svelte
+++ b/packages/svelte/test-app/Pages/InfiniteScroll/InfiniteScrollWithLink.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { inertia, InfiniteScroll } from '@inertiajs/svelte'
+  import UserCard, { type User } from './UserCard.svelte'
+
+  export let users: { data: User[] }
+</script>
+
+<div>
+  <a href="/infinite-scroll" use:inertia>Go back to Links</a>
+  <InfiniteScroll data="users" style="display: grid; gap: 20px">
+    <div slot="loading" style="text-align: center; padding: 20px">Loading...</div>
+
+    {#each users.data as user (user.id)}
+      <UserCard {user} />
+    {/each}
+  </InfiniteScroll>
+</div>

--- a/packages/svelte/test-app/Pages/InfiniteScroll/Links.svelte
+++ b/packages/svelte/test-app/Pages/InfiniteScroll/Links.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { inertia } from '@inertiajs/svelte'
+</script>
+
+<div>
+  <a href="/infinite-scroll-with-link" use:inertia>Go to InfiniteScrollWithLink</a>
+</div>

--- a/packages/svelte/test-app/Pages/InfiniteScroll/Links.svelte
+++ b/packages/svelte/test-app/Pages/InfiniteScroll/Links.svelte
@@ -4,4 +4,5 @@
 
 <div>
   <a href="/infinite-scroll-with-link" use:inertia>Go to InfiniteScrollWithLink</a>
+  <a href="/infinite-scroll-with-link" use:inertia={{ prefetch: true }}>Go to InfiniteScrollWithLink (Prefetch)</a>
 </div>

--- a/packages/vue3/src/infiniteScroll.ts
+++ b/packages/vue3/src/infiniteScroll.ts
@@ -101,7 +101,11 @@ const InfiniteScroll = defineComponent({
     const loadingNext = ref(false)
     const requestCount = ref(0)
 
-    const { dataManager, elementManager } = useInfiniteScroll({
+    const {
+      dataManager,
+      elementManager,
+      flush: flushInfiniteScroll,
+    } = useInfiniteScroll({
       // Data
       getPropName: () => props.data,
       inReverseMode: () => props.reverse,
@@ -166,10 +170,7 @@ const InfiniteScroll = defineComponent({
       }
     })
 
-    onUnmounted(() => {
-      dataManager.removeEventListener()
-      elementManager.flushAll()
-    })
+    onUnmounted(flushInfiniteScroll)
 
     watch(
       () => [autoLoad.value, props.onlyNext, props.onlyPrevious],

--- a/packages/vue3/test-app/Pages/InfiniteScroll/InfiniteScrollWithLink.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/InfiniteScrollWithLink.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { InfiniteScroll, Link } from '@inertiajs/vue3'
+import { User, default as UserCard } from './UserCard.vue'
+
+defineProps<{
+  users: { data: User[] }
+}>()
+</script>
+
+<template>
+  <div>
+    <Link href="/infinite-scroll">Go back to Links</Link>
+    <InfiniteScroll data="users" style="display: grid; gap: 20px">
+      <UserCard v-for="user in users.data" :key="user.id" :user="user" />
+
+      <template #loading>
+        <div style="text-align: center; padding: 20px">Loading...</div>
+      </template>
+    </InfiniteScroll>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/InfiniteScroll/Links.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/Links.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <div>
+    <Link href="/infinite-scroll-with-link">Go to InfiniteScrollWithLink</Link>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/InfiniteScroll/Links.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/Links.vue
@@ -5,5 +5,6 @@ import { Link } from '@inertiajs/vue3'
 <template>
   <div>
     <Link href="/infinite-scroll-with-link">Go to InfiniteScrollWithLink</Link>
+    <Link href="/infinite-scroll-with-link" prefetch>Go to InfiniteScrollWithLink (Prefetch)</Link>
   </div>
 </template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -902,6 +902,10 @@ function renderInfiniteScroll(req, res, component, total = 40, orderByDesc = fal
   )
 }
 
+app.get('/infinite-scroll', (req, res) => inertia.render(req, res, { component: 'InfiniteScroll/Links' }))
+app.get('/infinite-scroll-with-link', (req, res) =>
+  renderInfiniteScroll(req, res, 'InfiniteScroll/InfiniteScrollWithLink'),
+)
 app.get('/infinite-scroll/manual', (req, res) => renderInfiniteScroll(req, res, 'InfiniteScroll/Manual'))
 app.get('/infinite-scroll/manual-after', (req, res) => renderInfiniteScroll(req, res, 'InfiniteScroll/ManualAfter', 60))
 app.get('/infinite-scroll/remember-state', (req, res) =>
@@ -1066,6 +1070,12 @@ app.get('/infinite-scroll/filtering/:preserveState', (req, res) => {
 })
 
 app.all('*', (req, res) => inertia.render(req, res))
+
+// Send errors to the console (instead of crashing the server)
+app.use((err, req, res, next) => {
+  console.error('❌ Express Error:', err)
+  res.status(500).send('Internal Server Error')
+})
 
 const adapterPorts = {
   vue3: 13715,

--- a/tests/infinite-scroll.spec.ts
+++ b/tests/infinite-scroll.spec.ts
@@ -1956,28 +1956,32 @@ Object.entries({
   })
 })
 
-test('it can reload unrelated props without affecting infinite scroll', async ({ page }) => {
-  await page.goto('/infinite-scroll/reload-unrelated')
+test.describe('Router', () => {
+  test('it can reload unrelated props without affecting infinite scroll', async ({ page }) => {
+    await page.goto('/infinite-scroll/reload-unrelated')
 
-  await expect(page.getByText('User 1', { exact: true })).toBeVisible()
-  await expect(page.getByText('User 15')).toBeVisible()
-  await expect(page.getByText('User 16')).toBeHidden()
+    await expect(page.getByText('User 1', { exact: true })).toBeVisible()
+    await expect(page.getByText('User 15')).toBeVisible()
+    await expect(page.getByText('User 16')).toBeHidden()
 
-  const initialTime = await page.locator('#time-display').textContent()
+    const initialTime = await page.locator('#time-display').textContent()
 
-  await page.locator('#reload-button').click()
+    await page.locator('#reload-button').click()
 
-  // Wait for reload to complete and verify timestamp changed
-  await page.waitForTimeout(300)
-  const updatedTime = await page.locator('#time-display').textContent()
-  expect(updatedTime).not.toBe(initialTime)
+    // Wait for reload to complete and verify timestamp changed
+    await page.waitForTimeout(300)
+    const updatedTime = await page.locator('#time-display').textContent()
+    expect(updatedTime).not.toBe(initialTime)
 
-  await expect(page.getByText('User 1', { exact: true })).toBeVisible()
-  await expect(page.getByText('User 15')).toBeVisible()
-  await expect(page.getByText('User 16')).toBeHidden()
+    await expect(page.getByText('User 1', { exact: true })).toBeVisible()
+    await expect(page.getByText('User 15')).toBeVisible()
+    await expect(page.getByText('User 16')).toBeHidden()
 
-  await scrollToBottom(page)
-  await expect(page.getByText('User 16')).toBeVisible()
-  await expect(page.getByText('User 30')).toBeVisible()
-  await expect(page.getByText('User 31')).toBeHidden()
+    await scrollToBottom(page)
+    await expect(page.getByText('User 16')).toBeVisible()
+    await expect(page.getByText('User 30')).toBeVisible()
+    await expect(page.getByText('User 31')).toBeHidden()
+  })
+
+  test('it can prefetch a page with scroll props', async ({ page }) => {})
 })

--- a/tests/infinite-scroll.spec.ts
+++ b/tests/infinite-scroll.spec.ts
@@ -1,5 +1,5 @@
 import { expect, Locator, Page, test } from '@playwright/test'
-import { requests } from './support'
+import { consoleMessages, requests } from './support'
 
 function infiniteScrollRequests() {
   return requests.requests.filter((req) => {
@@ -1984,4 +1984,30 @@ test.describe('Router', () => {
   })
 
   test('it can prefetch a page with scroll props', async ({ page }) => {})
+
+  test('it can navigate rapidly between pages with infinite scroll without errors', async ({ page }) => {
+    consoleMessages.listen(page)
+
+    await page.goto('/infinite-scroll')
+
+    // Navigate back and forth 10 times rapidly
+    for (let i = 0; i < 20; i++) {
+      await page.getByRole('link', { name: 'Go to InfiniteScrollWithLink' }).click()
+      expect(consoleMessages.errors).toHaveLength(0)
+      await page.getByRole('link', { name: 'Go back to Links' }).click()
+      expect(consoleMessages.errors).toHaveLength(0)
+    }
+
+    await page.getByRole('link', { name: 'Go to InfiniteScrollWithLink' }).click()
+
+    // Check if the infinite scroll content is still functional
+    await expect(page.getByText('User 1', { exact: true })).toBeVisible()
+    await expect(page.getByText('User 15')).toBeVisible()
+    await expect(page.getByText('User 16')).toBeHidden()
+
+    await scrollToBottom(page)
+    await expect(page.getByText('User 16')).toBeVisible()
+    await expect(page.getByText('User 30')).toBeVisible()
+    await expect(page.getByText('User 31')).toBeHidden()
+  })
 })


### PR DESCRIPTION
This PR improves the cleanup of registered event listeners when navigating away from pages with one or more `<InfiniteScroll>` components:

* The `IntersectionObserver` listeners (for URL synchronization) got already disconnected when navigating away, but the callback is debounced so that it would still execute. That has been fixed.
* The Inertia `success` callback that checks if a `ScrollProp` should be reset now checks if the event is for the same component, otherwise it ignores it.
* Added tests for the changes above and also for prefetching pages with `<InfiniteScroll>` components.