### PR TITLE
Fix conflicting Client Side Visits by queuing the URL synchronization

### DIFF
--- a/packages/core/src/domUtils.ts
+++ b/packages/core/src/domUtils.ts
@@ -29,14 +29,15 @@ export const getElementsInViewportFromCollection = (
   elements: HTMLElement[],
 ): HTMLElement[] => {
   const referenceIndex = elements.indexOf(referenceElement)
-  const visibleElements: HTMLElement[] = []
+  const upwardElements: HTMLElement[] = []
+  const downwardElements: HTMLElement[] = []
 
   // Traverse upwards until an element is not visible
   for (let i = referenceIndex; i >= 0; i--) {
     const element = elements[i]
 
     if (elementInViewport(element)) {
-      visibleElements.push(element)
+      upwardElements.push(element)
     } else {
       break
     }
@@ -47,11 +48,12 @@ export const getElementsInViewportFromCollection = (
     const element = elements[i]
 
     if (elementInViewport(element)) {
-      visibleElements.push(element)
+      downwardElements.push(element)
     } else {
       break
     }
   }
 
-  return visibleElements
+  // Reverse upward elements to maintain DOM order, then append downward elements
+  return [...upwardElements.reverse(), ...downwardElements]
 }

--- a/packages/core/src/infiniteScroll/queryString.ts
+++ b/packages/core/src/infiniteScroll/queryString.ts
@@ -49,7 +49,7 @@ export const useInfiniteScrollQueryString = (options: {
           setTimeout(() => resolve())
         })
       })
-      .then(() => {
+      .finally(() => {
         if (enabled && initialUrl && payloadUrl && initialUrl.href !== payloadUrl.href) {
           // Update URL without triggering a page reload or affecting scroll position
           router.replace({

--- a/packages/core/src/infiniteScroll/queryString.ts
+++ b/packages/core/src/infiniteScroll/queryString.ts
@@ -22,16 +22,12 @@ export const useInfiniteScrollQueryString = (options: {
 }) => {
   let enabled = true
 
-  const cleanupUrlInstances = (): void => {
-    initialUrl = payloadUrl = null
-  }
-
   const queuePageUpdate = (page: string) => {
     queue
       .add(() => {
         return new Promise((resolve) => {
           if (!enabled) {
-            cleanupUrlInstances()
+            initialUrl = payloadUrl = null
             return resolve()
           }
 
@@ -63,7 +59,7 @@ export const useInfiniteScrollQueryString = (options: {
           })
         }
 
-        cleanupUrlInstances()
+        initialUrl = payloadUrl = null
       })
   }
 

--- a/packages/core/src/infiniteScroll/queryString.ts
+++ b/packages/core/src/infiniteScroll/queryString.ts
@@ -1,7 +1,11 @@
+import { router } from '..'
 import debounce from '../debounce'
 import { getElementsInViewportFromCollection } from '../domUtils'
-import { router } from '../index'
+import Queue from './../queue'
 import { getPageFromElement } from './elements'
+
+// Shared queue among all instances to ensure URL updates are processed sequentially
+const queue = new Queue<Promise<void>>()
 
 /**
  * As users scroll through infinite content, this system updates the URL to reflect
@@ -14,6 +18,36 @@ export const useInfiniteScrollQueryString = (options: {
   shouldPreserveUrl: () => boolean
 }) => {
   let enabled = true
+
+  const queuePageUpdate = (page: string) => {
+    queue.add(() => {
+      return new Promise((resolve) => {
+        if (!enabled) {
+          return resolve()
+        }
+
+        const pageName = options.getPageName()
+        const url = new URL(window.location.href)
+
+        // Clean URLs: don't show ?page=1 in the URL, just remove the parameter entirely
+        if (page === '1') {
+          url.searchParams.delete(pageName)
+        } else {
+          url.searchParams.set(pageName, page)
+        }
+
+        // Update URL without triggering a page reload or affecting scroll position
+        router.replace({
+          url: url.toString(),
+          preserveScroll: true,
+          preserveState: true,
+          onFinish: () => {
+            resolve()
+          },
+        })
+      })
+    })
+  }
 
   // Debounced to avoid excessive URL updates during fast scrolling
   const onItemIntersected = debounce((itemElement: HTMLElement) => {
@@ -41,25 +75,9 @@ export const useInfiniteScrollQueryString = (options: {
     const sortedPages = Array.from(pageMap.entries()).sort((a, b) => b[1] - a[1])
     const mostVisiblePage = sortedPages[0]?.[0]
 
-    if (mostVisiblePage === undefined) {
-      return
+    if (mostVisiblePage !== undefined) {
+      queuePageUpdate(mostVisiblePage)
     }
-
-    const url = new URL(window.location.href)
-
-    // Clean URLs: don't show ?page=1 in the URL, just remove the parameter entirely
-    if (mostVisiblePage === '1') {
-      url.searchParams.delete(options.getPageName())
-    } else {
-      url.searchParams.set(options.getPageName(), mostVisiblePage.toString())
-    }
-
-    // Update URL without triggering a page reload or affecting scroll position
-    router.replace({
-      url: url.toString(),
-      preserveScroll: true,
-      preserveState: true,
-    })
   }, 250)
 
   return {

--- a/packages/react/test-app/Pages/InfiniteScroll/DualSibling.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/DualSibling.tsx
@@ -1,0 +1,58 @@
+import { InfiniteScroll } from '@inertiajs/react'
+import UserCard, { User } from './UserCard'
+
+interface Props {
+  users1: { data: User[] }
+  users2: { data: User[] }
+}
+
+export default ({ users1, users2 }: Props) => {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>Dual Sibling InfiniteScroll</h1>
+      <p style={{ marginBottom: '20px' }}>Two InfiniteScroll components side by side, sharing the window scroll</p>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '40px' }}>
+        <div>
+          <h2>Users 1</h2>
+          <InfiniteScroll
+            data="users1"
+            style={{ display: 'grid', gap: '20px' }}
+            manual
+            next={({ loading, fetch }) => (
+              <div style={{ textAlign: 'center', padding: '20px' }}>
+                <button onClick={fetch} disabled={loading}>
+                  {loading ? 'Loading...' : 'Load More Users 1'}
+                </button>
+              </div>
+            )}
+          >
+            {users1.data.map((user) => (
+              <UserCard key={user.id} user={user} />
+            ))}
+          </InfiniteScroll>
+        </div>
+
+        <div>
+          <h2>Users 2</h2>
+          <InfiniteScroll
+            data="users2"
+            style={{ display: 'grid', gap: '20px' }}
+            manual
+            next={({ loading, fetch }) => (
+              <div style={{ textAlign: 'center', padding: '20px' }}>
+                <button onClick={fetch} disabled={loading}>
+                  {loading ? 'Loading...' : 'Load More Users 2'}
+                </button>
+              </div>
+            )}
+          >
+            {users2.data.map((user) => (
+              <UserCard key={user.id} user={user} />
+            ))}
+          </InfiniteScroll>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/InfiniteScroll/ProgrammaticRef.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/ProgrammaticRef.tsx
@@ -1,33 +1,33 @@
 import { InfiniteScrollRef } from '@inertiajs/core'
 import { InfiniteScroll } from '@inertiajs/react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import UserCard, { User } from './UserCard'
 
 export default ({ users }: { users: { data: User[] } }) => {
-  const infRef = useRef<InfiniteScrollRef>(null)
+  const [infRef, setInfRef] = useState<InfiniteScrollRef | null>(null)
   const [hasPrevious, setHasMoreBefore] = useState(false)
   const [hasNext, setHasMoreAfter] = useState(false)
 
   const updateStates = () => {
-    setHasMoreBefore(infRef.current?.hasPrevious() || false)
-    setHasMoreAfter(infRef.current?.hasNext() || false)
+    setHasMoreBefore(infRef?.hasPrevious() || false)
+    setHasMoreAfter(infRef?.hasNext() || false)
   }
 
   const fetchNext = () => {
-    if (infRef.current) {
-      infRef.current.fetchNext({ onFinish: updateStates })
+    if (infRef) {
+      infRef.fetchNext({ onFinish: updateStates })
     }
   }
 
   const fetchPrevious = () => {
-    if (infRef.current) {
-      infRef.current.fetchPrevious({ onFinish: updateStates })
+    if (infRef) {
+      infRef.fetchPrevious({ onFinish: updateStates })
     }
   }
 
   useEffect(() => {
     updateStates()
-  }, [infRef.current])
+  }, [infRef])
 
   return (
     <div>
@@ -44,7 +44,7 @@ export default ({ users }: { users: { data: User[] } }) => {
       </div>
 
       <InfiniteScroll
-        ref={infRef}
+        ref={setInfRef}
         data="users"
         style={{ display: 'grid', gap: '20px' }}
         manual

--- a/packages/svelte/test-app/Pages/InfiniteScroll/DualSibling.svelte
+++ b/packages/svelte/test-app/Pages/InfiniteScroll/DualSibling.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { InfiniteScroll } from '@inertiajs/svelte'
+  import UserCard, { type User } from './UserCard.svelte'
+
+  export let users1: { data: User[] }
+  export let users2: { data: User[] }
+</script>
+
+<div style="padding: 20px">
+  <h1>Dual Sibling InfiniteScroll</h1>
+  <p style="margin-bottom: 20px">Two InfiniteScroll components side by side, sharing the window scroll</p>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 40px">
+    <div>
+      <h2>Users 1</h2>
+      <InfiniteScroll data="users1" style="display: grid; gap: 20px" manual>
+        {#each users1.data as user (user.id)}
+          <UserCard {user} />
+        {/each}
+
+        <div slot="next" let:loading let:fetch  style="text-align: center; padding: 20px">
+            <button
+              on:click={fetch}
+              disabled={loading}
+            >
+              {loading ? 'Loading...' : 'Load More Users 1'}
+            </button>
+        </div>
+      </InfiniteScroll>
+    </div>
+
+    <div>
+      <h2>Users 2</h2>
+      <InfiniteScroll data="users2" style="display: grid; gap: 20px" manual>
+        {#each users2.data as user (user.id)}
+          <UserCard {user} />
+        {/each}
+
+        <div slot="next" let:loading let:fetch  style="text-align: center; padding: 20px">
+            <button
+              on:click={fetch}
+              disabled={loading}
+            >
+              {loading ? 'Loading...' : 'Load More Users 2'}
+            </button>
+        </div>
+      </InfiniteScroll>
+    </div>
+  </div>
+</div>

--- a/packages/vue3/test-app/Pages/InfiniteScroll/DualSibling.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/DualSibling.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { InfiniteScroll } from '@inertiajs/vue3'
+import { User, default as UserCard } from './UserCard.vue'
+
+defineProps<{
+  users1: { data: User[] }
+  users2: { data: User[] }
+}>()
+</script>
+
+<template>
+  <div style="padding: 20px">
+    <h1>Dual Sibling InfiniteScroll</h1>
+    <p style="margin-bottom: 20px">Two InfiniteScroll components side by side, sharing the window scroll</p>
+
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 40px">
+      <div>
+        <h2>Users 1</h2>
+        <InfiniteScroll data="users1" style="display: grid; gap: 20px" manual>
+          <UserCard v-for="user in users1.data" :key="user.id" :user="user" />
+
+          <template #next="{ loading, fetch }">
+            <div style="text-align: center; padding: 20px">
+              <button @click="fetch" :disabled="loading">
+                {{ loading ? 'Loading...' : 'Load More Users 1' }}
+              </button>
+            </div>
+          </template>
+        </InfiniteScroll>
+      </div>
+
+      <div>
+        <h2>Users 2</h2>
+        <InfiniteScroll data="users2" style="display: grid; gap: 20px" manual>
+          <UserCard v-for="user in users2.data" :key="user.id" :user="user" />
+
+          <template #next="{ loading, fetch }">
+            <div style="text-align: center; padding: 20px">
+              <button @click="fetch" :disabled="loading">
+                {{ loading ? 'Loading...' : 'Load More Users 2' }}
+              </button>
+            </div>
+          </template>
+        </InfiniteScroll>
+      </div>
+    </div>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -1021,6 +1021,51 @@ app.get('/infinite-scroll/dual-containers', (req, res) => {
     partialReload ? 250 : 0,
   )
 })
+app.get('/infinite-scroll/dual-sibling', (req, res) => {
+  const users1Page = req.query.users1 ? parseInt(req.query.users1) : 1
+  const users2Page = req.query.users2 ? parseInt(req.query.users2) : 1
+  const partialReload = !!req.headers['x-inertia-partial-data']
+  const shouldAppend = req.headers['x-inertia-infinite-scroll-merge-intent'] !== 'prepend'
+
+  const { paginated: users1Paginated, scrollProp: users1ScrollProp } = paginateUsers(
+    users1Page,
+    15,
+    40,
+    false,
+    'users1',
+  )
+  const { paginated: users2Paginated, scrollProp: users2ScrollProp } = paginateUsers(
+    users2Page,
+    15,
+    60,
+    false,
+    'users2',
+  )
+
+  const props = {}
+  const scrollProps = {}
+
+  if (!partialReload || req.headers['x-inertia-partial-data']?.includes('users1')) {
+    props.users1 = users1Paginated
+    scrollProps.users1 = users1ScrollProp
+  }
+
+  if (!partialReload || req.headers['x-inertia-partial-data']?.includes('users2')) {
+    props.users2 = users2Paginated
+    scrollProps.users2 = users2ScrollProp
+  }
+
+  setTimeout(
+    () =>
+      inertia.render(req, res, {
+        component: 'InfiniteScroll/DualSibling',
+        props,
+        [shouldAppend ? 'mergeProps' : 'prependProps']: ['users1.data', 'users2.data'],
+        scrollProps,
+      }),
+    partialReload ? 250 : 0,
+  )
+})
 
 function renderInfiniteScrollWithTag(req, res, component, total = 40, orderByDesc = false, perPage = 15) {}
 

--- a/tests/infinite-scroll.spec.ts
+++ b/tests/infinite-scroll.spec.ts
@@ -279,6 +279,45 @@ test.describe('Automatic page loading', () => {
     expect(page.url()).toContain('users1=2')
     expect(page.url()).toContain('users2=2')
   })
+
+  test('it handles dual sibling InfiniteScroll with manual mode and query string updates', async ({ page }) => {
+    requests.listen(page)
+    await page.goto('/infinite-scroll/dual-sibling')
+
+    await expect(page.getByText('User 1', { exact: true }).first()).toBeVisible()
+    await expect(page.getByText('User 15').first()).toBeVisible()
+    await expect(page.getByText('User 1', { exact: true }).last()).toBeVisible()
+    await expect(page.getByText('User 15').last()).toBeVisible()
+    await expect(page.getByText('User 16')).toBeHidden()
+
+    await page.getByRole('button', { name: 'Load More Users 1' }).click()
+    await expect(page.getByText('User 16').first()).toBeVisible()
+    await expect(page.getByText('User 30').first()).toBeVisible()
+
+    await page.getByRole('button', { name: 'Load More Users 2' }).click()
+    await expect(page.getByText('User 16').last()).toBeVisible()
+    await expect(page.getByText('User 30').last()).toBeVisible()
+
+    await expect(page.getByText('User 31')).toBeHidden()
+
+    await scrollToBottom(page)
+    await page.waitForFunction(
+      () => window.location.search.includes('users1=2') && window.location.search.includes('users2=2'),
+      {},
+      { timeout: 1000 },
+    )
+    expect(page.url()).toContain('users1=2')
+    expect(page.url()).toContain('users2=2')
+
+    await scrollToTop(page)
+    await page.waitForFunction(
+      () => !window.location.search.includes('users1=') && !window.location.search.includes('users2='),
+      {},
+      { timeout: 1000 },
+    )
+    expect(page.url()).not.toContain('users1=')
+    expect(page.url()).not.toContain('users2=')
+  })
 })
 
 test.describe('Manual page loading', () => {

--- a/tests/infinite-scroll.spec.ts
+++ b/tests/infinite-scroll.spec.ts
@@ -37,10 +37,10 @@ async function getUserIdsFromDOM(page: Page) {
 }
 
 // Helper function to check URL updates
-async function expectQueryString(page: any, expectedPage: string) {
+async function expectQueryString(page: Page, expectedPage: string) {
   if (expectedPage === '1') {
     // Page 1 removes the page param entirely
-    await page.waitForFunction(() => !window.location.search.includes('page='), { timeout: 800 })
+    await page.waitForFunction(() => !window.location.search.includes('page='), {}, { timeout: 800 })
     const currentUrl = await page.url()
     expect(currentUrl).not.toContain('page=')
   } else {
@@ -1811,6 +1811,7 @@ Object.entries({
     test('it keeps the existing query parameters intact when updating the page param', async ({ page }) => {
       requests.listen(page)
       await page.goto(path)
+      await page.setViewportSize({ width: 1200, height: 400 })
 
       await page.getByRole('link', { name: 'N-Z' }).first().click()
 
@@ -1877,6 +1878,8 @@ Object.entries({
     test('it resets the page and filter params when searching for a user', async ({ page }) => {
       requests.listen(page)
       await page.goto(path)
+      await page.setViewportSize({ width: 1200, height: 400 })
+
       await page.getByRole('link', { name: 'N-Z' }).first().click()
       await expect(page.getByText('Niko Christiansen Jr.')).toBeVisible()
       await expect(page.getByText('Current filter: n-z').first()).toBeVisible()


### PR DESCRIPTION
This PR fixes an issue when you have multiple `<InfiniteScroll>` instances on a single page that are *not* using scroll containers, so both instances are trying to update the URL at the same time as the user scrolls the browser.

Fixes #2599