### PR TITLE
Introduce types for Head Manager

### DIFF
--- a/packages/core/src/head.ts
+++ b/packages/core/src/head.ts
@@ -1,3 +1,4 @@
+import { HeadManager, HeadManagerOnUpdateCallback, HeadManagerTitleCallback } from '.'
 import debounce from './debounce'
 
 const Renderer = {
@@ -57,15 +58,9 @@ const Renderer = {
 
 export default function createHeadManager(
   isServer: boolean,
-  titleCallback: (title: string) => string,
-  onUpdate: (elements: string[]) => void,
-): {
-  forceUpdate: () => void
-  createProvider: () => {
-    update: (elements: string[]) => void
-    disconnect: () => void
-  }
-} {
+  titleCallback: HeadManagerTitleCallback,
+  onUpdate: HeadManagerOnUpdateCallback,
+): HeadManager {
   const states: Record<string, Array<string>> = {}
   let lastProviderId = 0
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -378,6 +378,17 @@ export type Component = unknown
 
 export type InertiaAppResponse = Promise<{ head: string[]; body: string } | void>
 
+export type HeadManagerTitleCallback = (title: string) => string
+export type HeadManagerOnUpdateCallback = (elements: string[]) => void
+export type HeadManager = {
+  forceUpdate: () => void
+  createProvider: () => {
+    reconnect: () => void
+    update: HeadManagerOnUpdateCallback
+    disconnect: () => void
+  }
+}
+
 export type LinkPrefetchOption = 'mount' | 'hover' | 'click'
 
 export type CacheForOption = number | string

--- a/packages/react/src/HeadContext.ts
+++ b/packages/react/src/HeadContext.ts
@@ -1,6 +1,7 @@
+import { HeadManager } from '@inertiajs/core'
 import { createContext } from 'react'
 
-const headContext = createContext(undefined)
+const headContext = createContext<HeadManager | null>(null)
 headContext.displayName = 'InertiaHeadContext'
 
 export default headContext

--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -1,13 +1,18 @@
-import { Page, PageProps, PageResolver, router, setupProgress } from '@inertiajs/core'
+import {
+  HeadManagerOnUpdateCallback,
+  HeadManagerTitleCallback,
+  Page,
+  PageProps,
+  PageResolver,
+  router,
+  setupProgress,
+} from '@inertiajs/core'
 import { ComponentType, FunctionComponent, Key, ReactElement, ReactNode, createElement } from 'react'
 import { renderToString } from 'react-dom/server'
 import App from './App'
 
 type ReactInstance = ReactElement
 type ReactComponent = ReactNode
-
-type HeadManagerOnUpdate = (elements: string[]) => void // TODO: When shipped, replace with: Inertia.HeadManagerOnUpdate
-type HeadManagerTitleCallback = (title: string) => string // TODO: When shipped, replace with: Inertia.HeadManagerTitleCallback
 
 type AppType<SharedProps extends PageProps = PageProps> = FunctionComponent<
   {
@@ -23,7 +28,7 @@ export type SetupOptions<ElementType, SharedProps extends PageProps> = {
     initialComponent: ReactComponent
     resolveComponent: PageResolver
     titleCallback?: HeadManagerTitleCallback
-    onHeadUpdate?: HeadManagerOnUpdate
+    onHeadUpdate?: HeadManagerOnUpdateCallback
   }
 }
 

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -1,4 +1,11 @@
-import { createHeadManager, Page, PageProps, router } from '@inertiajs/core'
+import {
+  createHeadManager,
+  HeadManagerOnUpdateCallback,
+  HeadManagerTitleCallback,
+  Page,
+  PageProps,
+  router,
+} from '@inertiajs/core'
 import {
   computed,
   DefineComponent,
@@ -19,8 +26,8 @@ export interface InertiaAppProps {
   initialPage: Page
   initialComponent?: object
   resolveComponent?: (name: string) => DefineComponent | Promise<DefineComponent>
-  titleCallback?: (title: string) => string
-  onHeadUpdate?: (elements: string[]) => void
+  titleCallback?: HeadManagerTitleCallback
+  onHeadUpdate?: HeadManagerOnUpdateCallback
 }
 
 export type InertiaApp = DefineComponent<InertiaAppProps>
@@ -47,12 +54,12 @@ const App: InertiaApp = defineComponent({
       required: false,
     },
     titleCallback: {
-      type: Function as PropType<(title: string) => string>,
+      type: Function as PropType<HeadManagerTitleCallback>,
       required: false,
       default: (title) => title,
     },
     onHeadUpdate: {
-      type: Function as PropType<(elements: string[]) => void>,
+      type: Function as PropType<HeadManagerOnUpdateCallback>,
       required: false,
       default: () => () => {},
     },

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -1,4 +1,4 @@
-import { Page, router, setupProgress } from '@inertiajs/core'
+import { HeadManagerTitleCallback, Page, router, setupProgress } from '@inertiajs/core'
 import { DefineComponent, Plugin, App as VueApp, createSSRApp, h } from 'vue'
 import App, { InertiaApp, InertiaAppProps, plugin } from './app'
 
@@ -6,7 +6,7 @@ interface CreateInertiaAppProps {
   id?: string
   resolve: (name: string) => DefineComponent | Promise<DefineComponent> | { default: DefineComponent }
   setup: (props: { el: Element; App: InertiaApp; props: InertiaAppProps; plugin: Plugin }) => void | VueApp
-  title?: (title: string) => string
+  title?: HeadManagerTitleCallback
   progress?:
     | false
     | {


### PR DESCRIPTION
TS cleanup for the Head Manager, resolving some todos by introducing shared `HeadManager`, `HeadManagerOnUpdateCallback`, and `HeadManagerTitleCallback` types.

This was originally planned in PR #2549, but I decided to split it up into multiple PRs for clarity.