### PR TITLE
Introduce `CancelToken` and `CancelTokenCallback` types to replace Axios imports

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -180,6 +180,12 @@ export type LocationVisit = {
   preserveScroll: boolean
 }
 
+export type CancelToken = {
+  cancel: VoidFunction
+}
+
+export type CancelTokenCallback = (cancelToken: CancelToken) => void
+
 export type Visit<T extends RequestPayload = RequestPayload> = {
   method: Method
   data: T
@@ -330,7 +336,7 @@ export type GlobalEventCallback<TEventName extends GlobalEventNames<T>, T extend
 export type InternalEvent = 'missingHistoryItem' | 'loadDeferredProps'
 
 export type VisitCallbacks<T extends RequestPayload = RequestPayload> = {
-  onCancelToken: { ({ cancel }: { cancel: VoidFunction }): void }
+  onCancelToken: CancelTokenCallback
   onBefore: GlobalEventCallback<'before', T>
   onBeforeUpdate: GlobalEventCallback<'beforeUpdate', T>
   onStart: GlobalEventCallback<'start', T>
@@ -420,9 +426,8 @@ export interface LinkComponentBaseProps
       | 'queryStringArrayFormat'
       | 'async'
     > &
-      Omit<VisitCallbacks, 'onCancelToken'> & {
+      VisitCallbacks & {
         href: string | UrlMethodPair
-        onCancelToken: (cancelToken: import('axios').CancelTokenSource) => void
         prefetch: boolean | LinkPrefetchOption | LinkPrefetchOption[]
         cacheFor: CacheForOption | CacheForOption[]
         cacheTags: string | string[]

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -1,4 +1,5 @@
 import {
+  CancelToken,
   ErrorValue,
   FormDataErrors,
   FormDataKeys,
@@ -70,7 +71,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
   const [defaults, setDefaults] = useState(
     (typeof rememberKeyOrInitialValues === 'string' ? maybeInitialValues : rememberKeyOrInitialValues) || ({} as TForm),
   )
-  const cancelToken = useRef(null)
+  const cancelToken = useRef<CancelToken | null>(null)
   const recentlySuccessfulTimeoutId = useRef(null)
   const [data, setData] = rememberKey ? useRemember(defaults, `${rememberKey}:data`) : useState(defaults)
   const [errors, setErrors] = rememberKey

--- a/packages/svelte/src/link.ts
+++ b/packages/svelte/src/link.ts
@@ -5,13 +5,13 @@ import {
   shouldIntercept,
   shouldNavigate,
   type CacheForOption,
+  type CancelToken,
   type GlobalEventsMap,
   type LinkComponentBaseProps,
   type LinkPrefetchOption,
   type Method,
   type VisitOptions,
 } from '@inertiajs/core'
-import type { CancelTokenSource } from 'axios'
 import type { ActionReturn } from 'svelte/action'
 
 type ActionEventHandlers = {
@@ -40,8 +40,8 @@ type ActionAttributes = {
     event: CustomEvent<SelectedGlobalEventsMap[K]['details']>,
   ) => void
 } & {
-  'on:cancel-token'?: (event: CustomEvent<CancelTokenSource>) => void
-  oncanceltoken?: (event: CustomEvent<CancelTokenSource>) => void
+  'on:cancel-token'?: (event: CustomEvent<CancelToken>) => void
+  oncanceltoken?: (event: CustomEvent<CancelToken>) => void
 }
 
 function link(

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -1,5 +1,6 @@
 import type {
   ActiveVisit,
+  CancelToken,
   Errors,
   ErrorValue,
   FormDataErrors,
@@ -70,7 +71,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
     ? (router.restore(rememberKey) as { data: TForm; errors: Record<FormDataKeys<TForm>, string> } | null)
     : null
   let defaults = cloneDeep(data)
-  let cancelToken: { cancel: () => void } | null = null
+  let cancelToken: CancelToken | null = null
   let recentlySuccessfulTimeoutId: ReturnType<typeof setTimeout> | null = null
   let transform = (data: TForm) => data as object
   // Track if defaults was called manually during onSuccess to avoid
@@ -169,7 +170,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
 
       const _options: Omit<VisitOptions, 'method'> = {
         ...options,
-        onCancelToken: (token: { cancel: () => void }) => {
+        onCancelToken: (token: CancelToken) => {
           cancelToken = token
 
           if (options.onCancelToken) {

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -1,6 +1,7 @@
 import {
   ActiveVisit,
   CacheForOption,
+  CancelTokenCallback,
   GlobalEventCallback,
   isUrlMethodPair,
   LinkComponentBaseProps,
@@ -115,7 +116,7 @@ const Link: InertiaLink = defineComponent({
       default: noop,
     },
     onCancelToken: {
-      type: Function as PropType<(cancelToken: import('axios').CancelTokenSource) => void>,
+      type: Function as PropType<CancelTokenCallback>,
       default: noop,
     },
     onPrefetching: {

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -1,4 +1,5 @@
 import {
+  CancelToken,
   ErrorValue,
   FormDataErrors,
   FormDataKeys,
@@ -59,7 +60,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
     ? (router.restore(rememberKey) as { data: TForm; errors: Record<FormDataKeys<TForm>, string> })
     : null
   let defaults = typeof data === 'function' ? cloneDeep(data()) : cloneDeep(data)
-  let cancelToken = null
+  let cancelToken: CancelToken | null = null
   let recentlySuccessfulTimeoutId = null
   let transform = (data) => data
 


### PR DESCRIPTION
This PR unifies the types around cancel tokens. Previously, we had a mixed bag of implementations.

```ts
import type { CancelTokenSource } from 'axios'

type VisitCallbacks = {
  // Core adapter...
  onCancelToken: { ({ cancel }: { cancel: VoidFunction }): void },

  // Svelte adapter...
  oncanceltoken?: (event: CustomEvent<CancelTokenSource>) => void
}

// Vue adapter...
defineProps({
  onCancelToken: {
    type: Function as PropType<(cancelToken: import('axios').CancelTokenSource) => void>,
  }
})
```

We now have unified internal types in the core package. These are used across all adapters without any dependency on Axios types.

This was originally planned in PR #2549, but I decided to split it up into multiple PRs for clarity.