### PR TITLE
Make `data` prop of `<InfiniteScroll>` required

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -601,7 +601,7 @@ export interface InfiniteScrollRef {
 }
 
 export interface InfiniteScrollComponentBaseProps {
-  data?: string
+  data: string
   buffer?: number
   as?: string
   manual?: boolean

--- a/packages/svelte/src/components/InfiniteScroll.svelte
+++ b/packages/svelte/src/components/InfiniteScroll.svelte
@@ -126,7 +126,7 @@
 
     infiniteScrollInstance = useInfiniteScroll({
       // Data
-      getPropName: () => data!,
+      getPropName: () => data,
       inReverseMode: () => reverse ?? false,
       shouldFetchNext: () => !onlyPrevious,
       shouldFetchPrevious: () => !onlyNext,


### PR DESCRIPTION
The `data` prop of the `<InfiniteScroll>` component is required to make it work.