### PR TITLE
TS fixes in Vue adapter for `useRemember` and `remember` mixin

### DIFF
--- a/packages/vue3/src/remember.ts
+++ b/packages/vue3/src/remember.ts
@@ -25,13 +25,13 @@ const remember: ComponentOptions = {
         ? this.$options.remember.key.call(this)
         : this.$options.remember.key
 
-    const restored = router.restore(rememberKey)
+    const restored = router.restore(rememberKey) as Record<string, unknown> | undefined
 
-    const rememberable = this.$options.remember.data.filter((key) => {
+    const rememberable = this.$options.remember.data.filter((key: string) => {
       return !(this[key] !== null && typeof this[key] === 'object' && this[key].__rememberable === false)
-    })
+    }) as string[]
 
-    const hasCallbacks = (key) => {
+    const hasCallbacks = (key: string) => {
       return (
         this[key] !== null &&
         typeof this[key] === 'object' &&
@@ -40,7 +40,7 @@ const remember: ComponentOptions = {
       )
     }
 
-    rememberable.forEach((key) => {
+    rememberable.forEach((key: string) => {
       if (this[key] !== undefined && restored !== undefined && restored[key] !== undefined) {
         hasCallbacks(key) ? this[key].__restore(restored[key]) : (this[key] = restored[key])
       }

--- a/packages/vue3/src/useRemember.ts
+++ b/packages/vue3/src/useRemember.ts
@@ -13,12 +13,12 @@ export default function useRemember<T extends object>(
   const restored = router.restore(key)
   const type = isReactive(data) ? reactive : ref
   const hasCallbacks = typeof data.__remember === 'function' && typeof data.__restore === 'function'
-  const remembered = type(restored === undefined ? data : hasCallbacks ? data.__restore(restored) : restored)
+  const remembered = type(restored === undefined ? data : hasCallbacks ? data.__restore!(restored) : restored)
 
   watch(
     remembered,
     (newValue) => {
-      router.remember(cloneDeep(hasCallbacks ? data.__remember() : newValue), key)
+      router.remember(cloneDeep(hasCallbacks ? data.__remember!() : newValue), key)
     },
     { immediate: true, deep: true },
   )


### PR DESCRIPTION
Adds missing types to the Vue adapter.

This was originally planned in PR #2549, but I decided to split it up into multiple PRs for clarity.