### PR TITLE
Switch `useContext` to `use` in `usePage()` hook

### DIFF
--- a/packages/react/src/usePage.ts
+++ b/packages/react/src/usePage.ts
@@ -3,7 +3,7 @@ import React from 'react'
 import PageContext from './PageContext'
 
 export default function usePage<TPageProps extends PageProps = PageProps>(): Page<TPageProps & SharedPageProps> {
-  // backwards compatibility for React <19
+  // React.use() was introduced in React 19, fallback to React.useContext() for earlier versions
   const page = typeof React.use === 'function' ? React.use(PageContext) : React.useContext(PageContext)
 
   if (!page) {


### PR DESCRIPTION
### Description
Changed context consumption in the `usePage()` hook from using React’s `useContext` to the new `use` API (added in React 19) as per the documentation here: [https://react.dev/reference/react/use#reading-context-with-use](https://react.dev/reference/react/use#reading-context-with-use) :
> `use` is preferred over `useContext` because it is more flexible.

This lets us call `usePage().props` from anywhere, even conditionally.
