### PR TITLE
fix(core): update history state after popstate to keep page data in sync

### DIFF
--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -100,8 +100,8 @@ class EventHandler {
           fireNavigateEvent(currentPage.get())
         })
 
-        const {url, ...pageWithoutUrl} = currentPage.get()
-        history.replaceState({...pageWithoutUrl} as Page)
+        const { url, ...pageWithoutUrl } = currentPage.get()
+        history.replaceState({ ...pageWithoutUrl } as Page)
       })
       .catch(() => {
         this.onMissingHistoryItem()


### PR DESCRIPTION
Fixes #2651 .

This fixes the issue where, after using the browser’s Back or Forward buttons, the page data inside the **[history class](https://github.com/inertiajs/inertia/blob/4e30447d10f60013de0006782b86a588ede72fd6/packages/core/src/history.ts)** was not being updated correctly (or as i think so).

I added a small change to update the history state using `replaceState` after a `popstate` event, it updates the page data but leaves the URL untouched (since the browser already updates that part in this popstate case).

```javascript
const { url, ...pageWithoutUrl } = currentPage.get()
history.replaceState({ ...pageWithoutUrl })
```

This fixed the problem in my testing.

### Note

I’m not sure **at all** if this change is completely safe or if it's even correct since I don’t have much experience with Inertia’s navigation internals, so I’d really appreciate feebdack on whether this change makes sense.