### PR TITLE
Export page component type for React adapter

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,6 +9,7 @@ export { default as Form } from './Form'
 export { default as Head } from './Head'
 export { default as InfiniteScroll } from './InfiniteScroll'
 export { InertiaLinkProps, default as Link } from './Link'
+export { ReactComponent as ResolvedComponent } from './types'
 export {
   InertiaFormProps,
   SetDataAction,

--- a/packages/react/test-app/app.tsx
+++ b/packages/react/test-app/app.tsx
@@ -1,5 +1,5 @@
 import type { VisitOptions } from '@inertiajs/core'
-import { createInertiaApp, router } from '@inertiajs/react'
+import { type ResolvedComponent, createInertiaApp, router } from '@inertiajs/react'
 import { createRoot } from 'react-dom/client'
 
 window.testing = { Inertia: router }
@@ -9,7 +9,7 @@ const withAppDefaults = new URLSearchParams(window.location.search).get('withApp
 createInertiaApp({
   page: window.initialPage,
   resolve: async (name) => {
-    const pages = import.meta.glob('./Pages/**/*.tsx', { eager: true })
+    const pages = import.meta.glob<ResolvedComponent>('./Pages/**/*.tsx', { eager: true })
     // const typedPages = import.meta.glob<ComponentType>('./Pages/**/*.tsx', { eager: true })
 
     if (name === 'DeferredProps/InstantReload') {

--- a/playgrounds/react/resources/js/app.tsx
+++ b/playgrounds/react/resources/js/app.tsx
@@ -1,10 +1,10 @@
-import { createInertiaApp } from '@inertiajs/react'
+import { type ResolvedComponent, createInertiaApp } from '@inertiajs/react'
 import { hydrateRoot } from 'react-dom/client'
 
 createInertiaApp({
   title: (title) => `${title} - React Playground`,
   resolve: (name) => {
-    const pages = import.meta.glob('./Pages/**/*.tsx', { eager: true })
+    const pages = import.meta.glob<ResolvedComponent>('./Pages/**/*.tsx', { eager: true })
     return pages[`./Pages/${name}.tsx`]
   },
   setup({ el, App, props }) {

--- a/playgrounds/react/resources/js/ssr.tsx
+++ b/playgrounds/react/resources/js/ssr.tsx
@@ -1,4 +1,4 @@
-import { createInertiaApp } from '@inertiajs/react'
+import { type ResolvedComponent, createInertiaApp } from '@inertiajs/react'
 import createServer from '@inertiajs/react/server'
 import * as ReactDOMServer from 'react-dom/server'
 
@@ -8,7 +8,7 @@ createServer((page) =>
     render: ReactDOMServer.renderToString,
     title: (title) => `${title} - React Playground`,
     resolve: (name) => {
-      const pages = import.meta.glob('./Pages/**/*.tsx', { eager: true })
+      const pages = import.meta.glob<ResolvedComponent>('./Pages/**/*.tsx', { eager: true })
       return pages[`./Pages/${name}.tsx`]
     },
     setup: ({ App, props }) => <App {...props} />,


### PR DESCRIPTION
This PR exports the page component type for use with `import.meta.glob` and default layouts.

Note: I've used `ResolvedComponent` to align with the Svelte adapter.