### PR TITLE
Ignore `preserveScroll` and `preserveState` when finding cached response

### DIFF
--- a/packages/core/src/prefetched.ts
+++ b/packages/core/src/prefetched.ts
@@ -240,6 +240,8 @@ class PrefetchedRequests {
         'showProgress',
         'replace',
         'prefetch',
+        'preserveScroll',
+        'preserveState',
         'onBefore',
         'onBeforeUpdate',
         'onStart',

--- a/packages/react/test-app/Pages/Prefetch/PreserveState.tsx
+++ b/packages/react/test-app/Pages/Prefetch/PreserveState.tsx
@@ -1,0 +1,29 @@
+import { router } from '@inertiajs/react'
+
+export default ({ page, timestamp }: { page: number; timestamp: number }) => {
+  const prefetchPage2 = () => {
+    router.prefetch('/prefetch/preserve-state', { method: 'get', data: { page: 2 } }, { cacheFor: '30s' })
+  }
+
+  const loadPage2WithoutPreserveState = () => {
+    router.get('/prefetch/preserve-state', { page: 2 }, { preserveState: false })
+  }
+
+  const loadPage2WithPreserveState = () => {
+    router.get('/prefetch/preserve-state', { page: 2 }, { preserveState: true })
+  }
+
+  return (
+    <div>
+      <div>Current Page: {page}</div>
+      <div>Timestamp: {timestamp}</div>
+
+      <h3>Prefetch:</h3>
+      <button onClick={prefetchPage2}>Prefetch Page 2</button>
+
+      <h3>Load (should use cache if prefetched):</h3>
+      <button onClick={loadPage2WithoutPreserveState}>Load Page 2 (preserveState: false)</button>
+      <button onClick={loadPage2WithPreserveState}>Load Page 2 (preserveState: true)</button>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/Prefetch/PreserveState.svelte
+++ b/packages/svelte/test-app/Pages/Prefetch/PreserveState.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { router } from '@inertiajs/svelte'
+
+  export let page: number
+  export let timestamp: number
+
+  const prefetchPage2 = () => {
+    router.prefetch('/prefetch/preserve-state', { method: 'get', data: { page: 2 } }, { cacheFor: '30s' })
+  }
+
+  const loadPage2WithoutPreserveState = () => {
+    router.get('/prefetch/preserve-state', { page: 2 }, { preserveState: false })
+  }
+
+  const loadPage2WithPreserveState = () => {
+    router.get('/prefetch/preserve-state', { page: 2 }, { preserveState: true })
+  }
+</script>
+
+<div>
+  <div>Current Page: {page}</div>
+  <div>Timestamp: {timestamp}</div>
+
+  <h3>Prefetch:</h3>
+  <button on:click={prefetchPage2}>Prefetch Page 2</button>
+
+  <h3>Load (should use cache if prefetched):</h3>
+  <button on:click={loadPage2WithoutPreserveState}>Load Page 2 (preserveState: false)</button>
+  <button on:click={loadPage2WithPreserveState}>Load Page 2 (preserveState: true)</button>
+</div>

--- a/packages/vue3/test-app/Pages/Prefetch/PreserveState.vue
+++ b/packages/vue3/test-app/Pages/Prefetch/PreserveState.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3'
+
+defineProps<{
+  page: number
+  timestamp: number
+}>()
+
+const prefetchPage2 = () => {
+  router.prefetch('/prefetch/preserve-state', { method: 'get', data: { page: 2 } }, { cacheFor: '30s' })
+}
+
+const loadPage2WithoutPreserveState = () => {
+  router.get('/prefetch/preserve-state', { page: 2 }, { preserveState: false })
+}
+
+const loadPage2WithPreserveState = () => {
+  router.get('/prefetch/preserve-state', { page: 2 }, { preserveState: true })
+}
+</script>
+
+<template>
+  <div>
+    <div>Current Page: {{ page }}</div>
+    <div>Timestamp: {{ timestamp }}</div>
+
+    <h3>Prefetch:</h3>
+    <button @click="prefetchPage2">Prefetch Page 2</button>
+
+    <h3>Load (should use cache if prefetched):</h3>
+    <button @click="loadPage2WithoutPreserveState">Load Page 2 (preserveState: false)</button>
+    <button @click="loadPage2WithPreserveState">Load Page 2 (preserveState: true)</button>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -357,6 +357,16 @@ app.get('/prefetch/wayfinder', (req, res) => {
   })
 })
 
+app.get('/prefetch/preserve-state', (req, res) => {
+  inertia.render(req, res, {
+    component: 'Prefetch/PreserveState',
+    props: {
+      page: parseInt(req.query.page || '1'),
+      timestamp: Date.now(),
+    },
+  })
+})
+
 app.get('/prefetch/:pageNumber', (req, res) => {
   inertia.render(req, res, {
     component: 'Prefetch/Page',

--- a/tests/prefetch.spec.ts
+++ b/tests/prefetch.spec.ts
@@ -615,3 +615,30 @@ test.describe('tags', () => {
     })
   })
 })
+
+test('can use prefetched requests with preserveState', async ({ page }) => {
+  await page.goto('/prefetch/preserve-state')
+
+  const prefetchResponse = page.waitForResponse('prefetch/preserve-state?page=2')
+  await page.getByRole('button', { name: 'Prefetch Page 2' }).click()
+  await prefetchResponse
+
+  requests.listen(page)
+
+  // Test both preserveState options use cache
+  await page.getByRole('button', { name: 'Load Page 2 (preserveState: false)' }).click()
+  await expect(page.getByText('Current Page: 2')).toBeVisible()
+  await expect(requests.requests.length).toBe(0)
+
+  await page.goto('/prefetch/preserve-state')
+
+  const prefetchResponse2 = page.waitForResponse('prefetch/preserve-state?page=2')
+  await page.getByRole('button', { name: 'Prefetch Page 2' }).click()
+  await prefetchResponse2
+
+  requests.listen(page)
+
+  await page.getByRole('button', { name: 'Load Page 2 (preserveState: true)' }).click()
+  await expect(page.getByText('Current Page: 2')).toBeVisible()
+  await expect(requests.requests.length).toBe(0)
+})


### PR DESCRIPTION
Fixes #2267.