### PR TITLE
fix(core): Fix issue where anchor scroll randomly doesn't work when React page loads

### DIFF
--- a/packages/core/src/scroll.ts
+++ b/packages/core/src/scroll.ts
@@ -35,11 +35,12 @@ export class Scroll {
     this.save()
 
     if (anchorHash) {
-      // We're using a setTimeout() here as a workaround for a bug in the React adapter where the
-      // rendering isn't completing fast enough, causing the anchor link to not be scrolled to.
-      setTimeout(() => {
-        const anchorElement = document.getElementById(anchorHash.slice(1))
-        anchorElement ? anchorElement.scrollIntoView() : window.scrollTo(0, 0)
+      // Using double requestAnimationFrame to wait for the browser to complete the current render cycle
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          const anchorElement = document.getElementById(anchorHash.slice(1))
+          anchorElement ? anchorElement.scrollIntoView() : window.scrollTo(0, 0)
+        })
       })
     }
   }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Problem

When navigating to a (React) page with an anchor ID, sometimes the anchor scroll doesn't work and the scroll position stays at the top of the page.

It seems like the scroll util isn't catching the anchor element in those cases because the React page hasn't fully rendered yet. I noticed there a check for the anchor element in a non-blocking thread using setTimeout, but it's still not quite consistent.

## Solution

My attempt instead wraps the anchor check in a double requestAnimationFrame to wait for next render cycle before checking for the anchor element.
