### PR TITLE
fix(react): Use flushSync for View Transitions API compatibility

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -59,6 +59,7 @@
     "esbuild": "^0.25.12",
     "esbuild-node-externals": "^1.19.1",
     "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -8,6 +8,7 @@ import {
   router,
 } from '@inertiajs/core'
 import { createElement, FunctionComponent, ReactNode, useEffect, useMemo, useState } from 'react'
+import ReactDOM from 'react-dom'
 import HeadContext from './HeadContext'
 import PageContext from './PageContext'
 import { LayoutFunction, ReactComponent, ReactPageHandlerArgs } from './types'
@@ -79,11 +80,21 @@ export default function App<SharedProps extends PageProps = PageProps>({
         return
       }
 
-      setCurrent((current) => ({
-        component,
-        page,
-        key: preserveState ? current.key : Date.now(),
-      }))
+      if ((ReactDOM as any).flushSync) {
+        (ReactDOM as any).flushSync(() => {
+          setCurrent((current) => ({
+            component,
+            page,
+            key: preserveState ? current.key : Date.now(),
+          }))
+        })
+      } else {
+        setCurrent((current) => ({
+          component,
+          page,
+          key: preserveState ? current.key : Date.now(),
+        }))
+      }
     }
 
     router.on('navigate', () => headManager.forceUpdate())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       react:
         specifier: ^19.2.0
         version: 19.2.0
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.0(react@19.2.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
Apologies in advance if there is anything wrong with this PR as it is my first one.

This fixes view transitions not working properly with React 19's concurrent rendering.

The issue is that React 19's concurrent rendering makes setState updates asynchronous by default. This breaks the View Transitions API timing since it captures snapshots before React has actually updated the DOM. When elements with `view-transition-name` unmount (like page content during navigation), those named elements need to be in the DOM when the "after" snapshot is captured, otherwise the View Transitions API can't match them up and the entire transition fails.

What ends up happening is:

1. View Transition API takes the "before" snapshot (captures elements with `view-transition-name`)
2. `setCurrent()` gets called to switch pages
3. View Transition API takes the "after" snapshot
4. Problem: React hasn't actually unmounted the old page content yet, so both snapshots show the same elements with the same `view-transition-name` values
5. Both snapshots are identical so there's no transition to animate
6. React updates the DOM 10-20ms later which is too late for the transition

The fix wraps `setCurrent()` in `flushSync()` which forces React to update the DOM synchronously during navigation. This ensures the old page content with its `view-transition-name` elements is unmounted and the new page content with its `view-transition-name` elements is mounted before the "after" snapshot is taken. This way the View Transitions API can properly match up the named elements and animate between them.

**Changes made:**
- Added `flushSync` import from `react-dom`
- Wrapped `setCurrent()` in the navigation handler with `flushSync()`
- Updated lockfile for the react-dom dependency

**Testing:**

I've tested this fairly extensively with different view transition setups to understand what works before and after the patch:

**Case 1 - Basic transitions (default fade):**
- Before patch: Works (no view-transition-names set on any elements)
- After patch: Works

**Case 2 - Page-level transitions (view-transition-names on page content):**
- Before patch: Broken - entire transition fails when navigating from pages with view-transition-names, just instant page change with no animation
- After patch: Works - card expansions, shared element transitions all animate properly

**Case 3 - Layout-level transitions (view-transition-names on persistent layout elements like header/sidebar):**
- Before patch: Works (layout doesn't unmount so timing isn't affected)
- After patch: Works

**Case 4 - Mixed transitions (view-transition-names on both layout AND page content with custom animations like morph, slide, flip, scale):**
- Before patch: Broken - entire transition system fails when navigating from pages with view-transition-names on content, no animations run at all
- After patch: Works - all custom animations (morph, slide, flip, scale) work correctly

**Case 5 - Layout changes (navigating between pages with different layouts):**
- Before patch: Works
- After patch: Works

I ran the test suite on all adapters even though this is just a fix for the react adapter as per contributing.md with these changes not affecting any existing tests.

The key pattern is that the bug triggers when navigating from pages that have view-transition-names on content that unmounts. Without `flushSync` the entire transition fails.

**Performance impact:**

This only affects navigation updates, not the entire app state. There's a minor trade-off in that navigation updates are now synchronous rather than concurrent, but this seems reasonable given navigation updates are relatively infrequent, they're already meant to be user-blocking (you're changing pages), `flushSync()` is the official React API designed for this exact use case, and the alternative is completely broken view transitions.

The reason this is necessary is that the View Transitions API fundamentally requires synchronous DOM updates to work correctly. It needs to capture accurate before/after snapshots at specific points in time. React 19's concurrent rendering is designed to batch and defer updates for performance which conflicts with this requirement.

According to the [React documentation on `flushSync`](https://react.dev/reference/react-dom/flushSync), "when integrating with third-party code such as browser APIs or UI libraries, it may be necessary to force React to flush updates." The View Transitions API is exactly this type of browser API that requires synchronous DOM updates to function correctly.

https://github.com/user-attachments/assets/dfa3d122-0ce6-4f0c-96d8-23d28ddf0858

https://github.com/user-attachments/assets/31cd0709-7c31-4a94-a691-08ca16bb4216