### PR TITLE
React: fix layout shortcut

### DIFF
--- a/packages/react/test-app/Pages/PersistentLayouts/Shorthand/Nested/PageA.tsx
+++ b/packages/react/test-app/Pages/PersistentLayouts/Shorthand/Nested/PageA.tsx
@@ -13,12 +13,6 @@ const PageA = () => {
   )
 }
 
-PageA.layout = (page: React.ReactNode) => {
-  return (
-    <SiteLayout>
-      <NestedLayout children={page} />
-    </SiteLayout>
-  )
-}
+PageA.layout = [SiteLayout, NestedLayout]
 
 export default PageA

--- a/packages/react/test-app/Pages/PersistentLayouts/Shorthand/Nested/PageB.tsx
+++ b/packages/react/test-app/Pages/PersistentLayouts/Shorthand/Nested/PageB.tsx
@@ -13,12 +13,6 @@ const PageB = () => {
   )
 }
 
-PageB.layout = (page: React.ReactNode) => {
-  return (
-    <SiteLayout>
-      <NestedLayout children={page} />
-    </SiteLayout>
-  )
-}
+PageB.layout = [SiteLayout, NestedLayout]
 
 export default PageB

--- a/packages/react/test-app/Pages/PersistentLayouts/Shorthand/Simple/PageA.tsx
+++ b/packages/react/test-app/Pages/PersistentLayouts/Shorthand/Simple/PageA.tsx
@@ -12,6 +12,6 @@ const PageA = () => {
   )
 }
 
-PageA.layout = (page: React.ReactNode) => <SiteLayout children={page} />
+PageA.layout = SiteLayout
 
 export default PageA

--- a/packages/react/test-app/Pages/PersistentLayouts/Shorthand/Simple/PageB.tsx
+++ b/packages/react/test-app/Pages/PersistentLayouts/Shorthand/Simple/PageB.tsx
@@ -12,6 +12,6 @@ const PageB = () => {
   )
 }
 
-PageB.layout = (page: React.ReactNode) => <SiteLayout children={page} />
+PageB.layout = SiteLayout
 
 export default PageB


### PR DESCRIPTION
This PR adds tests for layout shortcuts in React adapter and also fixes the `Component.layout = MyLayout` shortcut (don't like the `try`/`catch` as a fix, but I don't think there's a better solution for functional components).

Note: both svelte and vue adapters already support and test the shortcuts.