### PR TITLE
Refactor duplicated initial page code

### DIFF
--- a/packages/core/src/domUtils.ts
+++ b/packages/core/src/domUtils.ts
@@ -124,3 +124,25 @@ export const requestAnimationFrame = (cb: () => void, times: number = 1): void =
     }
   })
 }
+
+export const getInitialPageFromDOM = <T>(id: string, useScriptElement: boolean = false): T | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  if (!useScriptElement) {
+    const el = document.getElementById(id)
+
+    if (el?.dataset.page) {
+      return JSON.parse(el.dataset.page)
+    }
+  }
+
+  const scriptEl = document.querySelector(`script[data-page="${id}"][type="application/json"]`)
+
+  if (scriptEl?.textContent) {
+    return JSON.parse(scriptEl.textContent)
+  }
+
+  return null
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@ import { Config } from './config'
 import { Router } from './router'
 
 export { config } from './config'
-export { getScrollableParent } from './domUtils'
+export { getInitialPageFromDOM, getScrollableParent } from './domUtils'
 export { objectToFormData } from './formData'
 export { formDataToObject } from './formObject'
 export { default as createHeadManager } from './head'

--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -1,13 +1,15 @@
 import {
   CreateInertiaAppOptionsForCSR,
   CreateInertiaAppOptionsForSSR,
+  getInitialPageFromDOM,
   InertiaAppResponse,
   InertiaAppSSRResponse,
+  Page,
   PageProps,
   router,
   setupProgress,
 } from '@inertiajs/core'
-import { Fragment, ReactElement, createElement } from 'react'
+import { createElement, Fragment, ReactElement } from 'react'
 import { renderToString } from 'react-dom/server'
 import App, { InertiaAppProps, type InertiaApp } from './App'
 import { config } from './index'
@@ -62,12 +64,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   const isServer = typeof window === 'undefined'
   const useScriptElementForInitialPage = config.get('future.useScriptElementForInitialPage')
-  const el = isServer ? null : document.getElementById(id)
-  const elPage =
-    isServer || !useScriptElementForInitialPage
-      ? null
-      : document.querySelector(`script[data-page="${id}"][type="application/json"]`)
-  const initialPage = page || JSON.parse(elPage?.textContent || el?.dataset.page || '{}')
+  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useScriptElementForInitialPage)!
 
   // @ts-expect-error - This can be improved once we remove the 'unknown' type from the resolver...
   const resolveComponent = (name) => Promise.resolve(resolve(name)).then((module) => module.default || module)
@@ -98,7 +95,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     const csrSetup = setup as (options: SetupOptions<HTMLElement, SharedProps>) => void
 
     return csrSetup({
-      el: el as HTMLElement,
+      el: document.getElementById(id)!,
       App,
       props,
     })

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -1,8 +1,10 @@
 import {
+  getInitialPageFromDOM,
   router,
   setupProgress,
   type CreateInertiaAppOptionsForCSR,
   type InertiaAppResponse,
+  type Page,
   type PageProps,
 } from '@inertiajs/core'
 import { escape } from 'lodash-es'
@@ -40,12 +42,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   const isServer = typeof window === 'undefined'
   const useScriptElementForInitialPage = config.get('future.useScriptElementForInitialPage')
-  const el = isServer ? null : document.getElementById(id)
-  const elPage =
-    isServer || !useScriptElementForInitialPage
-      ? null
-      : document.querySelector(`script[data-page="${id}"][type="application/json"]`)
-  const initialPage = page || JSON.parse(elPage?.textContent || el?.dataset.page || '{}')
+  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useScriptElementForInitialPage)!
 
   const resolveComponent = (name: string) => Promise.resolve(resolve(name))
 
@@ -54,7 +51,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     router.decryptHistory().catch(() => {}),
   ]).then(([initialComponent]) => {
     return setup({
-      el,
+      el: isServer ? null : document.getElementById(id),
       App,
       props: { initialPage, initialComponent, resolveComponent },
     })

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -1,8 +1,10 @@
 import {
   CreateInertiaAppOptionsForCSR,
   CreateInertiaAppOptionsForSSR,
+  getInitialPageFromDOM,
   InertiaAppResponse,
   InertiaAppSSRResponse,
+  Page,
   PageProps,
   router,
   setupProgress,
@@ -60,12 +62,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   const isServer = typeof window === 'undefined'
   const useScriptElementForInitialPage = config.get('future.useScriptElementForInitialPage')
-  const el = isServer ? null : document.getElementById(id)
-  const elPage =
-    isServer || !useScriptElementForInitialPage
-      ? null
-      : document.querySelector(`script[data-page="${id}"][type="application/json"]`)
-  const initialPage = page || JSON.parse(elPage?.textContent || el?.dataset.page || '{}')
+  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useScriptElementForInitialPage)!
 
   const resolveComponent = (name: string) => Promise.resolve(resolve(name)).then((module) => module.default || module)
 
@@ -96,7 +93,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     const csrSetup = setup as (options: SetupOptions<HTMLElement, SharedProps>) => void
 
     return csrSetup({
-      el: el as HTMLElement,
+      el: document.getElementById(id)!,
       App,
       props,
       plugin,


### PR DESCRIPTION
This PR extracts the initial page data retrieval logic into a shared `getInitialPageFromDOM()` utility, reducing duplication across the adapters. 

It handles both the traditional `data-page` attribute and the newer `<script type="application/json">` approach (introduced in #2687). There's also improved compatibility if somebody only updates the config server-side.