### PR TITLE
bugfix(whenVisible-vue): Fix loaded state when data already exists

### DIFF
--- a/packages/react/test-app/Pages/WhenVisibleBackButton.tsx
+++ b/packages/react/test-app/Pages/WhenVisibleBackButton.tsx
@@ -1,0 +1,29 @@
+import { Link, WhenVisible } from '@inertiajs/react'
+
+export default ({
+  lazyData,
+}: {
+  lazyData?: {
+    text: string
+  }
+}) => {
+  return (
+    <div>
+      <h1>WhenVisible + Back Button</h1>
+
+      <Link href="/links/method">Navigate Away</Link>
+
+      <div style={{ marginTop: '2000px', padding: '20px', border: '1px solid #ccc' }}>
+        <WhenVisible data="lazyData" fallback={<p>Loading lazy data...</p>}>
+          <p>{lazyData?.text}</p>
+        </WhenVisible>
+      </div>
+
+      <div style={{ marginTop: '2000px', padding: '20px', border: '1px solid #ccc' }}>
+        <WhenVisible data="lazyData" always fallback={<p>Loading always data...</p>}>
+          <p>Always: {lazyData?.text}</p>
+        </WhenVisible>
+      </div>
+    </div>
+  )
+}

--- a/packages/svelte/src/components/WhenVisible.svelte
+++ b/packages/svelte/src/components/WhenVisible.svelte
@@ -15,20 +15,10 @@
   let observer: IntersectionObserver | null = null
 
   const page = usePage()
+  $: keys = data ? (Array.isArray(data) ? data : [data]) : []
+  $: loaded = keys.length > 0 && keys.every((key) => $page.props[key] !== undefined)
 
-  // Watch for page prop changes and reset loaded state when data becomes undefined
-  $: {
-    if (Array.isArray(data)) {
-      // For arrays, reset loaded if any prop becomes undefined
-      if (data.some((key) => $page.props[key] === undefined)) {
-        loaded = false
-      }
-    } else if ($page.props[data as string] === undefined) {
-      loaded = false
-    }
-  }
-
-  $: if (el) {
+  $: if (el && (!loaded || always)) {
     registerObserver()
   }
 

--- a/packages/svelte/test-app/Pages/WhenVisibleBackButton.svelte
+++ b/packages/svelte/test-app/Pages/WhenVisibleBackButton.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { Link, WhenVisible } from '@inertiajs/svelte'
+
+  export let lazyData:
+    | {
+        text: string
+      }
+    | undefined = undefined
+</script>
+
+<div>
+  <h1>WhenVisible + Back Button</h1>
+
+  <Link href="/links/method">Navigate Away</Link>
+
+  <div style="margin-top: 2000px; padding: 20px; border: 1px solid #ccc">
+    <WhenVisible data="lazyData">
+      <svelte:fragment slot="fallback">
+        <p>Loading lazy data...</p>
+      </svelte:fragment>
+
+      <p>{lazyData?.text}</p>
+    </WhenVisible>
+  </div>
+
+  <div style="margin-top: 2000px; padding: 20px; border: 1px solid #ccc">
+    <WhenVisible data="lazyData" always>
+      <svelte:fragment slot="fallback">
+        <p>Loading always data...</p>
+      </svelte:fragment>
+
+      <p>Always: {lazyData?.text}</p>
+    </WhenVisible>
+  </div>
+</div>

--- a/packages/vue3/src/whenVisible.ts
+++ b/packages/vue3/src/whenVisible.ts
@@ -34,27 +34,24 @@ export default defineComponent({
   unmounted() {
     this.observer?.disconnect()
   },
+  computed: {
+    keys(): string[] {
+      return this.data ? ((Array.isArray(this.data) ? this.data : [this.data]) as string[]) : []
+    },
+  },
   created() {
     const page = usePage()
 
     this.$watch(
+      () => this.keys.map((key) => page.props[key]),
       () => {
-        return Array.isArray(this.data)
-          ? this.data.map((data) => page.props[data as string])
-          : page.props[this.data as string]
-      },
-      (value) => {
-        if (Array.isArray(this.data)) {
-          if (this.data.every((data) => page.props[data as string] !== undefined)) {
-            this.loaded = true
-            return
-          }
-        } else if (value !== undefined) {
-          this.loaded = true
+        const exists = this.keys.length > 0 && this.keys.every((key) => page.props[key] !== undefined)
+        this.loaded = exists
+
+        if (exists && !this.always) {
           return
         }
 
-        this.loaded = false
         this.$nextTick(this.registerObserver)
       },
       { immediate: true },

--- a/packages/vue3/test-app/Pages/WhenVisibleBackButton.vue
+++ b/packages/vue3/test-app/Pages/WhenVisibleBackButton.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Link, WhenVisible } from '@inertiajs/vue3'
+
+defineProps<{
+  lazyData?: {
+    text: string
+  }
+}>()
+</script>
+
+<template>
+  <div>
+    <h1>WhenVisible + Back Button</h1>
+
+    <Link href="/links/method">Navigate Away</Link>
+
+    <div style="margin-top: 2000px; padding: 20px; border: 1px solid #ccc">
+      <WhenVisible data="lazyData">
+        <template #fallback>
+          <p>Loading lazy data...</p>
+        </template>
+
+        <p>{{ lazyData?.text }}</p>
+      </WhenVisible>
+    </div>
+
+    <div style="margin-top: 2000px; padding: 20px; border: 1px solid #ccc">
+      <WhenVisible data="lazyData" always>
+        <template #fallback>
+          <p>Loading always data...</p>
+        </template>
+
+        <p>Always: {{ lazyData?.text }}</p>
+      </WhenVisible>
+    </div>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -695,6 +695,29 @@ app.get('/when-visible-array-reload', (req, res) => {
   }
 })
 
+app.get('/when-visible-back-button', (req, res) => {
+  const page = () =>
+    inertia.render(req, res, {
+      component: 'WhenVisibleBackButton',
+      props: {},
+    })
+
+  if (req.headers['x-inertia-partial-data']) {
+    setTimeout(() => {
+      inertia.render(req, res, {
+        component: 'WhenVisibleBackButton',
+        props: {
+          lazyData: {
+            text: 'This is lazy loaded data!',
+          },
+        },
+      })
+    }, 250)
+  } else {
+    page()
+  }
+})
+
 app.get('/progress/:pageNumber', (req, res) => {
   setTimeout(
     () =>


### PR DESCRIPTION
When the data already exists, there is nothing that either triggers the re-loading or marks the data as loaded already.

This bugfix resolves this issue by setting the loaded value to true when the data already exists.

I am currently experiencing this issue when the data already exists in history and the back button is used for navigation.