### PR TITLE
Escape forward slashes when using useScriptElementForInitialPage

### DIFF
--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -124,7 +124,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
         createElement('script', {
           'data-page': id,
           type: 'application/json',
-          dangerouslySetInnerHTML: { __html: JSON.stringify(initialPage) },
+          dangerouslySetInnerHTML: { __html: JSON.stringify(initialPage).replace(/\//g, '\\/') },
         }),
         createElement('div', { id }, reactApp as ReactElement),
       )

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -62,7 +62,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
     return {
       body: useScriptElementForInitialPage
-        ? `<script data-page="${id}" type="application/json">${JSON.stringify(initialPage)}</script><div data-server-rendered="true" id="${id}">${html}</div>`
+        ? `<script data-page="${id}" type="application/json">${JSON.stringify(initialPage).replace(/\//g, '\\/')}</script><div data-server-rendered="true" id="${id}">${html}</div>`
         : `<div data-server-rendered="true" id="${id}" data-page="${escape(JSON.stringify(initialPage))}">${html}</div>`,
       head: [head, css ? `<style data-vite-css>${css.code}</style>` : ''],
     }

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -118,7 +118,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
         h('script', {
           'data-page': id,
           type: 'application/json',
-          innerHTML: JSON.stringify(initialPage),
+          innerHTML: JSON.stringify(initialPage).replace(/\//g, '\\/'),
         }),
         h('div', {
           id,

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -49,7 +49,7 @@ app.get('/ssr/page-with-script-element', (req, res) =>
   inertia.renderSSR(req, res, {
     component: 'SSR/PageWithScriptElement',
     props: {
-      message: 'Hello from script element!',
+      message: 'Hello from script element! Escape </script>.',
     },
   }),
 )

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -38,14 +38,14 @@ test.describe('SSR', () => {
 
     expect(html).toContain('data-page="app"')
     expect(html).toContain('<script data-page="app" type="application/json">')
-    expect(html).toContain('Hello from script element!')
+    expect(html).toContain('Hello from script element! Escape <\\/script>.')
 
     await page.goto('/ssr/page-with-script-element')
     const scriptContent = await page.locator('script[data-page="app"]').textContent()
     expect(JSON.parse(scriptContent || '')).toMatchObject({
       component: 'SSR/PageWithScriptElement',
       props: {
-        message: 'Hello from script element!',
+        message: 'Hello from script element! Escape </script>.',
       },
     })
   })


### PR DESCRIPTION
Followup of #2687.

Prevents the HTML parser from prematurely closing the script element when `</script>` is in a prop value.