### PR TITLE
Test for loading deferred props on `router.reload()` without `only`/`except`

### DIFF
--- a/packages/react/test-app/Pages/DeferredProps/WithReload.tsx
+++ b/packages/react/test-app/Pages/DeferredProps/WithReload.tsx
@@ -1,0 +1,30 @@
+import { Deferred, router, usePage } from '@inertiajs/react'
+
+const Results = () => {
+  const { results } = usePage<{ results?: { data: string[]; page: number } }>().props
+
+  return (
+    <>
+      <div id="results-data">{results?.data?.join(', ')}</div>
+      <div id="results-page">Page: {results?.page}</div>
+    </>
+  )
+}
+
+export default () => {
+  const handleReload = () => {
+    router.reload({
+      data: { page: 2 },
+    })
+  }
+
+  return (
+    <>
+      <Deferred data="results" fallback={<div>Loading results...</div>}>
+        <Results />
+      </Deferred>
+
+      <button onClick={handleReload}>Reload with page 2</button>
+    </>
+  )
+}

--- a/packages/svelte/test-app/Pages/DeferredProps/WithReload.svelte
+++ b/packages/svelte/test-app/Pages/DeferredProps/WithReload.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { Deferred, router } from '@inertiajs/svelte'
+
+  export let results
+
+  const handleReload = () => {
+    router.reload({
+      data: { page: 2 },
+    })
+  }
+</script>
+
+<Deferred data="results">
+  <svelte:fragment slot="fallback">
+    <div>Loading results...</div>
+  </svelte:fragment>
+  <div id="results-data">{results?.data?.join(', ')}</div>
+  <div id="results-page">Page: {results?.page}</div>
+</Deferred>
+
+<button on:click={handleReload}>Reload with page 2</button>

--- a/packages/vue3/test-app/Pages/DeferredProps/WithReload.vue
+++ b/packages/vue3/test-app/Pages/DeferredProps/WithReload.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Deferred, router } from '@inertiajs/vue3'
+
+defineProps<{
+  results?: { data: string[]; page: number }
+}>()
+
+const handleReload = () => {
+  router.reload({
+    data: { page: 2 },
+  })
+}
+</script>
+
+<template>
+  <Deferred data="results">
+    <template #fallback>
+      <div>Loading results...</div>
+    </template>
+    <div id="results-data">{{ results?.data?.join(', ') }}</div>
+    <div id="results-page">Page: {{ results?.page }}</div>
+  </Deferred>
+
+  <button @click="handleReload">Reload with page 2</button>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -1185,6 +1185,35 @@ app.post('/deferred-props/with-errors', (req, res) => {
   res.redirect(303, '/deferred-props/with-errors')
 })
 
+app.get('/deferred-props/with-reload', (req, res) => {
+  const page = parseInt(req.query.page) || 1
+
+  if (!req.headers['x-inertia-partial-data']) {
+    return inertia.render(req, res, {
+      component: 'DeferredProps/WithReload',
+      url: req.originalUrl,
+      deferredProps: {
+        default: ['results'],
+      },
+      props: {},
+    })
+  }
+
+  setTimeout(
+    () =>
+      inertia.render(req, res, {
+        component: 'DeferredProps/WithReload',
+        url: req.originalUrl,
+        props: {
+          results: req.headers['x-inertia-partial-data']?.includes('results')
+            ? { data: [`Item ${page}-1`, `Item ${page}-2`, `Item ${page}-3`], page }
+            : undefined,
+        },
+      }),
+    300,
+  )
+})
+
 app.get('/svelte/props-and-page-store', (req, res) =>
   inertia.render(req, res, { component: 'Svelte/PropsAndPageStore', props: { foo: req.query.foo || 'default' } }),
 )

--- a/tests/deferred-props.spec.ts
+++ b/tests/deferred-props.spec.ts
@@ -273,6 +273,34 @@ test('prefetch works with deferred props without errors', async ({ page }) => {
   expect(consoleMessages.errors).toHaveLength(0)
 })
 
+test('router.reload() without only/except triggers deferred props to reload', async ({ page }) => {
+  await page.goto('/deferred-props/with-reload')
+
+  await expect(page.getByText('Loading results...')).toBeVisible()
+
+  await page.waitForResponse(
+    (response) => response.request().headers()['x-inertia-partial-data'] === 'results' && response.status() === 200,
+  )
+
+  await expect(page.getByText('Loading results...')).not.toBeVisible()
+  await expect(page.locator('#results-data')).toHaveText('Item 1-1, Item 1-2, Item 1-3')
+  await expect(page.locator('#results-page')).toHaveText('Page: 1')
+
+  const deferredResponsePromise = page.waitForResponse(
+    (response) => response.request().headers()['x-inertia-partial-data'] === 'results' && response.status() === 200,
+  )
+
+  await page.getByRole('button', { name: 'Reload with page 2' }).click()
+
+  await expect(page.getByText('Loading results...')).toBeVisible()
+
+  await deferredResponsePromise
+
+  await expect(page.getByText('Loading results...')).not.toBeVisible()
+  await expect(page.locator('#results-data')).toHaveText('Item 2-1, Item 2-2, Item 2-3')
+  await expect(page.locator('#results-page')).toHaveText('Page: 2')
+})
+
 test('deferred props do not clear validation errors', async ({ page }) => {
   await page.goto('/deferred-props/with-errors')
 


### PR DESCRIPTION
This PR adds a test for loading deferred props when calling `router.reload()` without the `except`, `only`, or `reset` visit option.