### PR TITLE
Merge `data` and `params` props in `<WhenVisible>`

### DIFF
--- a/packages/react/src/WhenVisible.ts
+++ b/packages/react/src/WhenVisible.ts
@@ -37,17 +37,13 @@ const WhenVisible = ({ children, data, params, buffer, as, always, fallback }: W
   }, [pageProps, keys])
 
   const getReloadParams = useCallback<() => Partial<ReloadOptions>>(() => {
+    const reloadParams: Partial<ReloadOptions> = { ...params }
+
     if (data) {
-      return {
-        only: (Array.isArray(data) ? data : [data]) as string[],
-      }
+      reloadParams.only = (Array.isArray(data) ? data : [data]) as string[]
     }
 
-    if (!params) {
-      throw new Error('You must provide either a `data` or `params` prop.')
-    }
-
-    return params
+    return reloadParams
   }, [params, data])
 
   const registerObserver = () => {

--- a/packages/react/test-app/Pages/WhenVisibleMergeParams.tsx
+++ b/packages/react/test-app/Pages/WhenVisibleMergeParams.tsx
@@ -1,0 +1,46 @@
+import { WhenVisible } from '@inertiajs/react'
+
+export default ({
+  dataOnlyProp,
+  mergedProp,
+  mergedWithCallbackProp,
+}: {
+  dataOnlyProp?: { text: string }
+  mergedProp?: { text: string }
+  mergedWithCallbackProp?: { text: string }
+}) => {
+  return (
+    <>
+      <div id="data-only" style={{ marginTop: '3000px' }}>
+        <WhenVisible data="dataOnlyProp" fallback={<div>Loading data only...</div>}>
+          <div>Data only loaded: {dataOnlyProp?.text}</div>
+        </WhenVisible>
+      </div>
+
+      <div id="merged" style={{ marginTop: '5000px' }}>
+        <WhenVisible
+          data="mergedProp"
+          params={{
+            data: { extra: 'from-params' },
+          }}
+          fallback={<div>Loading merged...</div>}
+        >
+          <div>Merged loaded: {mergedProp?.text}</div>
+        </WhenVisible>
+      </div>
+
+      <div id="merged-with-callback" style={{ marginTop: '5000px' }}>
+        <WhenVisible
+          data="mergedWithCallbackProp"
+          params={{
+            data: { page: '2' },
+            preserveUrl: true,
+          }}
+          fallback={<div>Loading merged with callback...</div>}
+        >
+          <div>Merged with callback loaded: {mergedWithCallbackProp?.text}</div>
+        </WhenVisible>
+      </div>
+    </>
+  )
+}

--- a/packages/svelte/src/components/WhenVisible.svelte
+++ b/packages/svelte/src/components/WhenVisible.svelte
@@ -73,17 +73,13 @@
   })
 
   function getReloadParams(): Partial<ReloadOptions> {
+    const reloadParams: Partial<ReloadOptions> = { ...params }
+
     if (data !== '') {
-      return {
-        only: (Array.isArray(data) ? data : [data]) as string[],
-      }
+      reloadParams.only = (Array.isArray(data) ? data : [data]) as string[]
     }
 
-    if (!params.data) {
-      throw new Error('You must provide either a `data` or `params` prop.')
-    }
-
-    return params
+    return reloadParams
   }
 </script>
 

--- a/packages/svelte/test-app/Pages/WhenVisibleMergeParams.svelte
+++ b/packages/svelte/test-app/Pages/WhenVisibleMergeParams.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { WhenVisible } from '@inertiajs/svelte'
+
+  export let dataOnlyProp: { text: string } | undefined = undefined
+  export let mergedProp: { text: string } | undefined = undefined
+  export let mergedWithCallbackProp: { text: string } | undefined = undefined
+</script>
+
+<div id="data-only" style="margin-top: 3000px">
+  <WhenVisible data="dataOnlyProp">
+    <svelte:fragment slot="fallback">
+      <div>Loading data only...</div>
+    </svelte:fragment>
+    <div>Data only loaded: {dataOnlyProp?.text}</div>
+  </WhenVisible>
+</div>
+
+<div id="merged" style="margin-top: 5000px">
+  <WhenVisible
+    data="mergedProp"
+    params={{
+      data: { extra: 'from-params' },
+    }}
+  >
+    <svelte:fragment slot="fallback">
+      <div>Loading merged...</div>
+    </svelte:fragment>
+    <div>Merged loaded: {mergedProp?.text}</div>
+  </WhenVisible>
+</div>
+
+<div id="merged-with-callback" style="margin-top: 5000px">
+  <WhenVisible
+    data="mergedWithCallbackProp"
+    params={{
+      data: { page: '2' },
+      preserveUrl: true,
+    }}
+  >
+    <svelte:fragment slot="fallback">
+      <div>Loading merged with callback...</div>
+    </svelte:fragment>
+    <div>Merged with callback loaded: {mergedWithCallbackProp?.text}</div>
+  </WhenVisible>
+</div>

--- a/packages/vue3/src/whenVisible.ts
+++ b/packages/vue3/src/whenVisible.ts
@@ -108,17 +108,13 @@ export default defineComponent({
       this.observer.observe(this.$el.nextSibling)
     },
     getReloadParams(): Partial<ReloadOptions> {
+      const reloadParams: Partial<ReloadOptions> = { ...this.$props.params }
+
       if (this.$props.data) {
-        return {
-          only: (Array.isArray(this.$props.data) ? this.$props.data : [this.$props.data]) as string[],
-        }
+        reloadParams.only = (Array.isArray(this.$props.data) ? this.$props.data : [this.$props.data]) as string[]
       }
 
-      if (!this.$props.params) {
-        throw new Error('You must provide either a `data` or `params` prop.')
-      }
-
-      return this.$props.params
+      return reloadParams
     },
   },
   render() {

--- a/packages/vue3/test-app/Pages/WhenVisibleMergeParams.vue
+++ b/packages/vue3/test-app/Pages/WhenVisibleMergeParams.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { WhenVisible } from '@inertiajs/vue3'
+
+defineProps<{
+  dataOnlyProp?: { text: string }
+  mergedProp?: { text: string }
+  mergedWithCallbackProp?: { text: string }
+}>()
+</script>
+
+<template>
+  <div id="data-only" style="margin-top: 3000px">
+    <WhenVisible data="dataOnlyProp">
+      <template #fallback>
+        <div>Loading data only...</div>
+      </template>
+      <div>Data only loaded: {{ dataOnlyProp?.text }}</div>
+    </WhenVisible>
+  </div>
+
+  <div id="merged" style="margin-top: 5000px">
+    <WhenVisible
+      data="mergedProp"
+      :params="{
+        data: { extra: 'from-params' },
+      }"
+    >
+      <template #fallback>
+        <div>Loading merged...</div>
+      </template>
+      <div>Merged loaded: {{ mergedProp?.text }}</div>
+    </WhenVisible>
+  </div>
+
+  <div id="merged-with-callback" style="margin-top: 5000px">
+    <WhenVisible
+      data="mergedWithCallbackProp"
+      :params="{
+        data: { page: '2' },
+        preserveUrl: true,
+      }"
+    >
+      <template #fallback>
+        <div>Loading merged with callback...</div>
+      </template>
+      <div>Merged with callback loaded: {{ mergedWithCallbackProp?.text }}</div>
+    </WhenVisible>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -788,6 +788,37 @@ app.get('/when-visible-fetching', (req, res) => {
   }
 })
 
+app.get('/when-visible-merge-params', (req, res) => {
+  const partialData = req.headers['x-inertia-partial-data']
+
+  if (partialData) {
+    const props = {}
+    const partialProps = partialData.split(',')
+
+    if (partialProps.includes('dataOnlyProp')) {
+      props.dataOnlyProp = { text: 'Data only success!' }
+    }
+    if (partialProps.includes('mergedProp')) {
+      props.mergedProp = { text: `Merged success! extra=${req.query.extra}` }
+    }
+    if (partialProps.includes('mergedWithCallbackProp')) {
+      props.mergedWithCallbackProp = { text: `Merged with callback success! page=${req.query.page}` }
+    }
+
+    setTimeout(() => {
+      inertia.render(req, res, {
+        component: 'WhenVisibleMergeParams',
+        props,
+      })
+    }, 100)
+  } else {
+    inertia.render(req, res, {
+      component: 'WhenVisibleMergeParams',
+      props: {},
+    })
+  }
+})
+
 app.get('/progress/:pageNumber', (req, res) => {
   setTimeout(
     () =>

--- a/tests/when-visible.spec.ts
+++ b/tests/when-visible.spec.ts
@@ -236,3 +236,25 @@ test('it exposes fetching state to the default slot', async ({ page }) => {
   await expect(page.getByText('Lazy data loaded!')).toBeVisible()
   await expect(page.getByText('Fetching in background...')).not.toBeVisible()
 })
+
+test('it merges data and params props', async ({ page }) => {
+  await page.goto('/when-visible-merge-params')
+
+  // Using only the data prop works as before
+  await page.evaluate(() => (window as any).scrollTo(0, 3000))
+  await expect(page.getByText('Loading data only...')).toBeVisible()
+  await page.waitForResponse(page.url())
+  await expect(page.getByText('Data only loaded: Data only success!')).toBeVisible()
+
+  // Using both data and params merges them - data sets 'only', params.data becomes query string
+  await page.evaluate(() => (window as any).scrollTo(0, 8000))
+  await expect(page.getByText('Loading merged...')).toBeVisible()
+  await page.waitForResponse((res) => res.url().includes('extra=from-params'))
+  await expect(page.getByText('Merged loaded: Merged success! extra=from-params')).toBeVisible()
+
+  // Other params options like preserveUrl are also passed through
+  await page.evaluate(() => (window as any).scrollTo(0, 13500))
+  await expect(page.getByText('Loading merged with callback...')).toBeVisible()
+  await page.waitForResponse((res) => res.url().includes('page=2'))
+  await expect(page.getByText('Merged with callback loaded: Merged with callback success! page=2')).toBeVisible()
+})


### PR DESCRIPTION
Fixes #2025

Previously, `<WhenVisible>` treated `data` and `params` as mutually exclusive. This PR merges both props, where `data` sets the `only` option and `params` provides additional reload options.