### PR TITLE
Add `dontRemember()` method to form helper

### DIFF
--- a/packages/react/src/useRemember.ts
+++ b/packages/react/src/useRemember.ts
@@ -1,9 +1,10 @@
 import { router } from '@inertiajs/core'
-import { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import { Dispatch, MutableRefObject, SetStateAction, useEffect, useState } from 'react'
 
 export default function useRemember<State>(
   initialState: State,
   key?: string,
+  excludeKeysRef?: MutableRefObject<string[]>,
 ): [State, Dispatch<SetStateAction<State>>] {
   const [state, setState] = useState(() => {
     const restored = router.restore(key) as State
@@ -12,7 +13,14 @@ export default function useRemember<State>(
   })
 
   useEffect(() => {
-    router.remember(state, key)
+    const keys = excludeKeysRef?.current
+    if (keys && keys.length > 0 && typeof state === 'object' && state !== null) {
+      const filtered = { ...state } as Record<string, unknown>
+      keys.forEach((k) => delete filtered[k])
+      router.remember(filtered, key)
+    } else {
+      router.remember(state, key)
+    }
   }, [state, key])
 
   return [state, setState]

--- a/packages/react/test-app/Pages/Remember/FormHelper/Password.tsx
+++ b/packages/react/test-app/Pages/Remember/FormHelper/Password.tsx
@@ -1,0 +1,35 @@
+import { Link, useForm } from '@inertiajs/react'
+
+export default () => {
+  const form = useForm('password-form', {
+    username: '',
+    password: '',
+  }).dontRemember('password')
+
+  return (
+    <div>
+      <label>
+        Username
+        <input
+          type="text"
+          id="username"
+          value={form.data.username}
+          onChange={(e) => form.setData('username', e.target.value)}
+        />
+      </label>
+      <label>
+        Password
+        <input
+          type="password"
+          id="password"
+          value={form.data.password}
+          onChange={(e) => form.setData('password', e.target.value)}
+        />
+      </label>
+
+      <Link href="/dump/get" className="link">
+        Navigate away
+      </Link>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/Remember/FormHelper/Password.svelte
+++ b/packages/svelte/test-app/Pages/Remember/FormHelper/Password.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { inertia, useForm } from '@inertiajs/svelte'
+
+  const form = useForm('password-form', {
+    username: '',
+    password: '',
+  }).dontRemember('password')
+</script>
+
+<div>
+  <label>
+    Username
+    <input type="text" id="username" bind:value={$form.username} />
+  </label>
+  <label>
+    Password
+    <input type="password" id="password" bind:value={$form.password} />
+  </label>
+
+  <a href="/dump/get" use:inertia class="link">Navigate away</a>
+</div>

--- a/packages/vue3/test-app/Pages/Remember/FormHelper/Password.vue
+++ b/packages/vue3/test-app/Pages/Remember/FormHelper/Password.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { Link, useForm } from '@inertiajs/vue3'
+
+const form = useForm('password-form', {
+  username: '',
+  password: '',
+}).dontRemember('password')
+</script>
+
+<template>
+  <div>
+    <label>
+      Username
+      <input type="text" id="username" v-model="form.username" />
+    </label>
+    <label>
+      Password
+      <input type="password" id="password" v-model="form.password" />
+    </label>
+
+    <Link href="/dump/get" class="link">Navigate away</Link>
+  </div>
+</template>

--- a/tests/remember.spec.ts
+++ b/tests/remember.spec.ts
@@ -386,6 +386,24 @@ test.describe('Remember (local state caching)', () => {
       await expect(page.locator('.handle_error')).toBeVisible()
       await expect(page.locator('.remember_error')).not.toBeVisible()
     })
+
+    test('it excludes fields via dontRemember', async ({ page }) => {
+      await page.goto('remember/form-helper/password')
+
+      await page.fill('#username', 'A')
+      await page.fill('#password', 'B')
+
+      await page.getByRole('link', { name: 'Navigate away' }).click()
+
+      await shouldBeDumpPage(page, 'get')
+
+      await page.goBack()
+
+      await expect(page).toHaveURL('remember/form-helper/password')
+
+      await expect(page.locator('#username')).toHaveValue('A')
+      await expect(page.locator('#password')).toHaveValue('')
+    })
   })
 
   test('restore without types', async ({ page }) => {


### PR DESCRIPTION
This PR adds a `dontRemember()` method to the form helper, allowing you to exclude specific fields from being remembered in history state. This is useful for sensitive fields like passwords that shouldn't persist across navigation.

```ts
const form = useForm('login-form', {
  email: '',
  password: '',
}).dontRemember('password')
```

You may also exclude multiple fields:

```ts
const form = useForm('payment-form', {
  card_number: '',
  cvv: '',
  expiry: '',
}).dontRemember('card_number', 'cvv')
```

This can also be used as a workaround for #1676, #2601, and #2725 as long as Safari/WebKit hasn't fixed it.