### PR TITLE
Fix `@typescript-eslint/unbound-method` warning when destructuring `useForm()` methods

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -664,8 +664,10 @@ export type FormComponentProps = Partial<
 export type FormComponentMethods = {
   clearErrors: (...fields: string[]) => void
   resetAndClearErrors: (...fields: string[]) => void
-  setError(field: string, value: ErrorValue): void
-  setError(errors: Record<string, ErrorValue>): void
+  setError: {
+    (field: string, value: ErrorValue): void
+    (errors: Record<string, ErrorValue>): void
+  }
   reset: (...fields: string[]) => void
   submit: () => void
   defaults: () => void
@@ -673,9 +675,9 @@ export type FormComponentMethods = {
   getFormData: () => FormData
   valid: (field: string) => boolean
   invalid: (field: string) => boolean
-  validate(field?: string | NamedInputEvent | ValidationConfig, config?: ValidationConfig): void
+  validate: (field?: string | NamedInputEvent | ValidationConfig, config?: ValidationConfig) => void
   touch: (...fields: string[]) => void
-  touched(field?: string): boolean
+  touched: (field?: string) => boolean
   validator: () => Validator
 }
 

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -58,14 +58,18 @@ export interface InertiaFormProps<TForm extends object> {
   recentlySuccessful: boolean
   setData: SetDataAction<TForm>
   transform: (callback: UseFormTransformCallback<TForm>) => void
-  setDefaults(): void
-  setDefaults<T extends FormDataKeys<TForm>>(field: T, value: FormDataValues<TForm, T>): void
-  setDefaults(fields: Partial<TForm>): void
-  reset<K extends FormDataKeys<TForm>>(...fields: K[]): void
-  clearErrors<K extends FormDataKeys<TForm>>(...fields: K[]): void
-  resetAndClearErrors<K extends FormDataKeys<TForm>>(...fields: K[]): void
-  setError<K extends FormDataKeys<TForm>>(field: K, value: ErrorValue): void
-  setError(errors: FormDataErrors<TForm>): void
+  setDefaults: {
+    (): void
+    <T extends FormDataKeys<TForm>>(field: T, value: FormDataValues<TForm, T>): void
+    (fields: Partial<TForm>): void
+  }
+  reset: <K extends FormDataKeys<TForm>>(...fields: K[]) => void
+  clearErrors: <K extends FormDataKeys<TForm>>(...fields: K[]) => void
+  resetAndClearErrors: <K extends FormDataKeys<TForm>>(...fields: K[]) => void
+  setError: {
+    <K extends FormDataKeys<TForm>>(field: K, value: ErrorValue): void
+    (errors: FormDataErrors<TForm>): void
+  }
   submit: (...args: UseFormSubmitArguments) => void
   get: (url: string, options?: UseFormSubmitOptions) => void
   patch: (url: string, options?: UseFormSubmitOptions) => void
@@ -77,26 +81,26 @@ export interface InertiaFormProps<TForm extends object> {
 }
 
 export interface InertiaFormValidationProps<TForm extends object> {
-  invalid<K extends FormDataKeys<TForm>>(field: K): boolean
-  setValidationTimeout(duration: number): InertiaPrecognitiveFormProps<TForm>
-  touch<K extends FormDataKeys<TForm>>(
+  invalid: <K extends FormDataKeys<TForm>>(field: K) => boolean
+  setValidationTimeout: (duration: number) => InertiaPrecognitiveFormProps<TForm>
+  touch: <K extends FormDataKeys<TForm>>(
     field: K | NamedInputEvent | Array<K>,
     ...fields: K[]
-  ): InertiaPrecognitiveFormProps<TForm>
-  touched<K extends FormDataKeys<TForm>>(field?: K): boolean
-  valid<K extends FormDataKeys<TForm>>(field: K): boolean
-  validate<K extends FormDataKeys<TForm>>(
+  ) => InertiaPrecognitiveFormProps<TForm>
+  touched: <K extends FormDataKeys<TForm>>(field?: K) => boolean
+  valid: <K extends FormDataKeys<TForm>>(field: K) => boolean
+  validate: <K extends FormDataKeys<TForm>>(
     field?: K | NamedInputEvent | PrecognitionValidationConfig<K>,
     config?: PrecognitionValidationConfig<K>,
-  ): InertiaPrecognitiveFormProps<TForm>
-  validateFiles(): InertiaPrecognitiveFormProps<TForm>
+  ) => InertiaPrecognitiveFormProps<TForm>
+  validateFiles: () => InertiaPrecognitiveFormProps<TForm>
   validating: boolean
   validator: () => Validator
-  withAllErrors(): InertiaPrecognitiveFormProps<TForm>
-  withoutFileValidation(): InertiaPrecognitiveFormProps<TForm>
+  withAllErrors: () => InertiaPrecognitiveFormProps<TForm>
+  withoutFileValidation: () => InertiaPrecognitiveFormProps<TForm>
   // Backward compatibility for easy migration from the original Precognition libraries
-  setErrors(errors: FormDataErrors<TForm>): InertiaPrecognitiveFormProps<TForm>
-  forgetError<K extends FormDataKeys<TForm> | NamedInputEvent>(field: K): InertiaPrecognitiveFormProps<TForm>
+  setErrors: (errors: FormDataErrors<TForm>) => InertiaPrecognitiveFormProps<TForm>
+  forgetError: <K extends FormDataKeys<TForm> | NamedInputEvent>(field: K) => InertiaPrecognitiveFormProps<TForm>
 }
 
 export type InertiaForm<TForm extends object> = InertiaFormProps<TForm>

--- a/packages/react/test-app/eslint.config.js
+++ b/packages/react/test-app/eslint.config.js
@@ -8,7 +8,7 @@ import typescript from 'typescript-eslint'
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   {
-    ignores: ['node_modules', 'dist/**/*', '*.config.js', '**/*.d.ts'],
+    ignores: ['node_modules', 'dist/**/*', '*.config.js', '**/*.d.ts', '*.timestamp-*'],
   },
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
@@ -18,6 +18,18 @@ export default [
     ...config,
     files: ['**/*.{ts,tsx}'],
   })),
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/unbound-method': 'error',
+    },
+  },
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
     ...react.configs.flat.recommended,

--- a/packages/svelte/test-app/eslint.config.js
+++ b/packages/svelte/test-app/eslint.config.js
@@ -9,7 +9,7 @@ export default ts.config(
     files: ['**/*.js', '**/*.ts', '**/*.svelte'],
   },
   {
-    ignores: ['node_modules', 'dist/**/*', '*.config.js', '**/*.d.ts'],
+    ignores: ['node_modules', 'dist/**/*', '*.config.js', '**/*.d.ts', '*.timestamp-*'],
   },
   js.configs.recommended,
   ...ts.configs.recommended,
@@ -54,6 +54,12 @@ export default ts.config(
     rules: {
       'svelte/no-navigation-without-resolve': 'off',
       'svelte/no-useless-mustaches': 'off',
+    },
+  },
+  {
+    files: ['**/*.ts', '**/*.svelte'],
+    rules: {
+      '@typescript-eslint/unbound-method': 'error',
     },
   },
 )

--- a/packages/vue3/test-app/eslint.config.js
+++ b/packages/vue3/test-app/eslint.config.js
@@ -9,7 +9,7 @@ export default defineConfigWithVueTs(
     files: ['**/*.vue', '**/*.js', '**/*.ts'],
   },
   {
-    ignores: ['node_modules', 'dist/**/*', '*.config.js', '**/*.d.ts'],
+    ignores: ['node_modules', 'dist/**/*', '*.config.js', '**/*.d.ts', '*.timestamp-*'],
   },
   vue.configs['flat/essential'],
   vueTsConfigs.recommended,
@@ -21,11 +21,16 @@ export default defineConfigWithVueTs(
         ...globals.browser,
         ...globals.es2020,
       },
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
   },
   {
     rules: {
       'vue/multi-word-component-names': 'off',
+      '@typescript-eslint/unbound-method': 'error',
     },
   },
   prettier,


### PR DESCRIPTION
This PR fixes the `@typescript-eslint/unbound-method` ESLint warning that occurs when destructuring methods from `useForm()`:

```tsx
const { reset } = useForm({ name: '' })
// Warning: Avoid referencing unbound methods which may cause unintentional scoping of `this`
```

The fix converts TypeScript interface definitions from method syntax to property syntax, which tells TypeScript these are standalone functions rather than methods that rely on `this` binding.

```tsx
// Before (method syntax - triggers warning)
reset<K extends FormDataKeys<TForm>>(...fields: K[]): void

// After (property syntax - no warning)
reset: <K extends FormDataKeys<TForm>>(...fields: K[]) => void
```

This is a type-level change only (no runtime behavior changes). The `@typescript-eslint/unbound-method` rule has also been added to all three test app ESLint configs to catch similar issues in the future.

Fixes #2513.