### PR TITLE
Add `@inertiajs/core` as peer dependency to adapter packages

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,6 +63,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
+    "@inertiajs/core": "workspace:*",
     "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -58,6 +58,7 @@
     "vite": "^5.4.21"
   },
   "peerDependencies": {
+    "@inertiajs/core": "workspace:*",
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -60,6 +60,7 @@
     "vue": "^3.5.24"
   },
   "peerDependencies": {
+    "@inertiajs/core": "workspace:*",
     "vue": "^3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds `@inertiajs/core` as a peer dependency to the React, Vue, and Svelte adapter packages.

When using pnpm, transitive dependencies are not hoisted to the project root by default. This causes issues when attempting to use TypeScript module augmentation on `@inertiajs/core` (e.g., extending `InertiaConfig` to type shared page props), as TypeScript cannot resolve the module.

By declaring `@inertiajs/core` as a peer dependency, pnpm (and other package managers with `auto-install-peers` enabled) will install it at the project root, making it accessible for [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).