### PR TITLE
Ensure Flash Data listener is registered before event is fired

### DIFF
--- a/packages/core/src/initialVisit.ts
+++ b/packages/core/src/initialVisit.ts
@@ -107,7 +107,7 @@ export class InitialVisit {
       const flash = page.flash
 
       if (Object.keys(flash).length > 0) {
-        fireFlashEvent(flash)
+        queueMicrotask(() => fireFlashEvent(flash))
       }
     })
   }


### PR DESCRIPTION
This PR fixes a race condition where `router.on('flash')` listeners registered in component setup may miss the initial flash event on page load.