### PR TITLE
Pass `true` to `inert` attribute in React 19

### DIFF
--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -27,6 +27,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
+import { isReact19 } from './react'
 import useForm from './useForm'
 
 // Polyfill for startTransition to support React 16.9+
@@ -284,11 +285,10 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
           event.preventDefault()
           submit((event.nativeEvent as SubmitEvent).submitter)
         },
-        // Only React 19 supports passing a boolean to the `inert` attribute.
-        // To support earlier versions as well, we use the string 'true'.
-        // Unfortunately, React 19 treats an empty string as `false`.
+        // React 19 supports passing a boolean to the `inert` attribute, but shows
+        // a warning when receiving a string. Earlier versions require the string 'true'.
         // See: https://github.com/inertiajs/inertia/pull/2536
-        inert: disableWhileProcessing && form.processing && 'true',
+        inert: disableWhileProcessing && form.processing && (isReact19 ? true : 'true'),
       },
       typeof children === 'function' ? children(exposed) : children,
     )

--- a/packages/react/src/react.ts
+++ b/packages/react/src/react.ts
@@ -1,7 +1,10 @@
-import { DependencyList, EffectCallback, useEffect, useLayoutEffect } from 'react'
+import React, { DependencyList, EffectCallback, useEffect, useLayoutEffect } from 'react'
 
 // Inspired by react-redux, this hook uses useLayoutEffect in the browser, and useEffect
 // when using SSR. Currently, useLayoutEffect doesn't work when rendered on the server.
 export function useIsomorphicLayoutEffect(effect: EffectCallback, deps?: DependencyList): void {
   typeof window === 'undefined' ? useEffect(effect, deps) : useLayoutEffect(effect, deps)
 }
+
+// React.use() was introduced in React 19
+export const isReact19 = typeof React.use === 'function'

--- a/packages/react/src/usePage.ts
+++ b/packages/react/src/usePage.ts
@@ -1,10 +1,11 @@
 import { Page, PageProps, SharedPageProps } from '@inertiajs/core'
 import React from 'react'
 import PageContext from './PageContext'
+import { isReact19 } from './react'
 
 export default function usePage<TPageProps extends PageProps = PageProps>(): Page<TPageProps & SharedPageProps> {
   // React.use() was introduced in React 19, fallback to React.useContext() for earlier versions
-  const page = typeof React.use === 'function' ? React.use(PageContext) : React.useContext(PageContext)
+  const page = isReact19 ? React.use(PageContext) : React.useContext(PageContext)
 
   if (!page) {
     throw new Error('usePage must be used within the Inertia component')


### PR DESCRIPTION
Fixes #2824