### PR TITLE
Fix cancellation of concurrent partial reloads with query parameters

### DIFF
--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -103,6 +103,10 @@ export const isSameUrlWithoutHash = (url1: URL | Location, url2: URL | Location)
   return urlWithoutHash(url1).href === urlWithoutHash(url2).href
 }
 
+export const isSameUrlWithoutQueryOrHash = (url1: URL | Location, url2: URL | Location): boolean => {
+  return url1.origin === url2.origin && url1.pathname === url2.pathname
+}
+
 export function isUrlMethodPair(href: unknown): href is UrlMethodPair {
   return href !== null && typeof href === 'object' && href !== undefined && 'url' in href && 'method' in href
 }

--- a/packages/react/test-app/Pages/Reload/ConcurrentWithData.tsx
+++ b/packages/react/test-app/Pages/Reload/ConcurrentWithData.tsx
@@ -1,0 +1,20 @@
+import { router, usePage } from '@inertiajs/react'
+
+export default () => {
+  const { foo, bar, timeframe } = usePage<{ foo?: string; bar?: string; timeframe?: string }>().props
+
+  function reloadBothPropsWithData() {
+    router.reload({ only: ['foo'], data: { timeframe: 'week' } })
+    setTimeout(() => router.reload({ only: ['bar'], data: { timeframe: 'week' } }), 50)
+  }
+
+  return (
+    <div>
+      <div id="foo">Foo: {foo}</div>
+      <div id="bar">Bar: {bar}</div>
+      <div id="timeframe">Timeframe: {timeframe}</div>
+
+      <button onClick={reloadBothPropsWithData}>Reload both props with data</button>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/Reload/ConcurrentWithData.svelte
+++ b/packages/svelte/test-app/Pages/Reload/ConcurrentWithData.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { router } from '@inertiajs/svelte'
+
+  export let foo: string | undefined
+  export let bar: string | undefined
+  export let timeframe: string | undefined
+
+  function reloadBothPropsWithData() {
+    router.reload({ only: ['foo'], data: { timeframe: 'week' } })
+    setTimeout(() => router.reload({ only: ['bar'], data: { timeframe: 'week' } }), 50)
+  }
+</script>
+
+<div>
+  <div id="foo">Foo: {foo}</div>
+  <div id="bar">Bar: {bar}</div>
+  <div id="timeframe">Timeframe: {timeframe}</div>
+
+  <button on:click={reloadBothPropsWithData}>Reload both props with data</button>
+</div>

--- a/packages/vue3/test-app/Pages/Reload/ConcurrentWithData.vue
+++ b/packages/vue3/test-app/Pages/Reload/ConcurrentWithData.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3'
+
+defineProps<{
+  foo?: string
+  bar?: string
+  timeframe?: string
+}>()
+
+function reloadBothPropsWithData() {
+  router.reload({ only: ['foo'], data: { timeframe: 'week' } })
+  setTimeout(() => router.reload({ only: ['bar'], data: { timeframe: 'week' } }), 50)
+}
+</script>
+
+<template>
+  <div>
+    <div id="foo">Foo: {{ foo }}</div>
+    <div id="bar">Bar: {{ bar }}</div>
+    <div id="timeframe">Timeframe: {{ timeframe }}</div>
+
+    <button @click="reloadBothPropsWithData">Reload both props with data</button>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2426,6 +2426,35 @@ app.get('/reload/concurrent', (req, res) => {
   )
 })
 
+app.get('/reload/concurrent-with-data', (req, res) => {
+  const partialData = req.headers['x-inertia-partial-data']
+  const timeframe = req.query.timeframe || 'day'
+
+  if (!partialData) {
+    return inertia.render(req, res, {
+      component: 'Reload/ConcurrentWithData',
+      props: {
+        foo: 'initial foo',
+        bar: 'initial bar',
+        timeframe,
+      },
+    })
+  }
+
+  setTimeout(
+    () =>
+      inertia.render(req, res, {
+        component: 'Reload/ConcurrentWithData',
+        props: {
+          foo: partialData.includes('foo') ? `foo reloaded (${timeframe}) at ${Date.now()}` : undefined,
+          bar: partialData.includes('bar') ? `bar reloaded (${timeframe}) at ${Date.now()}` : undefined,
+          timeframe,
+        },
+      }),
+    600,
+  )
+})
+
 app.all('*page', (req, res) => inertia.render(req, res))
 
 // Send errors to the console (instead of crashing the server)


### PR DESCRIPTION
This PR fixes an issue where concurrent partial reloads were being cancelled when passing `data` to `router.reload()`.

Fixes #2842.