### PR TITLE
Support for the `formTarget` attribute in the `<Form>` component

### DIFF
--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -199,6 +199,12 @@ const Form = forwardRef<FormComponentRef, ComponentProps>(
 
     const submit = (submitter?: FormSubmitter) => {
       const [url, data] = getUrlAndData(submitter)
+      const formTarget = (submitter as HTMLButtonElement | HTMLInputElement | null)?.getAttribute('formtarget')
+
+      if (formTarget === '_blank' && resolvedMethod === 'get') {
+        window.open(url, '_blank')
+        return
+      }
 
       const submitOptions: FormSubmitOptions = {
         headers,

--- a/packages/react/test-app/Pages/FormComponent/FormTarget.tsx
+++ b/packages/react/test-app/Pages/FormComponent/FormTarget.tsx
@@ -1,0 +1,14 @@
+import { Form } from '@inertiajs/react'
+
+export default () => {
+  return (
+    <Form action="/non-inertia/download" method="get">
+      <input type="text" name="search" id="search" defaultValue="test-query" />
+
+      <button type="submit" formTarget="_blank" name="format" value="csv" id="button-blank">
+        Button with formTarget blank
+      </button>
+      <input type="submit" formTarget="_blank" name="type" value="export" id="input-blank" />
+    </Form>
+  )
+}

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -106,6 +106,12 @@
 
   export function submit(submitter?: FormSubmitter) {
     const [url, data] = getUrlAndData(submitter)
+    const formTarget = (submitter as HTMLButtonElement | HTMLInputElement | null)?.getAttribute('formtarget')
+
+    if (formTarget === '_blank' && _method === 'get') {
+      window.open(url, '_blank')
+      return
+    }
 
     const maybeReset = (resetOption: boolean | string[] | undefined) => {
       if (!resetOption) {

--- a/packages/svelte/test-app/Pages/FormComponent/FormTarget.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/FormTarget.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { Form } from '@inertiajs/svelte'
+</script>
+
+<Form action="/non-inertia/download" method="get">
+  <input type="text" name="search" id="search" value="test-query" />
+
+  <button type="submit" formtarget="_blank" name="format" value="csv" id="button-blank">
+    Button with formTarget blank
+  </button>
+  <input type="submit" formtarget="_blank" name="type" value="export" id="input-blank" />
+</Form>

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -227,6 +227,14 @@ const Form = defineComponent({
     }
 
     const submit = (submitter?: FormSubmitter) => {
+      const [url, data] = getUrlAndData(submitter)
+      const formTarget = (submitter as HTMLButtonElement | HTMLInputElement | null)?.getAttribute('formtarget')
+
+      if (formTarget === '_blank' && method.value === 'get') {
+        window.open(url, '_blank')
+        return
+      }
+
       const maybeReset = (resetOption: boolean | string[]) => {
         if (!resetOption) {
           return
@@ -266,8 +274,6 @@ const Form = defineComponent({
         },
         ...props.options,
       }
-
-      const [url, data] = getUrlAndData(submitter)
 
       // We need transform because we can't override the default data with different keys (by design)
       form.transform(() => props.transform(data)).submit(method.value, url, submitOptions)

--- a/packages/vue3/test-app/Pages/FormComponent/FormTarget.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/FormTarget.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <Form action="/non-inertia/download" method="get">
+    <input type="text" name="search" id="search" value="test-query" />
+
+    <button type="submit" formtarget="_blank" name="format" value="csv" id="button-blank">
+      Button with formTarget blank
+    </button>
+    <input type="submit" formtarget="_blank" name="type" value="export" id="input-blank" />
+  </Form>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -34,6 +34,12 @@ app.all('/non-inertia', (req, res) =>
   `),
 )
 
+app.get('/non-inertia/download', (req, res) => {
+  const query = new URLSearchParams(req.query).toString()
+  res.setHeader('Content-Type', 'text/plain')
+  res.status(200).send(`query:${query}`)
+})
+
 // SSR test routes (only rendered with SSR when SSR=true)
 app.get('/ssr/page1', (req, res) =>
   inertia.renderSSR(req, res, {

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -1596,4 +1596,34 @@ test.describe('Form Component', () => {
       })
     })
   })
+
+  test.describe('Form Target', () => {
+    test('it opens a new tab when button has formTarget="_blank" on GET forms', async ({ page, context }) => {
+      await page.goto('/form-component/form-target')
+
+      const newPagePromise = context.waitForEvent('page')
+      await page.click('#button-blank')
+      const newPage = await newPagePromise
+
+      await newPage.waitForLoadState()
+      const text = await newPage.locator('body').innerText()
+
+      expect(text).toContain('query:search=test-query&format=csv')
+      await newPage.close()
+    })
+
+    test('it opens a new tab when input has formTarget="_blank" on GET forms', async ({ page, context }) => {
+      await page.goto('/form-component/form-target')
+
+      const newPagePromise = context.waitForEvent('page')
+      await page.click('#input-blank')
+      const newPage = await newPagePromise
+
+      await newPage.waitForLoadState()
+      const text = await newPage.locator('body').innerText()
+
+      expect(text).toContain('query:search=test-query&type=export')
+      await newPage.close()
+    })
+  })
 })


### PR DESCRIPTION
This PR adds support for the `formtarget="_blank"` attribute on submit buttons and inputs within the `<Form>` component.

When a submitter has `formtarget="_blank"` and the form method is `get`, the form data is processed using Inertia's normal data handling (including `transform()` and `queryStringArrayFormat`) and then opened in a new tab via `window.open()`.

Fixes #2841.