### PR TITLE
Clear stale form errors on resubmit

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -238,7 +238,9 @@ export default function useForm<TForm extends FormDataType<TForm>>(
           if (isMounted.current) {
             setProcessing(false)
             setProgress(null)
-            setError(errors as FormDataErrors<TForm>)
+            setErrors(errors as FormDataErrors<TForm>)
+            setHasErrors(Object.keys(errors).length > 0)
+            validatorRef.current?.setErrors(errors as Errors)
           }
 
           if (options.onError) {

--- a/packages/react/test-app/Pages/FormHelper/ErrorsClearOnResubmit.tsx
+++ b/packages/react/test-app/Pages/FormHelper/ErrorsClearOnResubmit.tsx
@@ -1,0 +1,42 @@
+import { useForm } from '@inertiajs/react'
+
+export default () => {
+  const form = useForm({
+    name: '',
+    handle: '',
+  })
+
+  return (
+    <div>
+      <label>
+        Name
+        <input
+          type="text"
+          id="name"
+          name="name"
+          value={form.data.name}
+          onChange={(e) => form.setData('name', e.target.value)}
+        />
+      </label>
+      {form.errors.name && <span id="name-error">{form.errors.name}</span>}
+
+      <label>
+        Handle
+        <input
+          type="text"
+          id="handle"
+          name="handle"
+          value={form.data.handle}
+          onChange={(e) => form.setData('handle', e.target.value)}
+        />
+      </label>
+      {form.errors.handle && <span id="handle-error">{form.errors.handle}</span>}
+
+      <button onClick={() => form.post('/form-helper/errors/clear-on-resubmit')} id="submit">
+        Submit
+      </button>
+
+      <span className="errors-status">Form has {form.hasErrors ? '' : 'no '}errors</span>
+    </div>
+  )
+}

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -454,7 +454,9 @@ export default function useForm<TForm extends FormDataType<TForm>>(
         onError: (errors: Errors) => {
           setFormState('processing', false)
           setFormState('progress', null)
-          this.clearErrors().setError(errors as FormDataErrors<TForm>)
+          setFormState('errors', errors as FormDataErrors<TForm>)
+
+          validatorRef?.setErrors(errors)
 
           if (options.onError) {
             return options.onError(errors)

--- a/packages/svelte/test-app/Pages/FormHelper/ErrorsClearOnResubmit.svelte
+++ b/packages/svelte/test-app/Pages/FormHelper/ErrorsClearOnResubmit.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { useForm } from '@inertiajs/svelte'
+
+  const form = useForm({
+    name: '',
+    handle: '',
+  })
+
+  const submit = () => {
+    $form.post('/form-helper/errors/clear-on-resubmit')
+  }
+</script>
+
+<div>
+  <label>
+    Name
+    <input type="text" id="name" name="name" bind:value={$form.name} />
+  </label>
+  {#if $form.errors.name}
+    <span id="name-error">{$form.errors.name}</span>
+  {/if}
+
+  <label>
+    Handle
+    <input type="text" id="handle" name="handle" bind:value={$form.handle} />
+  </label>
+  {#if $form.errors.handle}
+    <span id="handle-error">{$form.errors.handle}</span>
+  {/if}
+
+  <button on:click={submit} id="submit">Submit</button>
+
+  <span class="errors-status">Form has {$form.hasErrors ? '' : 'no '}errors</span>
+</div>

--- a/packages/vue3/test-app/Pages/FormHelper/ErrorsClearOnResubmit.vue
+++ b/packages/vue3/test-app/Pages/FormHelper/ErrorsClearOnResubmit.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3'
+
+const form = useForm({
+  name: '',
+  handle: '',
+})
+
+const submit = () => {
+  form.post('/form-helper/errors/clear-on-resubmit')
+}
+</script>
+
+<template>
+  <div>
+    <label>
+      Name
+      <input type="text" id="name" name="name" v-model="form.name" />
+    </label>
+    <span id="name-error" v-if="form.errors.name">{{ form.errors.name }}</span>
+
+    <label>
+      Handle
+      <input type="text" id="handle" name="handle" v-model="form.handle" />
+    </label>
+    <span id="handle-error" v-if="form.errors.handle">{{ form.errors.handle }}</span>
+
+    <button @click="submit" id="submit">Submit</button>
+
+    <span class="errors-status">Form has {{ form.hasErrors ? '' : 'no ' }}errors</span>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -353,6 +353,29 @@ app.post('/form-helper/errors', (req, res) =>
   }),
 )
 
+app.get('/form-helper/errors/clear-on-resubmit', (req, res) =>
+  inertia.render(req, res, { component: 'FormHelper/ErrorsClearOnResubmit' }),
+)
+
+app.post('/form-helper/errors/clear-on-resubmit', (req, res) => {
+  const name = req.body['name']
+  const handle = req.body['handle']
+  const errors = {}
+
+  if (!name || name.length < 3) {
+    errors.name = 'The name must be at least 3 characters.'
+  }
+
+  if (!handle || handle.length < 3) {
+    errors.handle = 'The handle must be at least 3 characters.'
+  }
+
+  inertia.render(req, res, {
+    component: 'FormHelper/ErrorsClearOnResubmit',
+    props: { errors },
+  })
+})
+
 app.post('/form-helper/events/errors', (req, res) => {
   setTimeout(() => {
     inertia.render(req, res, {

--- a/tests/form-helper.spec.ts
+++ b/tests/form-helper.spec.ts
@@ -305,6 +305,24 @@ test.describe('Form Helper', () => {
     })
   })
 
+  test('it clears errors for fields that are no longer invalid on resubmit', async ({ page }) => {
+    pageLoads.watch(page)
+    await page.goto('/form-helper/errors/clear-on-resubmit')
+
+    // Submit with both fields empty
+    await clickAndWaitForResponse(page, 'Submit', undefined, 'button')
+    await expect(page.locator('#name-error')).toHaveText('The name must be at least 3 characters.')
+    await expect(page.locator('#handle-error')).toHaveText('The handle must be at least 3 characters.')
+
+    // Fill name with valid value and resubmit
+    await page.fill('#name', 'John')
+    await clickAndWaitForResponse(page, 'Submit', undefined, 'button')
+
+    // Name error should be cleared, handle error should remain
+    await expect(page.locator('#name-error')).not.toBeVisible()
+    await expect(page.locator('#handle-error')).toHaveText('The handle must be at least 3 characters.')
+  })
+
   test.describe('Dirty', () => {
     test.beforeEach(async ({ page }) => {
       pageLoads.watch(page)


### PR DESCRIPTION
When a form submission returns validation errors, the `onError` handler was merging new errors with existing ones instead of replacing them. This caused stale errors to persist even when those fields became valid on subsequent submissions.

The issue affected both React and Svelte. Both adapters now directly replace errors in `onError`, matching Vue's behavior.

Fixes #2834.