### PR TITLE
[3.x] Remove `hideProgress()` and `revealProgress()` exports

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,7 @@ export { formDataToObject } from './formObject'
 export { default as createHeadManager } from './head'
 export { default as useInfiniteScroll } from './infiniteScroll'
 export { shouldIntercept, shouldNavigate } from './navigationEvents'
-export { hide as hideProgress, progress, reveal as revealProgress, default as setupProgress } from './progress'
+export { progress, default as setupProgress } from './progress'
 export { FormComponentResetSymbol, resetFormFields } from './resetFormFields'
 export * from './types'
 export {

--- a/packages/core/src/progress.ts
+++ b/packages/core/src/progress.ts
@@ -49,8 +49,6 @@ class Progress {
 }
 
 export const progress = new Progress()
-export const reveal = progress.reveal
-export const hide = progress.hide
 
 function addEventListeners(delay: number): void {
   document.addEventListener('inertia:start', (e) => handleStartEvent(e, delay))


### PR DESCRIPTION
This PR removes the standalone `hideProgress()` and `revealProgress()` exports in favor of `progress.hide()` and `progress.reveal()`. See also PR #2581.