### PR TITLE
Support wildcard paths in `validate()` method

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@types/lodash-es": "^4.17.12",
     "axios": "^1.13.2",
-    "laravel-precognition": "^1.0.0",
+    "laravel-precognition": "^1.0.1",
     "lodash-es": "^4.17.23",
     "qs": "^6.14.1"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@inertiajs/core": "workspace:*",
     "@types/lodash-es": "^4.17.12",
-    "laravel-precognition": "^1.0.0",
+    "laravel-precognition": "^1.0.1",
     "lodash-es": "^4.17.23"
   }
 }

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -22,6 +22,7 @@ import {
 import {
   createValidator,
   NamedInputEvent,
+  PrecognitionPath,
   resolveName,
   toSimpleValidationErrors,
   ValidationConfig,
@@ -90,7 +91,7 @@ export interface InertiaFormValidationProps<TForm extends object> {
   ) => InertiaPrecognitiveFormProps<TForm>
   touched: <K extends FormDataKeys<TForm>>(field?: K) => boolean
   valid: <K extends FormDataKeys<TForm>>(field: K) => boolean
-  validate: <K extends FormDataKeys<TForm>>(
+  validate: <K extends FormDataKeys<TForm> | PrecognitionPath<TForm>>(
     field?: K | NamedInputEvent | PrecognitionValidationConfig<K>,
     config?: PrecognitionValidationConfig<K>,
   ) => InertiaPrecognitiveFormProps<TForm>

--- a/packages/react/test-app/Pages/FormHelper/TypeScript/Precognition.tsx
+++ b/packages/react/test-app/Pages/FormHelper/TypeScript/Precognition.tsx
@@ -53,4 +53,45 @@ export default () => {
   nestedForm.valid('user.email')
   // @ts-expect-error - Field does not exist
   nestedForm.invalid('user.email')
+
+  // Wildcard path support (PrecognitionPath)
+  const wildcardForm = useForm({
+    users: [] as Array<{ name: string; email: string }>,
+    profile: { age: 0, city: '' },
+    company: { name: '', addresses: [] as string[] },
+    nested: { companies: [] as Array<{ name: string; addresses: string[] }> },
+  }).withPrecognition('post', '/precognition/wildcard')
+
+  // Valid array field paths
+  wildcardForm.validate('users')
+  wildcardForm.validate('users.*')
+  wildcardForm.validate('users.*.name')
+  wildcardForm.validate('users.*.email')
+  wildcardForm.validate('users.*.*')
+
+  // Valid object field paths
+  wildcardForm.validate('profile')
+  wildcardForm.validate('profile.*')
+  wildcardForm.validate('profile.age')
+
+  // Valid nested paths
+  wildcardForm.validate('company')
+  wildcardForm.validate('company.addresses')
+  wildcardForm.validate('nested')
+  wildcardForm.validate('nested.companies')
+  wildcardForm.validate('nested.companies.*')
+  wildcardForm.validate('nested.companies.*.name')
+  wildcardForm.validate('nested.companies.*.addresses')
+  wildcardForm.validate('nested.companies.*.*')
+
+  // @ts-expect-error - nonexistent property in array items
+  wildcardForm.validate('users.*.unknown')
+  // @ts-expect-error - missing wildcard for array access
+  wildcardForm.validate('users.email')
+  // @ts-expect-error - invalid deep nesting
+  wildcardForm.validate('profile.age.foo')
+  // @ts-expect-error - field does not exist
+  wildcardForm.validate('nonexistent')
+  // @ts-expect-error - no such field
+  wildcardForm.validate('profile.country')
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@inertiajs/core": "workspace:*",
     "@types/lodash-es": "^4.17.12",
-    "laravel-precognition": "^1.0.0",
+    "laravel-precognition": "^1.0.1",
     "lodash-es": "^4.17.23"
   }
 }

--- a/packages/svelte/src/useForm.ts
+++ b/packages/svelte/src/useForm.ts
@@ -22,7 +22,7 @@ import type {
 } from '@inertiajs/core'
 import { router, UseFormUtils } from '@inertiajs/core'
 import type { AxiosProgressEvent } from 'axios'
-import type { NamedInputEvent, ValidationConfig, Validator } from 'laravel-precognition'
+import type { NamedInputEvent, PrecognitionPath, ValidationConfig, Validator } from 'laravel-precognition'
 import { createValidator, resolveName, toSimpleValidationErrors } from 'laravel-precognition'
 import { cloneDeep, get, has, isEqual, set } from 'lodash-es'
 import { get as getStore, writable, type Writable } from 'svelte/store'
@@ -101,7 +101,7 @@ export interface InertiaFormValidationProps<TForm extends object> {
   touch<K extends FormDataKeys<TForm>>(field: K | NamedInputEvent | Array<K>, ...fields: K[]): this
   touched<K extends FormDataKeys<TForm>>(field?: K): boolean
   valid<K extends FormDataKeys<TForm>>(field: K): boolean
-  validate<K extends FormDataKeys<TForm>>(
+  validate<K extends FormDataKeys<TForm> | PrecognitionPath<TForm>>(
     field?: K | NamedInputEvent | PrecognitionValidationConfig<K>,
     config?: PrecognitionValidationConfig<K>,
   ): this

--- a/packages/svelte/test-app/Pages/FormHelper/TypeScript/Precognition.svelte
+++ b/packages/svelte/test-app/Pages/FormHelper/TypeScript/Precognition.svelte
@@ -53,4 +53,45 @@
   nestedForm.valid('user.email')
   // @ts-expect-error - Field does not exist
   nestedForm.invalid('user.email')
+
+  // Wildcard path support (PrecognitionPath)
+  const wildcardForm = useForm({
+    users: [] as Array<{ name: string; email: string }>,
+    profile: { age: 0, city: '' },
+    company: { name: '', addresses: [] as string[] },
+    nested: { companies: [] as Array<{ name: string; addresses: string[] }> },
+  }).withPrecognition('post', '/precognition/wildcard')
+
+  // Valid array field paths
+  wildcardForm.validate('users')
+  wildcardForm.validate('users.*')
+  wildcardForm.validate('users.*.name')
+  wildcardForm.validate('users.*.email')
+  wildcardForm.validate('users.*.*')
+
+  // Valid object field paths
+  wildcardForm.validate('profile')
+  wildcardForm.validate('profile.*')
+  wildcardForm.validate('profile.age')
+
+  // Valid nested paths
+  wildcardForm.validate('company')
+  wildcardForm.validate('company.addresses')
+  wildcardForm.validate('nested')
+  wildcardForm.validate('nested.companies')
+  wildcardForm.validate('nested.companies.*')
+  wildcardForm.validate('nested.companies.*.name')
+  wildcardForm.validate('nested.companies.*.addresses')
+  wildcardForm.validate('nested.companies.*.*')
+
+  // @ts-expect-error - nonexistent property in array items
+  wildcardForm.validate('users.*.unknown')
+  // @ts-expect-error - missing wildcard for array access
+  wildcardForm.validate('users.email')
+  // @ts-expect-error - invalid deep nesting
+  wildcardForm.validate('profile.age.foo')
+  // @ts-expect-error - field does not exist
+  wildcardForm.validate('nonexistent')
+  // @ts-expect-error - no such field
+  wildcardForm.validate('profile.country')
 </script>

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@inertiajs/core": "workspace:*",
     "@types/lodash-es": "^4.17.12",
-    "laravel-precognition": "^1.0.0",
+    "laravel-precognition": "^1.0.1",
     "lodash-es": "^4.17.23"
   }
 }

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -22,6 +22,7 @@ import {
 import {
   createValidator,
   NamedInputEvent,
+  PrecognitionPath,
   resolveName,
   toSimpleValidationErrors,
   ValidationConfig,
@@ -94,7 +95,7 @@ export interface InertiaFormValidationProps<TForm extends object> {
   touch<K extends FormDataKeys<TForm>>(field: K | NamedInputEvent | Array<K>, ...fields: K[]): this
   touched<K extends FormDataKeys<TForm>>(field?: K): boolean
   valid<K extends FormDataKeys<TForm>>(field: K): boolean
-  validate<K extends FormDataKeys<TForm>>(
+  validate<K extends FormDataKeys<TForm> | PrecognitionPath<TForm>>(
     field?: K | NamedInputEvent | PrecognitionValidationConfig<K>,
     config?: PrecognitionValidationConfig<K>,
   ): this

--- a/packages/vue3/test-app/Pages/FormHelper/TypeScript/Precognition.vue
+++ b/packages/vue3/test-app/Pages/FormHelper/TypeScript/Precognition.vue
@@ -53,4 +53,45 @@ nestedForm.validate({ only: ['user.email'] })
 nestedForm.valid('user.email')
 // @ts-expect-error - Field does not exist
 nestedForm.invalid('user.email')
+
+// Wildcard path support (PrecognitionPath)
+const wildcardForm = useForm({
+  users: [] as Array<{ name: string; email: string }>,
+  profile: { age: 0, city: '' },
+  company: { name: '', addresses: [] as string[] },
+  nested: { companies: [] as Array<{ name: string; addresses: string[] }> },
+}).withPrecognition('post', '/precognition/wildcard')
+
+// Valid array field paths
+wildcardForm.validate('users')
+wildcardForm.validate('users.*')
+wildcardForm.validate('users.*.name')
+wildcardForm.validate('users.*.email')
+wildcardForm.validate('users.*.*')
+
+// Valid object field paths
+wildcardForm.validate('profile')
+wildcardForm.validate('profile.*')
+wildcardForm.validate('profile.age')
+
+// Valid nested paths
+wildcardForm.validate('company')
+wildcardForm.validate('company.addresses')
+wildcardForm.validate('nested')
+wildcardForm.validate('nested.companies')
+wildcardForm.validate('nested.companies.*')
+wildcardForm.validate('nested.companies.*.name')
+wildcardForm.validate('nested.companies.*.addresses')
+wildcardForm.validate('nested.companies.*.*')
+
+// @ts-expect-error - nonexistent property in array items
+wildcardForm.validate('users.*.unknown')
+// @ts-expect-error - missing wildcard for array access
+wildcardForm.validate('users.email')
+// @ts-expect-error - invalid deep nesting
+wildcardForm.validate('profile.age.foo')
+// @ts-expect-error - field does not exist
+wildcardForm.validate('nonexistent')
+// @ts-expect-error - no such field
+wildcardForm.validate('profile.country')
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: ^1.13.2
         version: 1.13.2
       laravel-precognition:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       lodash-es:
         specifier: ^4.17.23
         version: 4.17.23
@@ -78,8 +78,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       laravel-precognition:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       lodash-es:
         specifier: ^4.17.23
         version: 4.17.23
@@ -179,8 +179,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       laravel-precognition:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       lodash-es:
         specifier: ^4.17.23
         version: 4.17.23
@@ -277,8 +277,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       laravel-precognition:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       lodash-es:
         specifier: ^4.17.23
         version: 4.17.23
@@ -2231,8 +2231,8 @@ packages:
   known-css-properties@0.37.0:
     resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==}
 
-  laravel-precognition@1.0.0:
-    resolution: {integrity: sha512-hvXPT7dayCQAidxnsY0hab9Q+Y2rsh7xRpH9uiFtXN8Dekc3tIZt+NrxrOZ9N5SwHBmRBze/Bv+ElfXac0kD6g==}
+  laravel-precognition@1.0.1:
+    resolution: {integrity: sha512-BYaDUjEclKbxuQTG9yZnRjjD7ag1Xh+8hGOXmcrw91/vpbIOJ8cSFADTI0kvwetIr3AM1vOJzYwaoA9+KHhLwA==}
 
   laravel-vite-plugin@1.3.0:
     resolution: {integrity: sha512-P5qyG56YbYxM8OuYmK2OkhcKe0AksNVJUjq9LUZ5tOekU9fBn9LujYyctI4t9XoLjuMvHJXXpCoPntY1oKltuA==}
@@ -5130,7 +5130,7 @@ snapshots:
 
   known-css-properties@0.37.0: {}
 
-  laravel-precognition@1.0.0:
+  laravel-precognition@1.0.1:
     dependencies:
       axios: 1.13.2
       lodash-es: 4.17.23


### PR DESCRIPTION
Laravel Precognition supports wildcard validation paths like `users.*` and `users.*.email` for validating array fields. The `validate()` method now accepts these wildcard paths in addition to the existing dot-notation paths.

```ts
type User = {
  name: string
  email: string
}

const form = useForm<{ users: User[] }>({
  users: [],
}).withPrecognition('post', '/users')

form.validate('users.*')
form.validate('users.*.email')
```

This uses the `PrecognitionPath` type exported as of `laravel-precognition` v1.0.1.