### PR TITLE
[3.x] Upgrade Svelte playground to Svelte 5 syntax

### DIFF
--- a/playgrounds/svelte5/resources/js/Components/Image.svelte
+++ b/playgrounds/svelte5/resources/js/Components/Image.svelte
@@ -30,7 +30,7 @@
     class={`h-full w-full object-cover transition duration-500 ease-out ${
       loaded ? 'blur-0 scale-100 opacity-100' : 'scale-105 opacity-0 blur-sm'
     }`}
-    on:load={handleLoad}
+    onload={handleLoad}
     alt=""
   />
 

--- a/playgrounds/svelte5/resources/js/Components/Layout.svelte
+++ b/playgrounds/svelte5/resources/js/Components/Layout.svelte
@@ -1,13 +1,13 @@
 <script>
-  import { inertia, page, useLayoutProps } from '@inertiajs/svelte'
+  import { inertia, usePage } from '@inertiajs/svelte'
 
   let { children } = $props()
 
-  const layoutProps = useLayoutProps({ padding: true })
+  const page = usePage()
 </script>
 
 <nav class="flex items-center space-x-6 bg-slate-800 px-10 py-6 text-white">
-  <div class="rounded-lg bg-slate-700 px-4 py-1">{$page.props.appName}</div>
+  <div class="rounded-lg bg-slate-700 px-4 py-1">{page.props.appName}</div>
   <a href="/" use:inertia class="hover:underline">Home</a>
   <a href="/users" use:inertia class="hover:underline">Users</a>
   <a href="/article" use:inertia class="hover:underline">Article</a>
@@ -22,6 +22,6 @@
   <button use:inertia={{ method: 'post', href: '/logout' }} type="button" class="hover:underline">Logout</button>
 </nav>
 
-<main class={$layoutProps.padding ? 'px-10 py-8' : ''}>
+<main class="px-10 py-8">
   {@render children()}
 </main>

--- a/playgrounds/svelte5/resources/js/Components/TestGrid.svelte
+++ b/playgrounds/svelte5/resources/js/Components/TestGrid.svelte
@@ -1,8 +1,7 @@
 <script>
-  let className = ''
-  export { className as class }
+  let { class: className = '', children, ...restProps } = $props()
 </script>
 
-<div {...$$restProps} class="mt-6 grid grid-cols-3 gap-4 {className}">
-  <slot />
+<div {...restProps} class="mt-6 grid grid-cols-3 gap-4 {className}">
+  {@render children()}
 </div>

--- a/playgrounds/svelte5/resources/js/Components/TestGridItem.svelte
+++ b/playgrounds/svelte5/resources/js/Components/TestGridItem.svelte
@@ -1,14 +1,13 @@
 <script>
-  let className
-  export { className as class }
+  let { class: className = '', title, children, ...restProps } = $props()
 </script>
 
-<div {...$$restProps} class="rounded-sm border border-gray-300 p-4 text-sm text-gray-500 {className}">
-  {#if $$slots.title}
+<div {...restProps} class="rounded-sm border border-gray-300 p-4 text-sm text-gray-500 {className}">
+  {#if title}
     <div class="mb-2 font-bold">
-      <slot name="title" />
+      {@render title()}
     </div>
   {/if}
 
-  <slot />
+  {@render children()}
 </div>

--- a/playgrounds/svelte5/resources/js/Pages/Async.svelte
+++ b/playgrounds/svelte5/resources/js/Pages/Async.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script module>
   export { default as layout } from '../Components/Layout.svelte'
 </script>
 
@@ -7,23 +7,23 @@
   import TestGrid from '../Components/TestGrid.svelte'
   import TestGridItem from '../Components/TestGridItem.svelte'
 
-  export let appName
-  export let jonathan: boolean
-  export let taylor: boolean
-  export let joe: boolean
+  let { appName, jonathan, taylor, joe }: { appName: string; jonathan: boolean; taylor: boolean; joe: boolean } =
+    $props()
 
-  let reloadCount = 0
+  let reloadCount = $state(0)
   const form = useForm({ jonathan, taylor, joe })
 
-  $: console.log('watched reload count value', reloadCount)
+  $effect(() => {
+    console.log('watched reload count value', reloadCount)
+  })
 
   function submit() {
     router.post(
       '/async/checkbox',
       {
-        jonathan: $form.jonathan,
-        taylor: $form.taylor,
-        joe: $form.joe,
+        jonathan: form.jonathan,
+        taylor: form.taylor,
+        joe: form.joe,
       },
       {
         async: true,
@@ -105,21 +105,21 @@
 <TestGrid>
   <TestGridItem class="space-y-4">
     <p>Trigger an async reload that takes a moment and immediately programmatically visit another page</p>
-    <button class="rounded-sm bg-green-600 px-4 py-2 text-white" on:click={simulateConflict}>Reload → Visit</button>
+    <button class="rounded-sm bg-green-600 px-4 py-2 text-white" onclick={simulateConflict}>Reload → Visit</button>
   </TestGridItem>
 
   <TestGridItem class="space-y-4">
-    <form on:change={submit}>
+    <form onchange={submit}>
       <label class="block">
-        <input bind:checked={$form.jonathan} type="checkbox" class="mr-2" />
+        <input bind:checked={form.jonathan} type="checkbox" class="mr-2" />
         Jonathan
       </label>
       <label class="block">
-        <input bind:checked={$form.taylor} type="checkbox" class="mr-2" />
+        <input bind:checked={form.taylor} type="checkbox" class="mr-2" />
         Taylor
       </label>
       <label class="block">
-        <input bind:checked={$form.joe} type="checkbox" class="mr-2" />
+        <input bind:checked={form.joe} type="checkbox" class="mr-2" />
         Joe
       </label>
     </form>
@@ -132,26 +132,24 @@
 
     <p>Reload should still happen but won't re-direct back to the reloaded component, we should respect the visit</p>
 
-    <button on:click={triggerVisitThenReload} class="rounded-sm bg-green-600 px-4 py-2 text-white"
-      >Visit → Reload</button
+    <button onclick={triggerVisitThenReload} class="rounded-sm bg-green-600 px-4 py-2 text-white">Visit → Reload</button
     >
   </TestGridItem>
 
   <TestGridItem class="space-y-4">
     <p>Simply trigger a 4 second reload so you can navigate or do whatever you'd like during it.</p>
-    <button on:click={triggerLongReload} class="rounded-sm bg-green-600 px-4 py-2 text-white"
-      >Trigger Long Reload</button
+    <button onclick={triggerLongReload} class="rounded-sm bg-green-600 px-4 py-2 text-white">Trigger Long Reload</button
     >
   </TestGridItem>
 
   <TestGridItem class="space-y-4">
     <p>Trigger an automatic cancellation from the token.</p>
-    <button on:click={triggerCancel} class="rounded-sm bg-green-600 px-4 py-2 text-white">Trigger Cancel</button>
+    <button onclick={triggerCancel} class="rounded-sm bg-green-600 px-4 py-2 text-white">Trigger Cancel</button>
   </TestGridItem>
 
   <TestGridItem class="space-y-4">
     <p>Trigger an automatic cancellation from the token after finishing request.</p>
-    <button on:click={triggerCancelAfterFinish} class="rounded-sm bg-green-600 px-4 py-2 text-white">
+    <button onclick={triggerCancelAfterFinish} class="rounded-sm bg-green-600 px-4 py-2 text-white">
       Trigger Cancel After Finish
     </button>
   </TestGridItem>

--- a/playgrounds/svelte5/resources/js/Pages/DataTable.svelte
+++ b/playgrounds/svelte5/resources/js/Pages/DataTable.svelte
@@ -14,11 +14,11 @@
 </svelte:head>
 
 <InfiniteScroll data="users" class="mx-auto max-w-7xl px-8" buffer={3000} itemsElement="tbody">
-  <div slot="loading">
+  {#snippet loading()}
     <div class="flex justify-center py-16">
       <Spinner class="size-6 text-gray-400" />
     </div>
-  </div>
+  {/snippet}
 
   <div class="overflow-hidden rounded-2xl shadow ring-1 ring-gray-200">
     <table class="min-w-full">

--- a/playgrounds/svelte5/resources/js/Pages/Flash.svelte
+++ b/playgrounds/svelte5/resources/js/Pages/Flash.svelte
@@ -3,9 +3,11 @@
 </script>
 
 <script>
-  import { Link, page, router } from '@inertiajs/svelte'
+  import { Link, usePage, router } from '@inertiajs/svelte'
 
   let { appName } = $props()
+
+  const page = usePage()
 
   let flashLog = $state([])
 
@@ -38,7 +40,7 @@
 <div class="mt-6 space-y-6">
   <div>
     <h2 class="text-lg font-semibold">Current page.flash</h2>
-    <pre class="mt-2 rounded-sm bg-gray-100 p-3 text-sm">{JSON.stringify($page.flash ?? 'null', null, 2)}</pre>
+    <pre class="mt-2 rounded-sm bg-gray-100 p-3 text-sm">{JSON.stringify(page.flash ?? 'null', null, 2)}</pre>
   </div>
 
   <div>

--- a/playgrounds/svelte5/resources/js/Pages/Form.svelte
+++ b/playgrounds/svelte5/resources/js/Pages/Form.svelte
@@ -15,7 +15,7 @@
 
   function submit(e) {
     e.preventDefault()
-    $form.post('/user')
+    form.post('/user')
   }
 </script>
 
@@ -26,37 +26,37 @@
 <h1 class="text-3xl">Form</h1>
 
 <form onsubmit={submit} class="mt-6 max-w-md space-y-4">
-  {#if $form.isDirty}
+  {#if form.isDirty}
     <div class="my-5 rounded-sm border border-amber-100 bg-amber-50 p-3 text-amber-800">There are unsaved changes!</div>
   {/if}
   <div>
     <label class="block" for="name">Name:</label>
     <input
       type="text"
-      bind:value={$form.name}
+      bind:value={form.name}
       id="name"
       class="mt-1 w-full appearance-none rounded-sm border border-gray-200 px-2 py-1 shadow-xs"
     />
-    {#if $form.errors.name}
-      <div class="mt-2 text-sm text-red-600">{$form.errors.name}</div>
+    {#if form.errors.name}
+      <div class="mt-2 text-sm text-red-600">{form.errors.name}</div>
     {/if}
   </div>
   <div>
     <label class="block" for="company">Company:</label>
     <input
       type="text"
-      bind:value={$form.company}
+      bind:value={form.company}
       id="company"
       class="mt-1 w-full appearance-none rounded-sm border border-gray-200 px-2 py-1 shadow-xs"
     />
-    {#if $form.errors.company}
-      <div class="mt-2 text-sm text-red-600">{$form.errors.company}</div>
+    {#if form.errors.company}
+      <div class="mt-2 text-sm text-red-600">{form.errors.company}</div>
     {/if}
   </div>
   <div>
     <label class="block" for="role">Role:</label>
     <select
-      bind:value={$form.role}
+      bind:value={form.role}
       id="role"
       class="mt-1 w-full appearance-none rounded-sm border border-gray-200 px-2 py-1 shadow-xs"
     >
@@ -65,14 +65,14 @@
       <option>Admin</option>
       <option>Super</option>
     </select>
-    {#if $form.errors.role}
-      <div class="mt-2 text-sm text-red-600">{$form.errors.role}</div>
+    {#if form.errors.role}
+      <div class="mt-2 text-sm text-red-600">{form.errors.role}</div>
     {/if}
   </div>
   <div class="flex gap-4">
-    <button type="submit" disabled={$form.processing} class="rounded-sm bg-slate-800 px-6 py-2 text-white">
+    <button type="submit" disabled={form.processing} class="rounded-sm bg-slate-800 px-6 py-2 text-white">
       Submit
     </button>
-    <button type="button" onclick={() => $form.reset()}>Reset</button>
+    <button type="button" onclick={() => form.reset()}>Reset</button>
   </div>
 </form>

--- a/playgrounds/svelte5/resources/js/Pages/FormComponent.svelte
+++ b/playgrounds/svelte5/resources/js/Pages/FormComponent.svelte
@@ -7,7 +7,7 @@
 
   let { appName, foo, bar, quux } = $props()
 
-  let customHeaders = { 'X-Custom-Header': 'Demo-Value' }
+  let customHeaders = $state({ 'X-Custom-Header': 'Demo-Value' })
   let errorBag = 'custom-bag'
 </script>
 

--- a/playgrounds/svelte5/resources/js/Pages/PhotoGrid.svelte
+++ b/playgrounds/svelte5/resources/js/Pages/PhotoGrid.svelte
@@ -19,11 +19,11 @@
   class="mx-auto grid max-w-7xl grid-cols-1 gap-6 px-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
   buffer={1000}
 >
-  <div slot="loading">
+  {#snippet loading()}
     <div class="flex justify-center py-16">
       <Spinner class="size-6 text-gray-400" />
     </div>
-  </div>
+  {/snippet}
 
   {#each photos.data as photo (photo.id)}
     <Image id={photo.id} url={photo.url} />

--- a/playgrounds/svelte5/resources/js/Pages/PhotoHorizontal.svelte
+++ b/playgrounds/svelte5/resources/js/Pages/PhotoHorizontal.svelte
@@ -16,11 +16,11 @@
 
 <div class="flex h-[200px] w-full overflow-x-scroll">
   <InfiniteScroll data="photos" buffer={1000} class="flex h-[200px] gap-6" preserveUrl onlyNext>
-    <div slot="loading">
+    {#snippet loading()}
       <div class="flex size-[200px] items-center justify-center">
         <Spinner class="size-6 text-gray-400" />
       </div>
-    </div>
+    {/snippet}
 
     {#each photos.data as photo (photo.id)}
       <Image id={photo.id} url={photo.url} />

--- a/playgrounds/svelte5/resources/js/Pages/Poll.svelte
+++ b/playgrounds/svelte5/resources/js/Pages/Poll.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script module>
   export { default as layout } from '../Components/Layout.svelte'
 </script>
 
@@ -8,13 +8,11 @@
   import TestGrid from '../Components/TestGrid.svelte'
   import TestGridItem from '../Components/TestGridItem.svelte'
 
-  export let appName
-  export let users = []
-  export let companies = []
+  let { appName, users = [], companies = [] } = $props()
 
-  let userPollCount = 0
-  let hookPollCount = 0
-  let companyPollCount = 0
+  let userPollCount = $state(0)
+  let hookPollCount = $state(0)
+  let companyPollCount = $state(0)
 
   const triggerAsyncRedirect = () => {
     router.get(
@@ -72,9 +70,9 @@
 
 <TestGrid>
   <TestGridItem>
-    <svelte:fragment slot="title">
+    {#snippet title()}
       User Poll Request Count: {userPollCount}
-    </svelte:fragment>
+    {/snippet}
     <div>
       {#each users as user}
         <div>{user}</div>
@@ -82,9 +80,9 @@
     </div>
   </TestGridItem>
   <TestGridItem>
-    <svelte:fragment slot="title">
+    {#snippet title()}
       Companies Poll Request Count: {companyPollCount}
-    </svelte:fragment>
+    {/snippet}
     <div>
       {#each companies as company}
         <div>{company}</div>
@@ -92,11 +90,11 @@
     </div>
   </TestGridItem>
   <TestGridItem>
-    <svelte:fragment slot="title">
+    {#snippet title()}
       Hook Poll Request Count: {hookPollCount}
-    </svelte:fragment>
+    {/snippet}
   </TestGridItem>
   <TestGridItem>
-    <button on:click={() => triggerAsyncRedirect()}>Trigger Async Redirect</button>
+    <button onclick={() => triggerAsyncRedirect()}>Trigger Async Redirect</button>
   </TestGridItem>
 </TestGrid>


### PR DESCRIPTION
The Svelte playground was still using Svelte 4 syntax in several places, causing runtime errors like `store_invalid_shape` and `binding_property_non_reactive`.