### PR TITLE
[3.x] Rename `useDataElementForInitialPage` to `useDataAttributeForInitialPage`

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -76,7 +76,7 @@ export const config = new Config<InertiaAppConfig>({
     forceIndicesArrayFormatInFormData: true,
   },
   legacy: {
-    useDataElementForInitialPage: false,
+    useDataAttributeForInitialPage: false,
   },
   prefetch: {
     cacheFor: 30_000,

--- a/packages/core/src/domUtils.ts
+++ b/packages/core/src/domUtils.ts
@@ -125,12 +125,12 @@ export const requestAnimationFrame = (cb: () => void, times: number = 1): void =
   })
 }
 
-export const getInitialPageFromDOM = <T>(id: string, useDataElement: boolean = false): T | null => {
+export const getInitialPageFromDOM = <T>(id: string, useDataAttribute: boolean = false): T | null => {
   if (typeof window === 'undefined') {
     return null
   }
 
-  if (useDataElement) {
+  if (useDataAttribute) {
     const el = document.getElementById(id)
 
     if (el?.dataset.page) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -573,7 +573,7 @@ export type InertiaAppConfig = {
     forceIndicesArrayFormatInFormData: boolean
   }
   legacy: {
-    useDataElementForInitialPage: boolean
+    useDataAttributeForInitialPage: boolean
   }
   prefetch: {
     cacheFor: CacheForOption | CacheForOption[]

--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -70,8 +70,8 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
   }
 
   const isServer = typeof window === 'undefined'
-  const useDataElement = config.get('legacy.useDataElementForInitialPage')
-  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useDataElement)!
+  const useDataAttribute = config.get('legacy.useDataAttributeForInitialPage')
+  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useDataAttribute)!
 
   const resolveComponent = (name: string, page?: Page) =>
     Promise.resolve(resolve(name, page)).then((module) => {
@@ -116,7 +116,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   if (isServer && render) {
     const element = () => {
-      if (useDataElement) {
+      if (useDataAttribute) {
         return createElement(
           'div',
           {

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -47,8 +47,8 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
   }
 
   const isServer = typeof window === 'undefined'
-  const useDataElement = config.get('legacy.useDataElementForInitialPage')
-  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useDataElement)!
+  const useDataAttribute = config.get('legacy.useDataAttributeForInitialPage')
+  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useDataAttribute)!
 
   const resolveComponent = (name: string, page?: Page) => Promise.resolve(resolve(name, page))
 
@@ -69,7 +69,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     const { body, head, css } = svelteApp
 
     return {
-      body: useDataElement
+      body: useDataAttribute
         ? `<div data-server-rendered="true" id="${id}" data-page="${escape(JSON.stringify(initialPage))}">${body}</div>`
         : `<script data-page="${id}" type="application/json">${JSON.stringify(initialPage).replace(/\//g, '\\/')}</script><div data-server-rendered="true" id="${id}">${body}</div>`,
       head: [head, css ? `<style data-vite-css>${css.code}</style>` : ''],

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -70,8 +70,8 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
   }
 
   const isServer = typeof window === 'undefined'
-  const useDataElement = config.get('legacy.useDataElementForInitialPage')
-  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useDataElement)!
+  const useDataAttribute = config.get('legacy.useDataAttributeForInitialPage')
+  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useDataAttribute)!
 
   const resolveComponent = (name: string, page?: Page) =>
     Promise.resolve(resolve(name, page)).then((module) => module.default || module)
@@ -116,7 +116,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   if (isServer && render) {
     const element = () => {
-      if (useDataElement) {
+      if (useDataAttribute) {
         return h('div', {
           id,
           'data-page': JSON.stringify(initialPage),


### PR DESCRIPTION
Follow-up to #2867, renamed `useDataElementForInitialPage` to `useDataAttributeForInitialPage`.