### PR TITLE
[3.x] Add a singleton for the usePage function

### DIFF
--- a/packages/svelte/src/page.ts
+++ b/packages/svelte/src/page.ts
@@ -7,6 +7,7 @@ type SveltePage<TPageProps extends PageProps = PageProps> = Omit<Page<TPageProps
   }
 }
 
+let pageAccessor: Readable<SveltePage> | null = null
 const { set, subscribe } = writable<SveltePage>()
 
 export const setPage = set
@@ -14,5 +15,9 @@ export const setPage = set
 export default { subscribe }
 
 export function usePage<TPageProps extends PageProps = PageProps>(): Readable<SveltePage<TPageProps>> {
-  return derived({ subscribe }, ($page) => $page as SveltePage<TPageProps>)
+  if (!pageAccessor) {
+    pageAccessor = derived({ subscribe }, ($page) => $page)
+  }
+
+  return pageAccessor as Readable<SveltePage<TPageProps>>
 }

--- a/packages/svelte/test-app/Pages/UsePage/Child.svelte
+++ b/packages/svelte/test-app/Pages/UsePage/Child.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { usePage } from '@inertiajs/svelte'
+  import type { Readable } from 'svelte/store'
+
+  export let parentPage: Readable<Record<string, unknown>>
+
+  const page = usePage()
+  // eslint-disable-next-line svelte/require-store-reactive-access
+  const sameAsParent = page === parentPage
+</script>
+
+<div>
+  <p><em>From child component:</em></p>
+  <p data-testid="child-url">{$page.url}</p>
+  <p data-testid="child-component">{$page.component}</p>
+  <p data-testid="child-same-ref">Same instance as parent: <strong>{sameAsParent ? 'yes' : 'no'}</strong></p>
+</div>

--- a/packages/svelte/test-app/Pages/UsePage/Page1.svelte
+++ b/packages/svelte/test-app/Pages/UsePage/Page1.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { inertia, usePage } from '@inertiajs/svelte'
+  import Child from './Child.svelte'
+
+  export let name: string
+
+  const pageA = usePage()
+  const pageB = usePage()
+  // eslint-disable-next-line svelte/require-store-reactive-access
+  const sameInstance = pageA === pageB
+</script>
+
+<div>
+  <h2>Page 1</h2>
+
+  <p data-testid="name-props">Name (props): <strong>{name}</strong></p>
+  <p data-testid="name-usepage">Name (usePage): <strong>{$pageA.props.name}</strong></p>
+  <p data-testid="url">URL: {$pageA.url}</p>
+  <p data-testid="same-ref">usePage() same instance: <strong>{sameInstance ? 'yes' : 'no'}</strong></p>
+
+  <hr />
+
+  <Child parentPage={pageA} />
+
+  <hr />
+
+  <a data-testid="go-page2" href="/use-page/page2" use:inertia>Go to Page 2</a>
+</div>

--- a/packages/svelte/test-app/Pages/UsePage/Page2.svelte
+++ b/packages/svelte/test-app/Pages/UsePage/Page2.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { inertia, usePage } from '@inertiajs/svelte'
+  import Child from './Child.svelte'
+
+  export let title: string
+
+  const pageA = usePage()
+  const pageB = usePage()
+  // eslint-disable-next-line svelte/require-store-reactive-access
+  const sameInstance = pageA === pageB
+</script>
+
+<div>
+  <h2>Page 2</h2>
+
+  <p data-testid="title-props">Title (props): <strong>{title}</strong></p>
+  <p data-testid="title-usepage">Title (usePage): <strong>{$pageA.props.title}</strong></p>
+  <p data-testid="url">URL: {$pageA.url}</p>
+  <p data-testid="same-ref">usePage() same instance: <strong>{sameInstance ? 'yes' : 'no'}</strong></p>
+
+  <hr />
+
+  <Child parentPage={pageA} />
+
+  <hr />
+
+  <a data-testid="go-page1" href="/use-page/page1" use:inertia>Go to Page 1</a>
+</div>

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -36,6 +36,7 @@ export type InertiaApp = DefineComponent<InertiaAppProps>
 
 const component = ref<DefineComponent | undefined>(undefined)
 const page = ref<Page>()
+let pageAccessor: Page | null = null
 const layout = shallowRef(null)
 const key = ref<number | undefined>(undefined)
 let headManager: HeadManager
@@ -139,19 +140,23 @@ export const plugin: Plugin = {
 }
 
 export function usePage<TPageProps extends PageProps = PageProps>(): Page<TPageProps & SharedPageProps> {
-  return reactive({
-    props: computed(() => page.value?.props),
-    url: computed(() => page.value?.url),
-    component: computed(() => page.value?.component),
-    version: computed(() => page.value?.version),
-    clearHistory: computed(() => page.value?.clearHistory),
-    deferredProps: computed(() => page.value?.deferredProps),
-    mergeProps: computed(() => page.value?.mergeProps),
-    prependProps: computed(() => page.value?.prependProps),
-    deepMergeProps: computed(() => page.value?.deepMergeProps),
-    matchPropsOn: computed(() => page.value?.matchPropsOn),
-    rememberedState: computed(() => page.value?.rememberedState),
-    encryptHistory: computed(() => page.value?.encryptHistory),
-    flash: computed(() => page.value?.flash),
-  }) as Page<TPageProps>
+  if (!pageAccessor) {
+    pageAccessor = reactive({
+      props: computed(() => page.value?.props),
+      url: computed(() => page.value?.url),
+      component: computed(() => page.value?.component),
+      version: computed(() => page.value?.version),
+      clearHistory: computed(() => page.value?.clearHistory),
+      deferredProps: computed(() => page.value?.deferredProps),
+      mergeProps: computed(() => page.value?.mergeProps),
+      prependProps: computed(() => page.value?.prependProps),
+      deepMergeProps: computed(() => page.value?.deepMergeProps),
+      matchPropsOn: computed(() => page.value?.matchPropsOn),
+      rememberedState: computed(() => page.value?.rememberedState),
+      encryptHistory: computed(() => page.value?.encryptHistory),
+      flash: computed(() => page.value?.flash),
+    }) as Page
+  }
+
+  return pageAccessor as Page<TPageProps>
 }

--- a/packages/vue3/test-app/Pages/UsePage/Child.vue
+++ b/packages/vue3/test-app/Pages/UsePage/Child.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { usePage } from '@inertiajs/vue3'
+
+interface Props {
+  parentPage: object
+}
+
+const { parentPage } = defineProps<Props>()
+
+const page = usePage()
+</script>
+
+<template>
+  <div>
+    <p><em>From child component:</em></p>
+    <p data-testid="child-url">URL: {{ page.url }}</p>
+    <p data-testid="child-component">Component: {{ page.component }}</p>
+    <p data-testid="child-same-ref">
+      Same instance as parent: <strong>{{ page === parentPage ? 'yes' : 'no' }}</strong>
+    </p>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/UsePage/Page1.vue
+++ b/packages/vue3/test-app/Pages/UsePage/Page1.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { Link, usePage } from '@inertiajs/vue3'
+import Child from './Child.vue'
+
+interface Props {
+  name: string
+}
+
+const { name } = defineProps<Props>()
+
+const pageA = usePage()
+const pageB = usePage()
+</script>
+
+<template>
+  <div>
+    <h2>Page 1</h2>
+
+    <p data-testid="name-props">
+      Name (props): <strong>{{ name }}</strong>
+    </p>
+    <p data-testid="name-usepage">
+      Name (usePage): <strong>{{ pageA.props.name }}</strong>
+    </p>
+    <p data-testid="url">URL: {{ pageA.url }}</p>
+    <p data-testid="same-ref">
+      usePage() same instance: <strong>{{ pageA === pageB ? 'yes' : 'no' }}</strong>
+    </p>
+
+    <hr />
+
+    <Child :parent-page="pageA" />
+
+    <hr />
+
+    <Link data-testid="go-page2" href="/use-page/page2">Go to Page 2</Link>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/UsePage/Page2.vue
+++ b/packages/vue3/test-app/Pages/UsePage/Page2.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { Link, usePage } from '@inertiajs/vue3'
+import Child from './Child.vue'
+
+interface Props {
+  title: string
+}
+
+const { title } = defineProps<Props>()
+
+const pageA = usePage()
+const pageB = usePage()
+</script>
+
+<template>
+  <div>
+    <h2>Page 2</h2>
+
+    <p data-testid="title-props">
+      Title (props): <strong>{{ title }}</strong>
+    </p>
+    <p data-testid="title-usepage">
+      Title (usePage): <strong>{{ pageA.props.title }}</strong>
+    </p>
+    <p data-testid="url">URL: {{ pageA.url }}</p>
+    <p data-testid="same-ref">
+      usePage() same instance: <strong>{{ pageA === pageB ? 'yes' : 'no' }}</strong>
+    </p>
+
+    <hr />
+
+    <Child :parent-page="pageA" />
+
+    <hr />
+
+    <Link data-testid="go-page1" href="/use-page/page1">Go to Page 1</Link>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2513,6 +2513,20 @@ app.get('/reload/concurrent-with-data', (req, res) => {
   )
 })
 
+app.get('/use-page/page1', (req, res) =>
+  inertia.render(req, res, {
+    component: 'UsePage/Page1',
+    props: { name: 'Alice' },
+  }),
+)
+
+app.get('/use-page/page2', (req, res) =>
+  inertia.render(req, res, {
+    component: 'UsePage/Page2',
+    props: { title: 'Dashboard' },
+  }),
+)
+
 app.all('*page', (req, res) => inertia.render(req, res))
 
 // Send errors to the console (instead of crashing the server)

--- a/tests/use-page.spec.ts
+++ b/tests/use-page.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('usePage', () => {
+  test.skip(process.env.PACKAGE !== 'vue3' && process.env.PACKAGE !== 'svelte')
+
+  test('returns the same instance on multiple calls', async ({ page }) => {
+    await page.goto('/use-page/page1')
+
+    await expect(page.getByTestId('same-ref')).toContainText('yes')
+  })
+
+  test('exposes reactive page props', async ({ page }) => {
+    await page.goto('/use-page/page1')
+
+    await expect(page.getByTestId('name-props')).toContainText('Alice')
+    await expect(page.getByTestId('name-usepage')).toContainText('Alice')
+    await expect(page.getByTestId('url')).toContainText('/use-page/page1')
+  })
+
+  test('exposes reactive page data in child components', async ({ page }) => {
+    await page.goto('/use-page/page1')
+
+    await expect(page.getByTestId('child-url')).toContainText('/use-page/page1')
+    await expect(page.getByTestId('child-component')).toContainText('UsePage/Page1')
+  })
+
+  test('returns the same instance in parent and child components', async ({ page }) => {
+    await page.goto('/use-page/page1')
+
+    await expect(page.getByTestId('child-same-ref')).toContainText('yes')
+  })
+
+  test('updates reactively after SPA navigation', async ({ page }) => {
+    await page.goto('/use-page/page1')
+
+    await expect(page.getByTestId('name-usepage')).toContainText('Alice')
+
+    await page.getByTestId('go-page2').click()
+    await expect(page.getByTestId('title-props')).toContainText('Dashboard')
+    await expect(page.getByTestId('title-usepage')).toContainText('Dashboard')
+    await expect(page.getByTestId('url')).toContainText('/use-page/page2')
+    await expect(page.getByTestId('child-url')).toContainText('/use-page/page2')
+    await expect(page.getByTestId('child-component')).toContainText('UsePage/Page2')
+    await expect(page.getByTestId('same-ref')).toContainText('yes')
+  })
+})


### PR DESCRIPTION
## Summary                                                                                                                                                          

`usePage()` currently creates a new `reactive()` object with 13 `computed()` properties on every call (Vue), and a new `derived()` store on every call (Svelte).

Since all instances read from the same underlying page ref, these extra allocations are redundant.

### The problem

Every call to `usePage()` allocates:
  - **Vue:** 1 `reactive()` + 13 `computed()`
  - **Svelte:** 1 `derived()` store subscription

In a component that calls `usePage()`, rendered in a loop of 30 items:
  - **Before:** 30 reactive proxies + 390 computed, all watching the same ref
  - **After:** 1 reactive + 13 computed, shared across all calls

This adds up in scenarios like virtual scrollers or large loops, where components mount and unmount frequently, each mount creates a new reactive wrapper that gets thrown away on unmount, only to be recreated on the next mount.

This also gives developers more flexibility to call usePage() freely without worrying about performance, whether it's in a loop, a deeply nested child, or called multiple times in the same component. 

From experience, it's common for developers to create wrapper composables around usePage(), and when a page uses 3-4 of those composables, each one calling usePage() internally, the allocations multiply quickly, especially inside loops.

Although it's a small optimization, we never know what codebases are using this :)

### The fix

A singleton solves this. The reactive wrapper is created once on the first call and returned on every subsequent call. This is safe because:
  - All computed properties / derived stores reference the same shared page state
  - The returned object is reactive, it reflects navigation changes automatically
  - No behavior changes for consumers
                                                                                                               
The pageAccessor is just computed getters over that same page.value, so it reads whatever the current request set. No different from before.

You can see the test pages by navigating to /use-page/page1. 

<img width="339" height="394" alt="Screenshot 2026-02-10 at 14 00 31" src="https://github.com/user-attachments/assets/849e2716-a394-4e70-b58b-07df90c77180" />

### What's not affected
React's `usePage()` already reads from a Context provider with no allocations, so no change is needed there.
  
  
@pascalbaljet  If this pattern was intentional, happy to hear the reasoning, otherwise this should be a small but useful optimization. Wish you all the best, Inertia is an amazing product keep the good work!

Happy to port this to the 3.x branch as well if this gets merged. 