### PR TITLE
[3.x] Allow calling `createInertiaApp()` without arguments

### DIFF
--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -73,20 +73,22 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 export default async function createInertiaApp<SharedProps extends PageProps = PageProps>(
   options?: InertiaAppOptionsAuto<SharedProps>,
 ): Promise<void | RenderFunction<SharedProps>>
-export default async function createInertiaApp<SharedProps extends PageProps = PageProps>({
-  id = 'app',
-  resolve,
-  setup,
-  title,
-  progress = {},
-  page,
-  render,
-  defaults = {},
-  http,
-}:
-  | InertiaAppOptionsForCSR<SharedProps>
-  | InertiaAppOptionsForSSR<SharedProps>
-  | InertiaAppOptionsAuto<SharedProps> = {} as InertiaAppOptionsAuto<SharedProps>): Promise<InertiaAppSSRResponse | RenderFunction<SharedProps> | void> {
+export default async function createInertiaApp<SharedProps extends PageProps = PageProps>(
+  {
+    id = 'app',
+    resolve,
+    setup,
+    title,
+    progress = {},
+    page,
+    render,
+    defaults = {},
+    http,
+  }:
+    | InertiaAppOptionsForCSR<SharedProps>
+    | InertiaAppOptionsForSSR<SharedProps>
+    | InertiaAppOptionsAuto<SharedProps> = {} as InertiaAppOptionsAuto<SharedProps>,
+): Promise<InertiaAppSSRResponse | RenderFunction<SharedProps> | void> {
   config.replace(defaults)
 
   if (http) {

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -53,17 +53,19 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 export default async function createInertiaApp<SharedProps extends PageProps = PageProps>(
   options?: InertiaAppOptionsAuto<SharedProps>,
 ): Promise<void | RenderFunction<SharedProps>>
-export default async function createInertiaApp<SharedProps extends PageProps = PageProps>({
-  id = 'app',
-  resolve,
-  setup,
-  progress = {},
-  page,
-  defaults = {},
-  http,
-}: InertiaAppOptionsForCSR<SharedProps> | InertiaAppOptionsAuto<SharedProps> = {} as InertiaAppOptionsAuto<SharedProps>): Promise<
-  InertiaAppSSRResponse | RenderFunction<SharedProps> | void
-> {
+export default async function createInertiaApp<SharedProps extends PageProps = PageProps>(
+  {
+    id = 'app',
+    resolve,
+    setup,
+    progress = {},
+    page,
+    defaults = {},
+    http,
+  }:
+    | InertiaAppOptionsForCSR<SharedProps>
+    | InertiaAppOptionsAuto<SharedProps> = {} as InertiaAppOptionsAuto<SharedProps>,
+): Promise<InertiaAppSSRResponse | RenderFunction<SharedProps> | void> {
   config.replace(defaults)
 
   if (http) {

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -73,20 +73,22 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 export default async function createInertiaApp<SharedProps extends PageProps = PageProps>(
   options?: InertiaAppOptionsAuto<SharedProps>,
 ): Promise<void | RenderFunction<SharedProps>>
-export default async function createInertiaApp<SharedProps extends PageProps = PageProps>({
-  id = 'app',
-  resolve,
-  setup,
-  title,
-  progress = {},
-  page,
-  render,
-  defaults = {},
-  http,
-}:
-  | InertiaAppOptionsForCSR<SharedProps>
-  | InertiaAppOptionsForSSR<SharedProps>
-  | InertiaAppOptionsAuto<SharedProps> = {} as InertiaAppOptionsAuto<SharedProps>): Promise<InertiaAppSSRResponse | RenderFunction<SharedProps> | void> {
+export default async function createInertiaApp<SharedProps extends PageProps = PageProps>(
+  {
+    id = 'app',
+    resolve,
+    setup,
+    title,
+    progress = {},
+    page,
+    render,
+    defaults = {},
+    http,
+  }:
+    | InertiaAppOptionsForCSR<SharedProps>
+    | InertiaAppOptionsForSSR<SharedProps>
+    | InertiaAppOptionsAuto<SharedProps> = {} as InertiaAppOptionsAuto<SharedProps>,
+): Promise<InertiaAppSSRResponse | RenderFunction<SharedProps> | void> {
   config.replace(defaults)
 
   if (http) {


### PR DESCRIPTION
`createInertiaApp({})` was allowed (empty object), but `createInertiaApp()` without any argument gave a TypeScript error. This makes the parameter optional across all three adapters.