### PR TITLE
[3.x] Remove `legacy.useDataAttributeForInitialPage` config option

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -76,9 +76,6 @@ export const config = new Config<InertiaAppConfig>({
     forceIndicesArrayFormatInFormData: true,
     withAllErrors: false,
   },
-  legacy: {
-    useDataAttributeForInitialPage: false,
-  },
   prefetch: {
     cacheFor: 30_000,
     hoverDelay: 75,

--- a/packages/core/src/domUtils.ts
+++ b/packages/core/src/domUtils.ts
@@ -125,17 +125,9 @@ export const requestAnimationFrame = (cb: () => void, times: number = 1): void =
   })
 }
 
-export const getInitialPageFromDOM = <T>(id: string, useDataAttribute: boolean = false): T | null => {
+export const getInitialPageFromDOM = <T>(id: string): T | null => {
   if (typeof window === 'undefined') {
     return null
-  }
-
-  if (useDataAttribute) {
-    const el = document.getElementById(id)
-
-    if (el?.dataset.page) {
-      return JSON.parse(el.dataset.page)
-    }
   }
 
   const scriptEl = document.querySelector(`script[data-page="${id}"][type="application/json"]`)

--- a/packages/core/src/ssrUtils.ts
+++ b/packages/core/src/ssrUtils.ts
@@ -1,13 +1,7 @@
 import type { Page } from './types'
 
-export function buildSSRBody(id: string, page: Page, html: string, useScriptElement: boolean): string {
-  if (useScriptElement) {
-    const json = JSON.stringify(page).replace(/\//g, '\\/')
+export function buildSSRBody(id: string, page: Page, html: string): string {
+  const json = JSON.stringify(page).replace(/\//g, '\\/')
 
-    return `<script data-page="${id}" type="application/json">${json}</script><div data-server-rendered="true" id="${id}">${html}</div>`
-  }
-
-  const escaped = JSON.stringify(page).replace(/"/g, '&quot;')
-
-  return `<div data-server-rendered="true" id="${id}" data-page="${escaped}">${html}</div>`
+  return `<script data-page="${id}" type="application/json">${json}</script><div data-server-rendered="true" id="${id}">${html}</div>`
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -603,9 +603,6 @@ export type InertiaAppConfig = {
     forceIndicesArrayFormatInFormData: boolean
     withAllErrors: boolean
   }
-  legacy: {
-    useDataAttributeForInitialPage: boolean
-  }
   prefetch: {
     cacheFor: CacheForOption | CacheForOption[]
     hoverDelay: number

--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -97,7 +97,6 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
   }
 
   const isServer = typeof window === 'undefined'
-  const useDataAttribute = config.get('legacy.useDataAttributeForInitialPage')
 
   const resolveComponent = (name: string, page?: Page) =>
     Promise.resolve(resolve!(name, page)).then((module) => {
@@ -134,13 +133,13 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
       }
 
       const html = renderToString(reactApp)
-      const body = buildSSRBody(id, page, html, !useDataAttribute)
+      const body = buildSSRBody(id, page, html)
 
       return { head, body }
     }
   }
 
-  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useDataAttribute)!
+  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id)!
 
   let head: string[] = []
 
@@ -189,7 +188,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   if (isServer && render && reactApp) {
     const html = render(reactApp)
-    const body = buildSSRBody(id, initialPage, html, !useDataAttribute)
+    const body = buildSSRBody(id, initialPage, html)
 
     return { head, body }
   }

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -74,7 +74,6 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
   }
 
   const isServer = typeof window === 'undefined'
-  const useDataAttribute = config.get('legacy.useDataAttributeForInitialPage')
 
   const resolveComponent = (name: string, page?: Page) => Promise.resolve(resolve!(name, page))
 
@@ -103,7 +102,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
         svelteApp = render(App, { props })
       }
 
-      const body = buildSSRBody(id, page, svelteApp.body, !useDataAttribute)
+      const body = buildSSRBody(id, page, svelteApp.body)
 
       return {
         body,
@@ -112,7 +111,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     }
   }
 
-  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useDataAttribute)!
+  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id)!
 
   const [initialComponent] = await Promise.all([
     resolveComponent(initialPage.component, initialPage) as Promise<ResolvedComponent>,
@@ -130,7 +129,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     const svelteApp = await setup({ el: null, App, props })
 
     if (svelteApp) {
-      const body = buildSSRBody(id, initialPage, svelteApp.body, !useDataAttribute)
+      const body = buildSSRBody(id, initialPage, svelteApp.body)
 
       return {
         body,

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -97,7 +97,6 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
   }
 
   const isServer = typeof window === 'undefined'
-  const useDataAttribute = config.get('legacy.useDataAttributeForInitialPage')
 
   const resolveComponent = (name: string, page?: Page) =>
     Promise.resolve(resolve!(name, page)).then((module) => module.default || module)
@@ -134,13 +133,13 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
       }
 
       const html = await renderToString(vueApp)
-      const body = buildSSRBody(id, page, html, !useDataAttribute)
+      const body = buildSSRBody(id, page, html)
 
       return { head, body }
     }
   }
 
-  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id, useDataAttribute)!
+  const initialPage = page || getInitialPageFromDOM<Page<SharedProps>>(id)!
 
   let head: string[] = []
 
@@ -195,7 +194,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   if (isServer && render && vueApp) {
     const html = await render(vueApp)
-    const body = buildSSRBody(id, initialPage, html, !useDataAttribute)
+    const body = buildSSRBody(id, initialPage, html)
 
     return { head, body }
   }

--- a/playgrounds/react/config/inertia.php
+++ b/playgrounds/react/config/inertia.php
@@ -59,10 +59,6 @@ return [
     | The `paths` and `extensions` options define where to look for page
     | components and which file extensions to consider.
     |
-    | By default, the initial page data is passed via a script element.
-    | Set `use_data_attribute_for_initial_page` to true to use a data
-    | attribute on the root element instead.
-    |
     */
 
     'pages' => [
@@ -85,8 +81,6 @@ return [
             'vue',
 
         ],
-
-        'use_data_attribute_for_initial_page' => (bool) env('INERTIA_USE_DATA_ATTRIBUTE_FOR_INITIAL_PAGE', false),
 
     ],
 

--- a/playgrounds/svelte5/config/inertia.php
+++ b/playgrounds/svelte5/config/inertia.php
@@ -59,10 +59,6 @@ return [
     | The `paths` and `extensions` options define where to look for page
     | components and which file extensions to consider.
     |
-    | By default, the initial page data is passed via a script element.
-    | Set `use_data_attribute_for_initial_page` to true to use a data
-    | attribute on the root element instead.
-    |
     */
 
     'pages' => [
@@ -85,8 +81,6 @@ return [
             'vue',
 
         ],
-
-        'use_data_attribute_for_initial_page' => (bool) env('INERTIA_USE_DATA_ATTRIBUTE_FOR_INITIAL_PAGE', false),
 
     ],
 

--- a/playgrounds/vue3/config/inertia.php
+++ b/playgrounds/vue3/config/inertia.php
@@ -59,10 +59,6 @@ return [
     | The `paths` and `extensions` options define where to look for page
     | components and which file extensions to consider.
     |
-    | By default, the initial page data is passed via a script element.
-    | Set `use_data_attribute_for_initial_page` to true to use a data
-    | attribute on the root element instead.
-    |
     */
 
     'pages' => [
@@ -85,8 +81,6 @@ return [
             'vue',
 
         ],
-
-        'use_data_attribute_for_initial_page' => (bool) env('INERTIA_USE_DATA_ATTRIBUTE_FOR_INITIAL_PAGE', false),
 
     ],
 


### PR DESCRIPTION
This removes the `legacy.useDataAttributeForInitialPage` config option that allowed falling back to the v2 behavior of passing initial page data via a `data-page` attribute on the root element.