### PR TITLE
[2.x] Fix flash data being cleared by `history.replaceState`

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -169,7 +169,10 @@ class History {
       return
     }
 
-    currentPage.merge(page)
+    // Exclude flash from the merge to prevent callers (like router.remember())
+    // from accidentally clearing flash data on the current page.
+    const { flash, ...pageWithoutFlash } = page
+    currentPage.merge(pageWithoutFlash)
 
     if (isServer) {
       return

--- a/packages/react/test-app/Pages/Flash/WithInfiniteScroll.tsx
+++ b/packages/react/test-app/Pages/Flash/WithInfiniteScroll.tsx
@@ -1,0 +1,30 @@
+import { InfiniteScroll, router, usePage } from '@inertiajs/react'
+import { useRef, useState } from 'react'
+
+export default ({ users }: { users: { data: { id: number; name: string }[] } }) => {
+  const page = usePage()
+  const [flashEventCount, setFlashEventCount] = useState(0)
+  const listenerSetup = useRef(false)
+
+  if (!listenerSetup.current) {
+    listenerSetup.current = true
+    router.on('flash', () => {
+      setFlashEventCount((n) => n + 1)
+    })
+  }
+
+  return (
+    <div>
+      <span id="flash">{JSON.stringify(page.flash)}</span>
+      <span id="flash-event-count">{flashEventCount}</span>
+
+      <InfiniteScroll data="users" style={{ display: 'grid', gap: '20px' }}>
+        {users.data.map((user) => (
+          <div key={user.id} style={{ height: '15vh', border: '1px solid #ccc' }}>
+            {user.name}
+          </div>
+        ))}
+      </InfiniteScroll>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/Flash/WithInfiniteScroll.svelte
+++ b/packages/svelte/test-app/Pages/Flash/WithInfiniteScroll.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { InfiniteScroll, page, router } from '@inertiajs/svelte'
+
+  export let users: { data: { id: number; name: string }[] }
+
+  let flashEventCount = 0
+
+  router.on('flash', () => {
+    flashEventCount++
+  })
+</script>
+
+<div>
+  <span id="flash">{JSON.stringify($page.flash)}</span>
+  <span id="flash-event-count">{flashEventCount}</span>
+
+  <InfiniteScroll data="users" style="display: grid; gap: 20px">
+    {#each users.data as user (user.id)}
+      <div style="height: 15vh; border: 1px solid #ccc">
+        {user.name}
+      </div>
+    {/each}
+  </InfiniteScroll>
+</div>

--- a/packages/vue3/test-app/Pages/Flash/WithInfiniteScroll.vue
+++ b/packages/vue3/test-app/Pages/Flash/WithInfiniteScroll.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { InfiniteScroll, router, usePage } from '@inertiajs/vue3'
+import { ref } from 'vue'
+
+defineProps<{
+  users: {
+    data: { id: number; name: string }[]
+  }
+}>()
+
+const page = usePage()
+const flashEventCount = ref(0)
+
+router.on('flash', () => {
+  flashEventCount.value++
+})
+</script>
+
+<template>
+  <div>
+    <span id="flash">{{ JSON.stringify(page.flash) }}</span>
+    <span id="flash-event-count">{{ flashEventCount }}</span>
+
+    <InfiniteScroll data="users" style="display: grid; gap: 20px">
+      <div v-for="user in users.data" :key="user.id" style="height: 15vh; border: 1px solid #ccc">
+        {{ user.name }}
+      </div>
+    </InfiniteScroll>
+  </div>
+</template>

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,21 @@
+**Commit message:**
+
+```
+Fix flash data being cleared by history.replaceState during component swap
+```
+
+**PR title:**
+
+```
+Fix flash data being cleared when page uses InfiniteScroll
+```
+
+**PR description:**
+
+```
+When navigating to a page with `<InfiniteScroll>`, the flash event (`router.on('flash')`) was never fired. The `<InfiniteScroll>` component calls `router.remember()` during mount, which triggers `history.replaceState()`, which in turn calls `currentPage.merge()` with `flash: {}` from `getWithoutFlashData()`. This overwrites the flash data that was just set on the page, so by the time `handleSuccess()` checks for flash data, it's already gone.
+
+The fix excludes flash data from the merge in `history.replaceState()`, preventing callers like `router.remember()` from accidentally clearing it. Flash data is only set through `currentPage.set()` (via `this.page = page`), never through `replaceState()` → `merge()`.
+
+Fixes #2856.
+```

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2134,6 +2134,24 @@ app.get('/flash/initial', (req, res) =>
     flash: { message: 'Hello from server' },
   }),
 )
+app.get('/flash/with-infinite-scroll', (req, res) => {
+  const page = req.query.page ? parseInt(req.query.page) : 1
+  const partialReload = !!req.headers['x-inertia-partial-data']
+  const shouldAppend = req.headers['x-inertia-infinite-scroll-merge-intent'] !== 'prepend'
+  const { paginated, scrollProp } = paginateUsers(page, 15, 40, false)
+
+  setTimeout(
+    () =>
+      inertia.render(req, res, {
+        component: 'Flash/WithInfiniteScroll',
+        props: { users: paginated },
+        [shouldAppend ? 'mergeProps' : 'prependProps']: ['users.data'],
+        scrollProps: { users: scrollProp },
+        flash: partialReload ? {} : { message: 'Flash with infinite scroll' },
+      }),
+    partialReload ? 250 : 0,
+  )
+})
 app.get('/flash/with-deferred', (req, res) => {
   if (!req.headers['x-inertia-partial-data']) {
     return inertia.render(req, res, {

--- a/tests/flash.spec.ts
+++ b/tests/flash.spec.ts
@@ -38,6 +38,16 @@ test.describe('Flash Data', () => {
     await expect(page.locator('#flash-event-count')).toHaveText('1')
   })
 
+  test('preserves flash data and fires event when page has InfiniteScroll', async ({ page }) => {
+    await page.goto('/')
+
+    await page.evaluate(() => window.testing.Inertia.visit('/flash/with-infinite-scroll'))
+    await page.waitForURL('**/flash/with-infinite-scroll')
+
+    await expect(page.locator('#flash')).toContainText('Flash with infinite scroll')
+    await expect(page.locator('#flash-event-count')).toHaveText('1')
+  })
+
   test('does not fire flash event on partial request when flash is unchanged', async ({ page }) => {
     await page.goto('/flash/partial')
 


### PR DESCRIPTION
This PR excludes flash data from the merge in `history.replaceState()`, preventing callers like `router.remember()` from accidentally clearing it.

Fixes #2856.