### PR TITLE
[2.x] Normalize flash event behavior on partial requests

### DIFF
--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -89,7 +89,7 @@ export class Response {
 
     const { flash } = currentPage.get()
 
-    if (Object.keys(flash).length > 0 && (!this.requestParams.isPartial() || !isEqual(flash, previousFlash))) {
+    if (Object.keys(flash).length > 0) {
       fireFlashEvent(flash)
       this.requestParams.all().onFlash(flash)
     }

--- a/tests/flash.spec.ts
+++ b/tests/flash.spec.ts
@@ -48,20 +48,18 @@ test.describe('Flash Data', () => {
     await expect(page.locator('#flash-event-count')).toHaveText('1')
   })
 
-  test('does not fire flash event on partial request when flash is unchanged', async ({ page }) => {
+  test('fires flash event on partial request when flash is unchanged', async ({ page }) => {
     await page.goto('/flash/partial')
 
     await expect(page.locator('#flash')).toContainText('Initial flash')
     await expect(page.locator('#flash-event-count')).toHaveText('1')
 
-    const initialCount = await page.locator('#count').textContent()
     const responsePromise = page.waitForResponse((res) => res.url().includes('/flash/partial'))
     await page.getByRole('button', { name: 'Reload with same flash' }).click()
     await responsePromise
 
-    await expect(page.locator('#count')).not.toHaveText(initialCount!)
     await expect(page.locator('#flash')).toContainText('Initial flash')
-    await expect(page.locator('#flash-event-count')).toHaveText('1')
+    await expect(page.locator('#flash-event-count')).toHaveText('2')
   })
 
   test('fires flash event on partial request when flash changes', async ({ page }) => {


### PR DESCRIPTION
In current versions of Inertia v2, the `onFlash` callback is only triggered when the `flash` prop differs from the previous response.

This occurs because, during partial requests only, Inertia compares the resolved `flash` prop using an equality check. If the `flash` payload contains identical values between partial requests, Inertia treats it as unchanged and does not trigger `onFlash`.

So:
```php
Inertia.flash({ records_affected: 1 });
```

followed by:
```php
Inertia.flash({ records_affected: 1 });
```

will only trigger `onFlash` once, even though both responses explicitly include flash data.

This behavior is inconsistent with the [documented purpose of flash data](https://inertiajs.com/docs/v2/data-props/flash-data), which is intended to **represent one-time, per-response state**. Flash data should be treated as an event-like payload rather than persistent state, and its presence in the response should be sufficient to trigger `onFlash`, regardless of value equality.

This makes it difficult to reliably use `onFlash `for user feedback such as success messages or action confirmations when the underlying value does not change.

**Please note:**
I was unable to run the test suite locally. However, I updated the relevant tests to reflect what I believe to be the expected behavior introduced by this PR.

Fixes Issue: https://github.com/inertiajs/inertia/issues/2900