### PR TITLE
Include resources directory in published packages

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "types"
+    "types",
+    "resources"
   ],
   "type": "module",
   "main": "dist/index.js",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -19,7 +19,8 @@
   "files": [
     "dist",
     "!dist/**/*.test.*",
-    "!dist/**/*.spec.*"
+    "!dist/**/*.spec.*",
+    "resources"
   ],
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -17,7 +17,8 @@
   },
   "files": [
     "dist",
-    "types"
+    "types",
+    "resources"
   ],
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
The `resources` directory is not included when the React, Vue, and Svelte adapter packages are published to npm.