### PR TITLE
[3.x] Fix axios adapter being required

### DIFF
--- a/packages/core/src/axiosHttpClient.ts
+++ b/packages/core/src/axiosHttpClient.ts
@@ -55,6 +55,7 @@ function loadAxiosModule(): Promise<typeof import('axios')> {
       throw error
     })
   }
+
   return axiosModulePromise
 }
 


### PR DESCRIPTION
This PR fixes a build error if axios isn't installed. It uses dynamic import since exporting adapter broke `instanceof` usage for adapters.

Related PR: https://github.com/laravel/precognition/pull/142

