### PR TITLE
[3.x] Fix duplicate base path in Vite SSR CSS link URLs

### DIFF
--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -33,7 +33,7 @@ export function collectCSSFromModuleGraph(server: ViteDevServer, entry: string):
 
   const origin = resolveDevServerOrigin(server)
   const base = server.config.base || '/'
-  const basePrefix = base === '/' ? '' : base
+  const basePrefix = base === '/' ? '' : base.replace(/\/$/, '')
 
   return cssModules.map(({ url, id }) => {
     const href = `${origin}${basePrefix}${url}`
@@ -82,9 +82,7 @@ function isCSSRequest(url: string): boolean {
 
 function resolveDevServerOrigin(server: ViteDevServer): string {
   if (server.resolvedUrls?.local[0]) {
-    const url = new URL(server.resolvedUrls.local[0])
-
-    return `${url.protocol}//${url.host}`
+    return new URL(server.resolvedUrls.local[0]).origin
   }
 
   const protocol = server.config.server.https ? 'https' : 'http'

--- a/packages/vite/tests/ssr.test.ts
+++ b/packages/vite/tests/ssr.test.ts
@@ -575,6 +575,49 @@ describe('SSR', () => {
       ])
     })
 
+    it('does not duplicate base path in CSS link URLs', async () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('resources/js/ssr.ts'))
+
+      const plugin = inertia()
+      const logger = createMockLogger()
+      const server = createMockServer(logger, { base: '/build/' })
+
+      const cssModule = {
+        url: '/resources/css/app.css',
+        id: '/project/resources/css/app.css',
+        importedModules: new Set(),
+      }
+      const entryModule = {
+        url: '/resources/js/ssr.ts',
+        id: '/project/resources/js/ssr.ts',
+        importedModules: new Set([cssModule]),
+      }
+
+      server.environments.ssr.moduleGraph.getModuleById.mockImplementation((id: string) =>
+        id === '/project/resources/js/ssr.ts' ? entryModule : undefined,
+      )
+      server.ssrLoadModule.mockResolvedValue({
+        default: vi.fn().mockResolvedValue({
+          head: [],
+          body: '<div id="app">Hello</div>',
+        }),
+      })
+
+      plugin.configResolved!(createMockConfig(logger, false, { base: '/build/' }))
+      plugin.configureServer!(server)
+
+      const middleware = server.middlewares.use.mock.calls[0][1]
+      const req = createMockRequest('POST', JSON.stringify({ component: 'Test', props: {} }))
+      const res = createMockResponse()
+
+      await middleware(req, res, vi.fn())
+
+      const response = JSON.parse(res.end.mock.calls[0][0])
+      expect(response.head).toEqual([
+        '<link rel="stylesheet" href="http://localhost:5173/build/resources/css/app.css" data-vite-dev-id="/project/resources/css/app.css">',
+      ])
+    })
+
     it('returns no CSS links when entry module is not in graph', async () => {
       mockExistsSync.mockImplementation((path: string) => path.endsWith('resources/js/ssr.ts'))
 
@@ -761,18 +804,25 @@ function createMockLogger() {
   return { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }
 
-function createMockConfig(logger: ReturnType<typeof createMockLogger>, ssr: boolean): ResolvedConfig {
-  return { root: '/project', logger, plugins: [], build: { ssr }, command: 'build' } as unknown as ResolvedConfig
+function createMockConfig(
+  logger: ReturnType<typeof createMockLogger>,
+  ssr: boolean,
+  { base = '/' }: { base?: string } = {},
+): ResolvedConfig {
+  return { root: '/project', logger, plugins: [], build: { ssr }, command: 'build', base } as unknown as ResolvedConfig
 }
 
-function createMockServer(logger: ReturnType<typeof createMockLogger>): ViteDevServer {
+function createMockServer(
+  logger: ReturnType<typeof createMockLogger>,
+  { base = '/' }: { base?: string } = {},
+): ViteDevServer {
   return {
     middlewares: { use: vi.fn() },
     ssrLoadModule: vi.fn(),
     ssrFixStacktrace: vi.fn(),
     environments: { ssr: { moduleGraph: { getModuleById: vi.fn() } } },
-    resolvedUrls: { local: ['http://localhost:5173/'], network: [] },
-    config: { logger, base: '/', root: '/project' },
+    resolvedUrls: { local: [`http://localhost:5173${base}`], network: [] },
+    config: { logger, base, root: '/project' },
   } as unknown as ViteDevServer
 }
 


### PR DESCRIPTION
Fixes #2932

`resolveDevServerOrigin()` was returning the full resolved URL from Vite, which already includes the configured base path (e.g. `http://localhost:5172/build`). Then `collectCSSFromModuleGraph()` added the base path again via `basePrefix`, producing doubled paths like `/build/build/` in the generated CSS link tags.

Fixed by using URL parsing to extract just the origin (protocol + host + port) from the resolved URL, so the base path is only added once.