### PR TITLE
[3.x] Populate global page store during Svelte 5 SSR

### DIFF
--- a/packages/react/test-app/Pages/SSR/Page1.tsx
+++ b/packages/react/test-app/Pages/SSR/Page1.tsx
@@ -1,26 +1,32 @@
-import { Link } from '@inertiajs/react'
+import { Link, usePage } from '@inertiajs/react'
 
-export default ({ user, items, count }: { user: { name: string; email: string }; items: string[]; count: number }) => (
-  <div>
-    <h1 data-testid="ssr-title">SSR Page 1</h1>
+export default ({ user, items, count }: { user: { name: string; email: string }; items: string[]; count: number }) => {
+  const page = usePage()
 
-    <div data-testid="user-info">
-      <p data-testid="user-name">Name: {user.name}</p>
-      <p data-testid="user-email">Email: {user.email}</p>
+  return (
+    <div>
+      <h1 data-testid="ssr-title">SSR Page 1</h1>
+
+      <p data-testid="page-url">URL: {page.url}</p>
+
+      <div data-testid="user-info">
+        <p data-testid="user-name">Name: {user.name}</p>
+        <p data-testid="user-email">Email: {user.email}</p>
+      </div>
+
+      <ul data-testid="items-list">
+        {items.map((item) => (
+          <li key={item} data-testid="item">
+            {item}
+          </li>
+        ))}
+      </ul>
+
+      <p data-testid="count">Count: {count}</p>
+
+      <Link href="/ssr/page2" data-testid="navigate-link">
+        Navigate to another page
+      </Link>
     </div>
-
-    <ul data-testid="items-list">
-      {items.map((item) => (
-        <li key={item} data-testid="item">
-          {item}
-        </li>
-      ))}
-    </ul>
-
-    <p data-testid="count">Count: {count}</p>
-
-    <Link href="/ssr/page2" data-testid="navigate-link">
-      Navigate to another page
-    </Link>
-  </div>
-)
+  )
+}

--- a/packages/svelte/src/components/App.svelte
+++ b/packages/svelte/src/components/App.svelte
@@ -35,6 +35,10 @@
   let page = $state({ ...initialPage, flash: initialPage.flash ?? {} })
   let renderProps = $derived.by<RenderProps>(() => resolveRenderProps(component, page, key))
 
+  // Synchronous initialization so the global page store is populated during SSR
+  // ($effect.pre does not run during Svelte 5 SSR)
+  setPage(page)
+
   // Reactively update the global page state when local page state changes
   $effect.pre(() => {
     setPage(page)

--- a/packages/svelte/test-app/Pages/SSR/Page1.svelte
+++ b/packages/svelte/test-app/Pages/SSR/Page1.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { inertia } from '@inertiajs/svelte'
+  import { inertia, usePage } from '@inertiajs/svelte'
 
   interface Props {
     user: { name: string; email: string }
@@ -8,10 +8,14 @@
   }
 
   let { user, items, count }: Props = $props()
+
+  const page = usePage()
 </script>
 
 <div>
   <h1 data-testid="ssr-title">SSR Page 1</h1>
+
+  <p data-testid="page-url">URL: {page.url}</p>
 
   <div data-testid="user-info">
     <p data-testid="user-name">Name: {user.name}</p>

--- a/packages/vue3/test-app/Pages/SSR/Page1.vue
+++ b/packages/vue3/test-app/Pages/SSR/Page1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Link } from '@inertiajs/vue3'
+import { Link, usePage } from '@inertiajs/vue3'
 
 defineProps<{
   user: {
@@ -9,11 +9,15 @@ defineProps<{
   items: string[]
   count: number
 }>()
+
+const page = usePage()
 </script>
 
 <template>
   <div>
     <h1 data-testid="ssr-title">SSR Page 1</h1>
+
+    <p data-testid="page-url">URL: {{ page.url }}</p>
 
     <div data-testid="user-info">
       <p data-testid="user-name">Name: {{ user.name }}</p>

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -18,6 +18,7 @@ test.describe('SSR', () => {
       expect(html).toContain('Item 2')
       expect(html).toContain('Item 3')
       expect(html).toMatch(/Count:.*42/)
+      expect(html).toMatch(/URL:.*\/ssr\/page1/)
     })
 
     test('hydrates correctly after initial SSR load', async ({ page }) => {
@@ -28,6 +29,7 @@ test.describe('SSR', () => {
       await expect(page.getByTestId('ssr-title')).toHaveText('SSR Page 1')
       await expect(page.getByTestId('user-name')).toHaveText('Name: John Doe')
       await expect(page.getByTestId('count')).toHaveText('Count: 42')
+      await expect(page.getByTestId('page-url')).toHaveText('URL: /ssr/page1')
 
       expect(consoleMessages.errors).toHaveLength(0)
     })
@@ -101,6 +103,7 @@ test.describe('SSR Auto Transform', () => {
       expect(html).toContain('Auto 2')
       expect(html).toContain('Auto 3')
       expect(html).toMatch(/Count:.*100/)
+      expect(html).toMatch(/URL:.*\/ssr-auto\/page1/)
     })
 
     test('it hydrates correctly after SSR with auto-transformed entry', async ({ page }) => {


### PR DESCRIPTION
In Svelte 5, `$effect.pre()` does not execute during SSR because `render()` from `svelte/server` is purely synchronous and skips all effects. This means the global page store exported from `@inertiajs/svelte` is never populated during server-side rendering, so any component reading `usePage()` or the `page` store receives empty props.

This adds a synchronous `setPage()` call in `App.svelte` that runs unconditionally during component initialization, ensuring the global store is populated before the render. The `$effect.pre` is kept for reactive client-side updates.

Fixes #2934.