### PR TITLE
[3.x] fix: always fire flash event regardless of partial reload equality

### DIFF
--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -84,8 +84,6 @@ export class Response {
 
     history.preserveUrl = this.requestParams.all().preserveUrl
 
-    const previousFlash = currentPage.get().flash
-
     await this.setPage()
 
     const errors = currentPage.get().props.errors || {}
@@ -108,7 +106,7 @@ export class Response {
 
     const { flash } = currentPage.get()
 
-    if (Object.keys(flash).length > 0 && (!this.requestParams.isPartial() || !isEqual(flash, previousFlash))) {
+    if (Object.keys(flash).length > 0 && !this.requestParams.isDeferredPropsRequest()) {
       fireFlashEvent(flash)
       this.requestParams.all().onFlash(flash)
     }

--- a/tests/flash.spec.ts
+++ b/tests/flash.spec.ts
@@ -48,7 +48,7 @@ test.describe('Flash Data', () => {
     await expect(page.locator('#flash-event-count')).toHaveText('1')
   })
 
-  test('does not fire flash event on partial request when flash is unchanged', async ({ page }) => {
+  test('fires flash event on partial request even when flash is unchanged', async ({ page }) => {
     await page.goto('/flash/partial')
 
     await expect(page.locator('#flash')).toContainText('Initial flash')
@@ -61,7 +61,7 @@ test.describe('Flash Data', () => {
 
     await expect(page.locator('#count')).not.toHaveText(initialCount!)
     await expect(page.locator('#flash')).toContainText('Initial flash')
-    await expect(page.locator('#flash-event-count')).toHaveText('1')
+    await expect(page.locator('#flash-event-count')).toHaveText('2')
   })
 
   test('fires flash event on partial request when flash changes', async ({ page }) => {


### PR DESCRIPTION
During partial reloads, `onFlash` was silently suppressed when the `flash` payload was identical to the previous response. This caused `onFlash` to fire only once even when the server explicitly returned flash data on every request.

`flash` is response-scoped protocol data that lives outside `page.props` and is not governed by `X-Inertia-Partial-Data` filtering. Its presence in the response is sufficient to trigger `onFlash`, regardless of value equality or partial reload status.

```ts
// before — flash event skipped if payload unchanged during partial reload
if (Object.keys(flash).length > 0 && (!this.requestParams.isPartial() || !isEqual(flash, previousFlash))) {
  fireFlashEvent(flash)
  this.requestParams.all().onFlash(flash)
}

// after — flash event fires on every response that carries flash,
// except deferred props background fetches (which replay the same flash from the initial load)
if (Object.keys(flash).length > 0 && !this.requestParams.isDeferredPropsRequest()) {
  fireFlashEvent(flash)
  this.requestParams.all().onFlash(flash)
}
```

Deferred props requests are background partial reloads triggered automatically after the initial page load to lazy-fetch slow props. They carry the same flash from the initial response, so excluding them prevents `onFlash` from firing twice for a single page load.

This is a port of #2902 to the `3.x` branch.
Fixes #2900.