### PR TITLE
[v3.x] refactor(svelte)!: migrate useLayoutProps from stores to runes

### DIFF
--- a/packages/svelte/resources/boost/skills/inertia-svelte-development/SKILL.blade.php
+++ b/packages/svelte/resources/boost/skills/inertia-svelte-development/SKILL.blade.php
@@ -389,8 +389,8 @@ const layout = useLayoutProps({
 let { children } = $props()
 </script>
 
-<header>{$layout.title}</header>
-{#if $layout.showSidebar}
+<header>{layout.title}</header>
+{#if layout.showSidebar}
     <aside>Sidebar</aside>
 {/if}
 <main>

--- a/packages/svelte/src/layoutProps.svelte.ts
+++ b/packages/svelte/src/layoutProps.svelte.ts
@@ -1,8 +1,18 @@
 import { createLayoutPropsStore, mergeLayoutProps } from '@inertiajs/core'
 import { getContext } from 'svelte'
-import { readable, type Readable } from 'svelte/store'
 
 const store = createLayoutPropsStore()
+
+const storeState = $state({
+  shared: {} as Record<string, unknown>,
+  named: {} as Record<string, Record<string, unknown>>,
+})
+
+store.subscribe(() => {
+  const snapshot = store.get()
+  storeState.shared = snapshot.shared
+  storeState.named = snapshot.named
+})
 
 export function setLayoutProps(props: Record<string, unknown>): void {
   store.set(props)
@@ -18,18 +28,23 @@ export function resetLayoutProps(): void {
 
 export const LAYOUT_CONTEXT_KEY = Symbol('inertia-layout')
 
-export function useLayoutProps<T extends Record<string, unknown>>(defaults: T): Readable<T> {
+export function useLayoutProps<T extends Record<string, unknown>>(defaults: T): T {
   const context = getContext<{ readonly staticProps: Record<string, unknown>; readonly name?: string } | undefined>(
     LAYOUT_CONTEXT_KEY,
   )
 
-  const resolve = () => {
+  const resolve = (): T => {
     const staticProps = context?.staticProps ?? {}
     const name = context?.name
-    const { shared, named } = store.get()
-    const dynamicProps = name ? { ...shared, ...named[name] } : shared
+    const dynamicProps = name ? { ...storeState.shared, ...(storeState.named[name] ?? {}) } : storeState.shared
     return mergeLayoutProps(defaults, staticProps, dynamicProps)
   }
 
-  return readable<T>(resolve(), (set) => store.subscribe(() => set(resolve())))
+  const state = $state<T>(resolve())
+
+  $effect.pre(() => {
+    Object.assign(state, resolve())
+  })
+
+  return state
 }

--- a/packages/svelte/test-app/Layouts/AppLayout.svelte
+++ b/packages/svelte/test-app/Layouts/AppLayout.svelte
@@ -19,12 +19,12 @@
   })
 </script>
 
-<div data-theme={$layoutProps.theme} class="app-layout">
+<div data-theme={layoutProps.theme} class="app-layout">
   <header>
-    <h1 class="app-title">{$layoutProps.title}</h1>
+    <h1 class="app-title">{layoutProps.title}</h1>
   </header>
   <div class="app-content">
-    {#if $layoutProps.showSidebar}
+    {#if layoutProps.showSidebar}
       <aside class="sidebar">
         <span>Sidebar</span>
       </aside>

--- a/packages/svelte/test-app/Layouts/ContentLayout.svelte
+++ b/packages/svelte/test-app/Layouts/ContentLayout.svelte
@@ -18,7 +18,7 @@
   })
 </script>
 
-<div class="content-layout" data-padding={$layoutProps.padding} data-max-width={$layoutProps.maxWidth}>
+<div class="content-layout" data-padding={layoutProps.padding} data-max-width={layoutProps.maxWidth}>
   <div class="content-wrapper">
     {@render children?.()}
   </div>


### PR DESCRIPTION
## Changes

- Migrate `useLayoutProps` from Svelte `readable` store to Svelte 5 `$state` + `$effect.pre` runes
  - Replaces per-component store subscriptions with a single module-level `$state`, consistent with how `page.svelte.ts` works
  - Layout props now use direct property access `layout.title` (no more `$` needed), consistent with `page.props` and other reactive state **(breaking change)**:
    ```diff
    - <title>{$layout.title ? `${$layout.title} - ` : ""}{page.props.appName}</title>
    + <title>{layout.title ? `${layout.title} - ` : ""}{page.props.appName}</title>
    ```
- Remove last `svelte/store` dependency from the Svelte adapter

## Note

If this PR is merged, I can open a PR to the v3 docs as well.