### PR TITLE
[2.x] Remove request from stream on network failure

### DIFF
--- a/packages/core/src/requestStream.ts
+++ b/packages/core/src/requestStream.ts
@@ -15,7 +15,7 @@ export class RequestStream {
   public send(request: Request) {
     this.requests.push(request)
 
-    request.send().then(() => {
+    request.send().finally(() => {
       this.requests = this.requests.filter((r) => r !== request)
     })
   }

--- a/packages/react/test-app/Pages/NetworkError.tsx
+++ b/packages/react/test-app/Pages/NetworkError.tsx
@@ -1,0 +1,28 @@
+import { router } from '@inertiajs/react'
+import { useEffect, useState } from 'react'
+
+export default () => {
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    return router.on('exception', () => {
+      setError(true)
+      return false
+    })
+  }, [])
+
+  function makeRequest() {
+    setError(false)
+    router.get('/network-error')
+  }
+
+  return (
+    <div>
+      <h1>Network Error</h1>
+      {error && <div id="network-error">Network error occurred</div>}
+      <button id="make-request" onClick={makeRequest}>
+        Make Request
+      </button>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/NetworkError.svelte
+++ b/packages/svelte/test-app/Pages/NetworkError.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { router } from '@inertiajs/svelte'
+  import { onMount } from 'svelte'
+
+  let error = false
+
+  onMount(() => {
+    return router.on('exception', () => {
+      error = true
+      return false
+    })
+  })
+
+  function makeRequest() {
+    error = false
+    router.get('/network-error')
+  }
+</script>
+
+<div>
+  <h1>Network Error</h1>
+  {#if error}
+    <div id="network-error">Network error occurred</div>
+  {/if}
+  <button id="make-request" on:click={makeRequest}>Make Request</button>
+</div>

--- a/packages/vue3/test-app/Pages/NetworkError.vue
+++ b/packages/vue3/test-app/Pages/NetworkError.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3'
+import { onMounted, onUnmounted, ref } from 'vue'
+
+const error = ref(false)
+
+let removeListener: () => void
+
+onMounted(() => {
+  removeListener = router.on('exception', () => {
+    error.value = true
+    return false
+  })
+})
+
+onUnmounted(() => removeListener?.())
+
+function makeRequest() {
+  error.value = false
+  router.get('/network-error')
+}
+</script>
+
+<template>
+  <div>
+    <h1>Network Error</h1>
+    <div v-if="error" id="network-error">Network error occurred</div>
+    <button id="make-request" @click="makeRequest">Make Request</button>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2534,6 +2534,8 @@ app.get('/reload/concurrent-with-data', (req, res) => {
   )
 })
 
+app.get('/network-error', (req, res) => inertia.render(req, res, { component: 'NetworkError' }))
+
 app.all('*page', (req, res) => inertia.render(req, res))
 
 // Send errors to the console (instead of crashing the server)

--- a/tests/network-error.spec.ts
+++ b/tests/network-error.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('network error', () => {
+  test('it cleans up request stream after network failure', async ({ page }) => {
+    await page.goto('/network-error')
+
+    await page.route('**/network-error', async (route) => {
+      if (route.request().headers()['x-inertia']) {
+        await route.abort('failed')
+      } else {
+        await route.continue()
+      }
+    })
+
+    await page.locator('#make-request').click()
+    await expect(page.locator('#network-error')).toBeVisible()
+
+    await page.waitForFunction(() => (window.testing.Inertia as any).syncRequestStream.requests.length === 0)
+  })
+})


### PR DESCRIPTION
Backport of #2940 for the 2.x branch.

When `request.send()` rejects due to a network failure, the request was never removed from the `requests` array because only `.then()` was used. This changes it to `.finally()` so the cleanup always runs regardless of whether the promise fulfilled or rejected.

The test pages use `router.on('exception', ...)` instead of the `onNetworkError` callback since that doesn't exist on 2.x.