### PR TITLE
[3.x] fix(type): add Record<string, string> to UrlMethodPair type 

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -698,7 +698,7 @@ export type ProgressSettings = {
   popover: boolean | null
 }
 
-export type UrlMethodPair = { url: string; method: Method; component?: string | string[] }
+export type UrlMethodPair = { url: string; method: Method; component?: string | string[] | Record<string, string> }
 
 export type UseFormTransformCallback<TForm> = (data: TForm) => object
 export type UseFormWithPrecognitionArguments =


### PR DESCRIPTION
Working on a project with `laravel/wayfinder-next`. Tried out v3-beta and got Typescript errors for example for `:action="store()"` and `form.submit(store())`. Only `submit(store().method, store().url) ` was okay.

Reason is that `Record<string, string>` was added to RouteDefinition in wayfinder.
[PR Change](https://github.com/laravel/wayfinder/pull/180/changes#diff-1644523c11defafd9ad2b3ef570b66249be7ded6e3e2e3a5f3c25ce1a4c9e8f8R20)
[PR wayfinder #180](https://github.com/laravel/wayfinder/pull/180)

So I extended `UrlMethodPair` in `packes/core/src/types.ts`:
```ts
export type UrlMethodPair = { url: string; method: Method; component?: string | string[] | Record<string, string> }
```
