### PR TITLE
[2.x] fix: always fire flash event regardless of partial reload equality

### DIFF
--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -65,8 +65,6 @@ export class Response {
 
     history.preserveUrl = this.requestParams.all().preserveUrl
 
-    const previousFlash = currentPage.get().flash
-
     await this.setPage()
 
     const errors = currentPage.get().props.errors || {}
@@ -89,7 +87,7 @@ export class Response {
 
     const { flash } = currentPage.get()
 
-    if (Object.keys(flash).length > 0 && (!this.requestParams.isPartial() || !isEqual(flash, previousFlash))) {
+    if (Object.keys(flash).length > 0 && !this.requestParams.isDeferredPropsRequest()) {
       fireFlashEvent(flash)
       this.requestParams.all().onFlash(flash)
     }

--- a/tests/flash.spec.ts
+++ b/tests/flash.spec.ts
@@ -48,7 +48,7 @@ test.describe('Flash Data', () => {
     await expect(page.locator('#flash-event-count')).toHaveText('1')
   })
 
-  test('does not fire flash event on partial request when flash is unchanged', async ({ page }) => {
+  test('fires flash event on partial request even when flash is unchanged', async ({ page }) => {
     await page.goto('/flash/partial')
 
     await expect(page.locator('#flash')).toContainText('Initial flash')
@@ -61,7 +61,7 @@ test.describe('Flash Data', () => {
 
     await expect(page.locator('#count')).not.toHaveText(initialCount!)
     await expect(page.locator('#flash')).toContainText('Initial flash')
-    await expect(page.locator('#flash-event-count')).toHaveText('1')
+    await expect(page.locator('#flash-event-count')).toHaveText('2')
   })
 
   test('fires flash event on partial request when flash changes', async ({ page }) => {


### PR DESCRIPTION
Backport of #2941. Fixes #2900.