### PR TITLE
[2.x] Remove `server-renderer` dependency from Vue adapter type

### DIFF
--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -11,7 +11,6 @@ import {
   SharedPageProps,
 } from '@inertiajs/core'
 import { createSSRApp, DefineComponent, h, Plugin, App as VueApp } from 'vue'
-import { renderToString } from 'vue/server-renderer'
 import App, { InertiaApp, InertiaAppProps, plugin } from './app'
 import { config } from './index'
 import { VueInertiaAppConfig } from './types'
@@ -40,7 +39,7 @@ type InertiaAppOptionsForSSR<SharedProps extends PageProps> = CreateInertiaAppOp
   VueApp,
   VueInertiaAppConfig
 > & {
-  render: typeof renderToString
+  render: (app: VueApp) => Promise<string>
 }
 
 export default async function createInertiaApp<SharedProps extends PageProps = PageProps & SharedPageProps>(


### PR DESCRIPTION
The Vue adapter's `createInertiaApp` type declarations import `renderToString` from `vue/server-renderer`, which transitively pulls in `node:stream` types. This causes TypeScript errors for projects that don't have `@types/node` installed and use `skipLibCheck: false`.

This replaces the `typeof renderToString` type with an explicit function signature.

Fixes #2921.