### PR TITLE
fix: skip view transition when document visibility is hidden

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -225,7 +225,7 @@ class CurrentPage {
   }): Promise<unknown> {
     const doSwap = () => this.swapComponent({ component, page, preserveState })
 
-    if (!viewTransition || !document?.startViewTransition) {
+    if (!viewTransition || !document?.startViewTransition || document.visibilityState === 'hidden') {
       return doSwap()
     }
 

--- a/tests/view-transitions.spec.ts
+++ b/tests/view-transitions.spec.ts
@@ -72,7 +72,9 @@ test.describe('View Transitions', () => {
     await expect(consoleMessages.messages).toEqual([])
   })
 
-  test('does not throw InvalidStateError when document visibility is hidden during view transition', async ({ page }) => {
+  test('does not throw InvalidStateError when document visibility is hidden during view transition', async ({
+    page,
+  }) => {
     consoleMessages.listen(page)
 
     await page.goto('/view-transition/page-a')

--- a/tests/view-transitions.spec.ts
+++ b/tests/view-transitions.spec.ts
@@ -71,4 +71,21 @@ test.describe('View Transitions', () => {
 
     await expect(consoleMessages.messages).toEqual([])
   })
+
+  test('does not throw InvalidStateError when document visibility is hidden during view transition', async ({ page }) => {
+    consoleMessages.listen(page)
+
+    await page.goto('/view-transition/page-a')
+    await expect(page.getByText('Page A - View Transition Test')).toBeVisible()
+
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+    })
+
+    await page.getByRole('button', { name: 'Transition with boolean' }).click()
+
+    await expect(page).toHaveURL('/view-transition/page-b')
+    await expect(page.getByText('Page B - View Transition Test')).toBeVisible()
+    await expect(consoleMessages.errors).toEqual([])
+  })
 })


### PR DESCRIPTION
Calling `document.startViewTransition()` when the document's visibility state is `hidden` (when the user has switched tabs, for example) throws an `InvalidStateError` in Safari.

Guard against this by falling back to a plain swap when the document is not visible.

Error message:
```
InvalidStateError
View transition was skipped because document visibility state is hidden.
```

[MDN](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API/Using#:~:text=Note:%20If%20the%20document's%20page%20visibility%20state%20is%20hidden%20(for%20example%20if%20the%20document%20is%20obscured%20by%20a%20window%2C%20the%20browser%20is%20minimized%2C%20or%20another%20browser%20tab%20is%20active)%20during%20a%20document.startViewTransition()%20call%2C%20the%20view%20transition%20is%20skipped%20entirely.) says

> Note: If the document's [page visibility state](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) is hidden (for example if the document is obscured by a window, the browser is minimized, or another browser tab is active) during a [document.startViewTransition()](https://developer.mozilla.org/en-US/docs/Web/API/Document/startViewTransition) call, the view transition is skipped entirely.

Safari turns it up a notch and throws this error.

---

I tried figuring [which branch](https://laravel.com/docs/contributions#which-branch) to merge this into, but I cannot figure it out 🤦‍♂️.
Please advise, and I can adjust.

Also, I cannot find any AI policy in the contribution guide, so full disclosure: Claude helped me here ☺️

