### PR TITLE
[3.x] Improve optimistic update rollback with multiple pending requests

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -1,4 +1,4 @@
-import { get, set } from 'lodash-es'
+import { cloneDeep, get, set } from 'lodash-es'
 import { eventHandler } from './eventHandler'
 import { fireNavigateEvent } from './events'
 import { history } from './history'
@@ -21,6 +21,9 @@ class CurrentPage {
   protected cleared = false
   protected pendingDeferredProps: Pick<Page, 'deferredProps' | 'url' | 'component'> | null = null
   protected historyQuotaExceeded = false
+  protected optimisticBaseline: Partial<Page['props']> = {}
+  protected pendingOptimistics: { id: number; callback: (props: Page['props']) => Partial<Page['props']> | void }[] = []
+  protected optimisticCounter = 0
 
   public init<ComponentType = Component>({
     initialPage,
@@ -90,7 +93,6 @@ class CurrentPage {
 
       // Clear flash data from the page object, we don't want it when navigating back/forward...
       const pageForHistory = { ...page, flash: {} }
-      delete pageForHistory.optimisticUpdatedAt
 
       return new Promise<void>((resolve) =>
         replace ? history.replaceState(pageForHistory, resolve) : history.pushState(pageForHistory, resolve),
@@ -252,22 +254,71 @@ class CurrentPage {
     return Promise.resolve(this.resolveComponent(component, page))
   }
 
-  public recordOptimisticUpdate(keys: string[], updatedAt: number): void {
-    if (!this.page.optimisticUpdatedAt) {
-      this.page.optimisticUpdatedAt = {}
-    }
+  public nextOptimisticId(): number {
+    return ++this.optimisticCounter
+  }
 
-    for (const key of keys) {
-      if (updatedAt > (this.page.optimisticUpdatedAt[key] || 0)) {
-        this.page.optimisticUpdatedAt[key] = updatedAt
-      }
+  public setBaseline(key: string, value: unknown): void {
+    if (!(key in this.optimisticBaseline)) {
+      this.optimisticBaseline[key] = value
     }
   }
 
-  public shouldPreserveOptimistic(key: string, updatedAt: number): boolean {
-    const lastUpdatedAt = this.page.optimisticUpdatedAt?.[key]
+  public updateBaseline(key: string, value: unknown): void {
+    if (key in this.optimisticBaseline) {
+      this.optimisticBaseline[key] = value
+    }
+  }
 
-    return lastUpdatedAt !== undefined && updatedAt < lastUpdatedAt
+  public hasBaseline(key: string): boolean {
+    return key in this.optimisticBaseline
+  }
+
+  public registerOptimistic(id: number, callback: (props: Page['props']) => Partial<Page['props']> | void): void {
+    this.pendingOptimistics.push({ id, callback })
+  }
+
+  public unregisterOptimistic(id: number): void {
+    this.pendingOptimistics = this.pendingOptimistics.filter((entry) => entry.id !== id)
+  }
+
+  public replayOptimistics(): Partial<Page['props']> {
+    const baselineKeys = Object.keys(this.optimisticBaseline)
+
+    if (baselineKeys.length === 0) {
+      return {}
+    }
+
+    const props = cloneDeep(this.page.props)
+
+    for (const key of baselineKeys) {
+      props[key] = cloneDeep(this.optimisticBaseline[key])
+    }
+
+    for (const { callback } of this.pendingOptimistics) {
+      const result = callback(cloneDeep(props))
+
+      if (result) {
+        Object.assign(props, result)
+      }
+    }
+
+    const replayedProps: Partial<Page['props']> = {}
+
+    for (const key of baselineKeys) {
+      replayedProps[key] = props[key]
+    }
+
+    return replayedProps
+  }
+
+  public pendingOptimisticCount(): number {
+    return this.pendingOptimistics.length
+  }
+
+  public clearOptimisticState(): void {
+    this.optimisticBaseline = {}
+    this.pendingOptimistics = []
   }
 
   public isTheSame(page: Page): boolean {

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -297,19 +297,16 @@ export class Response {
   }
 
   protected preserveOptimisticProps(pageResponse: Page): void {
-    const optimisticUpdatedAt = currentPage.get().optimisticUpdatedAt
-
-    if (!optimisticUpdatedAt || !router.hasPendingOptimistic()) {
+    if (!router.hasPendingOptimistic()) {
       return
     }
 
     for (const key of Object.keys(pageResponse.props)) {
-      if (key in optimisticUpdatedAt) {
+      if (currentPage.hasBaseline(key)) {
+        currentPage.updateBaseline(key, pageResponse.props[key])
         pageResponse.props[key] = currentPage.get().props[key]
       }
     }
-
-    pageResponse.optimisticUpdatedAt = { ...optimisticUpdatedAt }
   }
 
   protected preserveEqualProps(pageResponse: Page): void {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -715,20 +715,26 @@ export class Router {
       return
     }
 
-    const propsSnapshot: Partial<Page['props']> = {}
+    const changedKeys: string[] = []
 
     for (const key of Object.keys(optimisticProps)) {
       if (!isEqual(currentProps[key], optimisticProps[key])) {
-        propsSnapshot[key] = cloneDeep(currentProps[key])
+        changedKeys.push(key)
       }
     }
 
-    if (Object.keys(propsSnapshot).length === 0) {
+    if (changedKeys.length === 0) {
       return
     }
 
-    const updatedAt = Date.now()
-    currentPage.recordOptimisticUpdate(Object.keys(propsSnapshot), updatedAt)
+    const id = currentPage.nextOptimisticId()
+    const component = currentPage.get().component
+
+    for (const key of changedKeys) {
+      currentPage.setBaseline(key, cloneDeep(currentProps[key]))
+    }
+
+    currentPage.registerOptimistic(id, optimistic)
     currentPage.setPropsQuietly({ ...currentProps, ...optimisticProps })
 
     let shouldRestore = true
@@ -741,18 +747,18 @@ export class Router {
 
     const originalOnFinish = events.onFinish
     events.onFinish = (visit) => {
-      if (shouldRestore) {
-        const propsToRestore: Partial<Page['props']> = {}
+      currentPage.unregisterOptimistic(id)
 
-        for (const [key, value] of Object.entries(propsSnapshot)) {
-          if (!currentPage.shouldPreserveOptimistic(key, updatedAt)) {
-            propsToRestore[key] = value
-          }
-        }
+      if (shouldRestore && currentPage.get().component === component) {
+        const replayedProps = currentPage.replayOptimistics()
 
-        if (Object.keys(propsToRestore).length > 0) {
-          currentPage.setPropsQuietly({ ...currentPage.get().props, ...propsToRestore })
+        if (Object.keys(replayedProps).length > 0) {
+          currentPage.setPropsQuietly({ ...currentPage.get().props, ...replayedProps })
         }
+      }
+
+      if (currentPage.pendingOptimisticCount() === 0) {
+        currentPage.clearOptimisticState()
       }
 
       return originalOnFinish(visit)

--- a/packages/react/test-app/Pages/Optimistic/Rollback.tsx
+++ b/packages/react/test-app/Pages/Optimistic/Rollback.tsx
@@ -1,0 +1,64 @@
+import { router } from '@inertiajs/react'
+
+interface Contact {
+  id: number
+  name: string
+  is_favorite: boolean
+}
+
+export default ({ contacts, errors }: { contacts: Contact[]; errors?: Record<string, string> }) => {
+  const toggleFavorite = (
+    contact: Contact,
+    { delay = 500, error = false }: { delay?: number; error?: boolean } = {},
+  ) => {
+    router
+      .optimistic<{ contacts: Contact[] }>((props) => ({
+        contacts: props.contacts.map((c) => (c.id === contact.id ? { ...c, is_favorite: !c.is_favorite } : c)),
+      }))
+      .post(
+        `/optimistic/rollback/toggle/${contact.id}?delay=${delay}&error=${error ? '1' : '0'}`,
+        {},
+        { preserveScroll: true },
+      )
+  }
+
+  const reset = () => {
+    router.post('/optimistic/rollback/reset')
+  }
+
+  return (
+    <div>
+      <h1>Optimistic Rollback</h1>
+
+      <div id="contact-list">
+        {contacts.map((contact) => (
+          <div key={contact.id} className="contact-item">
+            <span className="contact-name">{contact.name}</span>
+            <span className="contact-status">{contact.is_favorite ? 'Favorite' : 'Not Favorite'}</span>
+            <button className="toggle-btn" onClick={() => toggleFavorite(contact)}>
+              Toggle
+            </button>
+            <button className="toggle-error-btn" onClick={() => toggleFavorite(contact, { error: true })}>
+              Toggle (Error)
+            </button>
+            <button className="toggle-slow-btn" onClick={() => toggleFavorite(contact, { delay: 1000 })}>
+              Toggle (Slow)
+            </button>
+            <button
+              className="toggle-slow-error-btn"
+              onClick={() => toggleFavorite(contact, { delay: 1000, error: true })}
+            >
+              Toggle (Slow Error)
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {errors?.toggle && <div id="error-message">{errors.toggle}</div>}
+
+      <button id="reset-btn" onClick={reset}>
+        Reset
+      </button>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/Optimistic/Rollback.svelte
+++ b/packages/svelte/test-app/Pages/Optimistic/Rollback.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { router } from '@inertiajs/svelte'
+
+  interface Contact {
+    id: number
+    name: string
+    is_favorite: boolean
+  }
+
+  interface Props {
+    contacts: Contact[]
+    errors?: Record<string, string>
+  }
+
+  let { contacts, errors }: Props = $props()
+
+  const toggleFavorite = (contact: Contact, { delay = 500, error = false }: { delay?: number; error?: boolean } = {}) => {
+    router
+      .optimistic<{ contacts: Contact[] }>((props) => ({
+        contacts: props.contacts.map((c) => (c.id === contact.id ? { ...c, is_favorite: !c.is_favorite } : c)),
+      }))
+      .post(
+        `/optimistic/rollback/toggle/${contact.id}?delay=${delay}&error=${error ? '1' : '0'}`,
+        {},
+        { preserveScroll: true },
+      )
+  }
+
+  const reset = () => {
+    router.post('/optimistic/rollback/reset')
+  }
+</script>
+
+<div>
+  <h1>Optimistic Rollback</h1>
+
+  <div id="contact-list">
+    {#each contacts as contact (contact.id)}
+      <div class="contact-item">
+        <span class="contact-name">{contact.name}</span>
+        <span class="contact-status">{contact.is_favorite ? 'Favorite' : 'Not Favorite'}</span>
+        <button class="toggle-btn" onclick={() => toggleFavorite(contact)}>Toggle</button>
+        <button class="toggle-error-btn" onclick={() => toggleFavorite(contact, { error: true })}>Toggle (Error)</button>
+        <button class="toggle-slow-btn" onclick={() => toggleFavorite(contact, { delay: 1000 })}>Toggle (Slow)</button>
+        <button class="toggle-slow-error-btn" onclick={() => toggleFavorite(contact, { delay: 1000, error: true })}>Toggle (Slow Error)</button>
+      </div>
+    {/each}
+  </div>
+
+  {#if errors?.toggle}
+    <div id="error-message">{errors.toggle}</div>
+  {/if}
+
+  <button id="reset-btn" onclick={reset}>Reset</button>
+</div>

--- a/packages/svelte/test-app/Pages/Optimistic/Rollback.svelte
+++ b/packages/svelte/test-app/Pages/Optimistic/Rollback.svelte
@@ -14,7 +14,10 @@
 
   let { contacts, errors }: Props = $props()
 
-  const toggleFavorite = (contact: Contact, { delay = 500, error = false }: { delay?: number; error?: boolean } = {}) => {
+  const toggleFavorite = (
+    contact: Contact,
+    { delay = 500, error = false }: { delay?: number; error?: boolean } = {},
+  ) => {
     router
       .optimistic<{ contacts: Contact[] }>((props) => ({
         contacts: props.contacts.map((c) => (c.id === contact.id ? { ...c, is_favorite: !c.is_favorite } : c)),
@@ -40,9 +43,12 @@
         <span class="contact-name">{contact.name}</span>
         <span class="contact-status">{contact.is_favorite ? 'Favorite' : 'Not Favorite'}</span>
         <button class="toggle-btn" onclick={() => toggleFavorite(contact)}>Toggle</button>
-        <button class="toggle-error-btn" onclick={() => toggleFavorite(contact, { error: true })}>Toggle (Error)</button>
+        <button class="toggle-error-btn" onclick={() => toggleFavorite(contact, { error: true })}>Toggle (Error)</button
+        >
         <button class="toggle-slow-btn" onclick={() => toggleFavorite(contact, { delay: 1000 })}>Toggle (Slow)</button>
-        <button class="toggle-slow-error-btn" onclick={() => toggleFavorite(contact, { delay: 1000, error: true })}>Toggle (Slow Error)</button>
+        <button class="toggle-slow-error-btn" onclick={() => toggleFavorite(contact, { delay: 1000, error: true })}
+          >Toggle (Slow Error)</button
+        >
       </div>
     {/each}
   </div>

--- a/packages/vue3/test-app/Pages/Optimistic/Rollback.vue
+++ b/packages/vue3/test-app/Pages/Optimistic/Rollback.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3'
+
+interface Contact {
+  id: number
+  name: string
+  is_favorite: boolean
+}
+
+defineProps<{
+  contacts: Contact[]
+  errors?: Record<string, string>
+}>()
+
+const toggleFavorite = (contact: Contact, { delay = 500, error = false }: { delay?: number; error?: boolean } = {}) => {
+  router
+    .optimistic<{ contacts: Contact[] }>((props) => ({
+      contacts: props.contacts.map((c) => (c.id === contact.id ? { ...c, is_favorite: !c.is_favorite } : c)),
+    }))
+    .post(
+      `/optimistic/rollback/toggle/${contact.id}?delay=${delay}&error=${error ? '1' : '0'}`,
+      {},
+      { preserveScroll: true },
+    )
+}
+
+const reset = () => {
+  router.post('/optimistic/rollback/reset')
+}
+</script>
+
+<template>
+  <div>
+    <h1>Optimistic Rollback</h1>
+
+    <div id="contact-list">
+      <div v-for="contact in contacts" :key="contact.id" class="contact-item">
+        <span class="contact-name">{{ contact.name }}</span>
+        <span class="contact-status">{{ contact.is_favorite ? 'Favorite' : 'Not Favorite' }}</span>
+        <button class="toggle-btn" @click="toggleFavorite(contact)">Toggle</button>
+        <button class="toggle-error-btn" @click="toggleFavorite(contact, { error: true })">Toggle (Error)</button>
+        <button class="toggle-slow-btn" @click="toggleFavorite(contact, { delay: 1000 })">Toggle (Slow)</button>
+        <button class="toggle-slow-error-btn" @click="toggleFavorite(contact, { delay: 1000, error: true })">Toggle (Slow Error)</button>
+      </div>
+    </div>
+
+    <div v-if="errors?.toggle" id="error-message">{{ errors.toggle }}</div>
+
+    <button id="reset-btn" @click="reset">Reset</button>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/Optimistic/Rollback.vue
+++ b/packages/vue3/test-app/Pages/Optimistic/Rollback.vue
@@ -40,7 +40,9 @@ const reset = () => {
         <button class="toggle-btn" @click="toggleFavorite(contact)">Toggle</button>
         <button class="toggle-error-btn" @click="toggleFavorite(contact, { error: true })">Toggle (Error)</button>
         <button class="toggle-slow-btn" @click="toggleFavorite(contact, { delay: 1000 })">Toggle (Slow)</button>
-        <button class="toggle-slow-error-btn" @click="toggleFavorite(contact, { delay: 1000, error: true })">Toggle (Slow Error)</button>
+        <button class="toggle-slow-error-btn" @click="toggleFavorite(contact, { delay: 1000, error: true })">
+          Toggle (Slow Error)
+        </button>
       </div>
     </div>
 

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -3251,6 +3251,63 @@ app.post('/optimistic/reset-likes', (req, res) => {
   res.redirect(303, '/optimistic')
 })
 
+app.get('/optimistic/rollback', (req, res) => {
+  const session = getOptimisticSession(req)
+
+  if (!session.contacts) {
+    session.contacts = [
+      { id: 1, name: 'John', is_favorite: false },
+      { id: 2, name: 'Jane', is_favorite: false },
+      { id: 3, name: 'Bob', is_favorite: false },
+    ]
+  }
+
+  inertia.render(req, res, {
+    component: 'Optimistic/Rollback',
+    props: {
+      contacts: [...session.contacts.map((c) => ({ ...c }))],
+    },
+  })
+})
+
+app.post('/optimistic/rollback/toggle/:id', (req, res) => {
+  const delay = parseInt(req.query.delay || '500')
+  const simulateError = req.query.error === '1'
+
+  setTimeout(() => {
+    if (simulateError) {
+      const session = getOptimisticSession(req)
+      return inertia.render(req, res, {
+        component: 'Optimistic/Rollback',
+        url: '/optimistic/rollback',
+        props: {
+          contacts: [...session.contacts.map((c) => ({ ...c }))],
+          errors: { toggle: 'Something went wrong' },
+        },
+      })
+    }
+
+    const session = getOptimisticSession(req)
+    const contact = session.contacts.find((c) => c.id === parseInt(req.params.id))
+
+    if (contact) {
+      contact.is_favorite = !contact.is_favorite
+    }
+
+    res.redirect(303, '/optimistic/rollback')
+  }, delay)
+})
+
+app.post('/optimistic/rollback/reset', (req, res) => {
+  const session = getOptimisticSession(req)
+  session.contacts = [
+    { id: 1, name: 'John', is_favorite: false },
+    { id: 2, name: 'Jane', is_favorite: false },
+    { id: 3, name: 'Bob', is_favorite: false },
+  ]
+  res.redirect(303, '/optimistic/rollback')
+})
+
 app.get('/use-page/page1', (req, res) =>
   inertia.render(req, res, {
     component: 'UsePage/Page1',

--- a/tests/optimistic-rollback.spec.ts
+++ b/tests/optimistic-rollback.spec.ts
@@ -16,9 +16,7 @@ test.describe('Optimistic Rollback', () => {
     await expect(page.locator('.contact-status').first()).toContainText('Not Favorite')
   })
 
-  test('it fully rolls back multiple optimistic updates on the same prop when all requests error', async ({
-    page,
-  }) => {
+  test('it fully rolls back multiple optimistic updates on the same prop when all requests error', async ({ page }) => {
     pageLoads.watch(page)
 
     await expect(page.locator('.contact-status').nth(0)).toContainText('Not Favorite')

--- a/tests/optimistic-rollback.spec.ts
+++ b/tests/optimistic-rollback.spec.ts
@@ -1,0 +1,74 @@
+import test, { expect } from '@playwright/test'
+import { pageLoads } from './support'
+
+test.describe('Optimistic Rollback', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    await page
+      .context()
+      .addCookies([
+        { name: 'optimistic-session', value: `rollback-${testInfo.workerIndex}`, domain: 'localhost', path: '/' },
+      ])
+
+    await page.goto('/optimistic/rollback')
+    await page.locator('#reset-btn').click()
+    await expect(page.locator('.contact-status').first()).toContainText('Not Favorite')
+  })
+
+  test('it fully rolls back multiple optimistic updates on the same prop when all requests error', async ({
+    page,
+  }) => {
+    pageLoads.watch(page)
+
+    await expect(page.locator('.contact-status').nth(0)).toContainText('Not Favorite')
+    await expect(page.locator('.contact-status').nth(1)).toContainText('Not Favorite')
+    await expect(page.locator('.contact-status').nth(2)).toContainText('Not Favorite')
+
+    await page.locator('.toggle-error-btn').nth(0).click()
+    await page.locator('.toggle-error-btn').nth(1).click()
+    await page.locator('.toggle-error-btn').nth(2).click()
+
+    await expect(page.locator('.contact-status').nth(0)).toContainText('Favorite')
+    await expect(page.locator('.contact-status').nth(1)).toContainText('Favorite')
+    await expect(page.locator('.contact-status').nth(2)).toContainText('Favorite')
+
+    await page.waitForTimeout(2000)
+
+    await expect(page.locator('.contact-status').nth(0)).toContainText('Not Favorite')
+    await expect(page.locator('.contact-status').nth(1)).toContainText('Not Favorite')
+    await expect(page.locator('.contact-status').nth(2)).toContainText('Not Favorite')
+  })
+
+  test('it preserves confirmed server state and pending optimistic updates when rolling back a failed request', async ({
+    page,
+  }) => {
+    pageLoads.watch(page)
+
+    // Request 1: toggle John (slow, in flight the whole time)
+    await page.locator('.toggle-slow-btn').nth(0).click()
+
+    // Request 2: toggle Jane (fast, will succeed)
+    await page.locator('.toggle-btn').nth(1).click()
+
+    // Request 3: toggle Bob (slow, will error)
+    await page.locator('.toggle-slow-error-btn').nth(2).click()
+
+    await expect(page.locator('.contact-status').nth(0)).toContainText('Favorite')
+    await expect(page.locator('.contact-status').nth(1)).toContainText('Favorite')
+    await expect(page.locator('.contact-status').nth(2)).toContainText('Favorite')
+
+    // Request 2 completes (fast success), optimistic states preserved
+    await page.waitForTimeout(700)
+    await expect(page.locator('.contact-status').nth(0)).toContainText('Favorite')
+    await expect(page.locator('.contact-status').nth(1)).toContainText('Favorite')
+    await expect(page.locator('.contact-status').nth(2)).toContainText('Favorite')
+
+    // Requests 1 and 3 complete (slow). Request 3 fails and rolls back Bob,
+    // but preserves John (confirmed by request 1) and Jane (confirmed by request 2)
+    await page.waitForTimeout(800)
+    await expect(page.locator('.contact-status').nth(0)).toContainText('Favorite')
+    await expect(page.locator('.contact-status').nth(1)).toContainText('Favorite')
+    await expect(page.locator('.contact-status').nth(2)).toContainText('Not Favorite')
+  })
+})

--- a/tests/optimistic.spec.ts
+++ b/tests/optimistic.spec.ts
@@ -141,7 +141,7 @@ test.describe('Optimistic', () => {
     await expect(page.locator('#likes-count')).toContainText('Likes: 5')
   })
 
-  test('it does not roll back when a newer optimistic update exists for the same prop', async ({ page }) => {
+  test('it replays remaining pending optimistic updates when an earlier one errors', async ({ page }) => {
     pageLoads.watch(page)
 
     await page.locator('#reset-likes-btn').click()
@@ -152,8 +152,10 @@ test.describe('Optimistic', () => {
 
     await expect(page.locator('#likes-count')).toContainText('Likes: 2')
 
+    // After the fast error resolves, the failed +1 is removed and the remaining
+    // pending +1 is replayed on the baseline (0), giving 1
     await page.waitForTimeout(300)
-    await expect(page.locator('#likes-count')).toContainText('Likes: 2')
+    await expect(page.locator('#likes-count')).toContainText('Likes: 1')
 
     await page.waitForTimeout(800)
     await expect(page.locator('#likes-count')).toContainText('Likes: 5')


### PR DESCRIPTION
When multiple optimistic updates are in flight at the same time and one or more fail, only the last request's changes were rolled back. Earlier pending requests were left un-reverted because the rollback mechanism was saving UI state while other network requests were still pending, causing the snapshot to include unconfirmed optimistic data.

This PR replaces the timestamp-based rollback approach with a baseline-and-replay system. When the first optimistic update for a prop occurs, the current (confirmed) value is saved as a baseline. Each pending optimistic update registers a callback, and on rollback, the system replays all remaining pending callbacks on top of the baseline. This ensures that when a request fails, only its changes are removed while confirmed server state and still-pending optimistic updates are preserved correctly. When the server responds with new data for a baselined prop, the baseline itself is updated so future rollbacks use the latest confirmed state.

Fixes #2950.