### PR TITLE
[3.x] Prevent useHttp from parsing empty 204 responses

### DIFF
--- a/packages/react/src/useHttp.ts
+++ b/packages/react/src/useHttp.ts
@@ -242,7 +242,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
           },
         })
 
-        const responseData = JSON.parse(httpResponse.data) as TResponse
+        const responseData = (httpResponse.data ? JSON.parse(httpResponse.data) : null) as TResponse
 
         if (httpResponse.status >= 200 && httpResponse.status < 300) {
           if (isMounted.current) {

--- a/packages/react/test-app/Pages/UseHttp/NoContent.tsx
+++ b/packages/react/test-app/Pages/UseHttp/NoContent.tsx
@@ -1,0 +1,43 @@
+import { useHttp } from '@inertiajs/react'
+import { useState } from 'react'
+
+export default () => {
+  const form = useHttp<{ name: string }>({
+    name: '',
+  })
+
+  const [responseValue, setResponseValue] = useState<string>('none')
+
+  const performPost = async () => {
+    try {
+      const result = await form.post('/api/no-content')
+      setResponseValue(JSON.stringify(result))
+    } catch {
+      setResponseValue('error')
+    }
+  }
+
+  return (
+    <div>
+      <h1>useHttp No Content Test</h1>
+
+      <section id="no-content-test">
+        <label>
+          Name
+          <input
+            type="text"
+            id="no-content-name"
+            value={form.data.name}
+            onChange={(e) => form.setData('name', e.target.value)}
+          />
+        </label>
+        <button onClick={performPost} id="no-content-button">
+          Submit
+        </button>
+        {form.processing && <div id="no-content-processing">Processing...</div>}
+        {form.wasSuccessful && <div id="no-content-success">Success</div>}
+        <div id="no-content-response">Response: {responseValue}</div>
+      </section>
+    </div>
+  )
+}

--- a/packages/svelte/src/useHttp.svelte.ts
+++ b/packages/svelte/src/useHttp.svelte.ts
@@ -221,7 +221,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
         },
       })
 
-      const responseData = JSON.parse(response.data) as TResponse
+      const responseData = (response.data ? JSON.parse(response.data) : null) as TResponse
 
       if (response.status >= 200 && response.status < 300) {
         markAsSuccessful()

--- a/packages/svelte/test-app/Pages/UseHttp/NoContent.svelte
+++ b/packages/svelte/test-app/Pages/UseHttp/NoContent.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { useHttp } from '@inertiajs/svelte'
+
+  const form = useHttp<{ name: string }>({
+    name: '',
+  })
+
+  let responseValue = $state('none')
+
+  const performPost = async () => {
+    try {
+      const result = await form.post('/api/no-content')
+      responseValue = JSON.stringify(result)
+    } catch {
+      responseValue = 'error'
+    }
+  }
+</script>
+
+<div>
+  <h1>useHttp No Content Test</h1>
+
+  <section id="no-content-test">
+    <label>
+      Name
+      <input type="text" id="no-content-name" bind:value={form.name} />
+    </label>
+    <button onclick={performPost} id="no-content-button">Submit</button>
+    {#if form.processing}
+      <div id="no-content-processing">Processing...</div>
+    {/if}
+    {#if form.wasSuccessful}
+      <div id="no-content-success">Success</div>
+    {/if}
+    <div id="no-content-response">Response: {responseValue}</div>
+  </section>
+</div>

--- a/packages/vue3/src/useHttp.ts
+++ b/packages/vue3/src/useHttp.ts
@@ -222,7 +222,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
         },
       })
 
-      const responseData = JSON.parse(response.data) as TResponse
+      const responseData = (response.data ? JSON.parse(response.data) : null) as TResponse
 
       if (response.status >= 200 && response.status < 300) {
         markAsSuccessful()

--- a/packages/vue3/test-app/Pages/UseHttp/NoContent.vue
+++ b/packages/vue3/test-app/Pages/UseHttp/NoContent.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { useHttp } from '@inertiajs/vue3'
+import { ref } from 'vue'
+
+const form = useHttp<{ name: string }>({
+  name: '',
+})
+
+const responseValue = ref<string>('none')
+
+const performPost = async () => {
+  try {
+    const result = await form.post('/api/no-content')
+    responseValue.value = JSON.stringify(result)
+  } catch {
+    responseValue.value = 'error'
+  }
+}
+</script>
+
+<template>
+  <div>
+    <h1>useHttp No Content Test</h1>
+
+    <section id="no-content-test">
+      <label>
+        Name
+        <input type="text" id="no-content-name" v-model="form.name" />
+      </label>
+      <button @click="performPost" id="no-content-button">Submit</button>
+      <div v-if="form.processing" id="no-content-processing">Processing...</div>
+      <div v-if="form.wasSuccessful" id="no-content-success">Success</div>
+      <div id="no-content-response">Response: {{ responseValue }}</div>
+    </section>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -3020,6 +3020,10 @@ app.post('/api/mixed', upload.any(), (req, res) => {
   })
 })
 
+app.post('/api/no-content', upload.none(), (req, res) => {
+  res.status(204).send()
+})
+
 app.get('/use-http', (req, res) => inertia.render(req, res, { component: 'UseHttp/Index' }))
 app.get('/use-http/methods', (req, res) => inertia.render(req, res, { component: 'UseHttp/Methods' }))
 app.get('/use-http/file-upload', (req, res) => inertia.render(req, res, { component: 'UseHttp/FileUpload' }))

--- a/tests/use-http.spec.ts
+++ b/tests/use-http.spec.ts
@@ -539,4 +539,14 @@ test.describe('useHttp', () => {
       await expect(page.locator('#all-email-error')).toContainText('The email must be a valid email address.')
     })
   })
+
+  test('it handles 204 no content responses without errors', async ({ page }) => {
+    await page.goto('/use-http/no-content')
+
+    await page.fill('#no-content-name', 'John')
+    await page.click('#no-content-button')
+
+    await expect(page.locator('#no-content-success')).toBeVisible()
+    await expect(page.locator('#no-content-response')).toContainText('Response: null')
+  })
 })


### PR DESCRIPTION
Added some extra handling to the `response.data` call to only parse when the data exists, prevents a syntax error from 204 no content responses.

Fixes https://github.com/inertiajs/inertia/issues/2966