### PR TITLE
[3.x] Fix layout props store leaking between SSR requests

### DIFF
--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -77,6 +77,10 @@ export default function App<SharedProps extends PageProps = PageProps>({
   onHeadUpdate,
   defaultLayout,
 }: InertiaAppProps<SharedProps>) {
+  if (typeof window === 'undefined') {
+    resetLayoutProps()
+  }
+
   const [current, setCurrent] = useState<CurrentPage>({
     component: initialComponent || null,
     page: { ...initialPage, flash: initialPage.flash ?? {} },

--- a/packages/react/test-app/Layouts/SSRLayout.tsx
+++ b/packages/react/test-app/Layouts/SSRLayout.tsx
@@ -1,0 +1,15 @@
+import { useLayoutProps } from '@inertiajs/react'
+import { ReactNode } from 'react'
+
+export default function SSRLayout({ children }: { children: ReactNode }) {
+  const layoutProps = useLayoutProps({
+    title: 'Default Title',
+  })
+
+  return (
+    <div className="ssr-layout">
+      <h1 data-testid="layout-title">{layoutProps.title}</h1>
+      {children}
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/SSR/LayoutPropsA.tsx
+++ b/packages/react/test-app/Pages/SSR/LayoutPropsA.tsx
@@ -1,0 +1,16 @@
+import { setLayoutProps } from '@inertiajs/react'
+import SSRLayout from '../../Layouts/SSRLayout'
+
+const LayoutPropsA = () => {
+  setLayoutProps({ title: 'Page A Title' })
+
+  return (
+    <div>
+      <p data-testid="page-content">Page A Content</p>
+    </div>
+  )
+}
+
+LayoutPropsA.layout = SSRLayout
+
+export default LayoutPropsA

--- a/packages/react/test-app/Pages/SSR/LayoutPropsB.tsx
+++ b/packages/react/test-app/Pages/SSR/LayoutPropsB.tsx
@@ -1,0 +1,13 @@
+import SSRLayout from '../../Layouts/SSRLayout'
+
+const LayoutPropsB = () => {
+  return (
+    <div>
+      <p data-testid="page-content">Page B Content</p>
+    </div>
+  )
+}
+
+LayoutPropsB.layout = SSRLayout
+
+export default LayoutPropsB

--- a/packages/svelte/src/components/App.svelte
+++ b/packages/svelte/src/components/App.svelte
@@ -46,6 +46,10 @@
 
   const isServer = typeof window === 'undefined'
 
+  if (isServer) {
+    resetLayoutProps()
+  }
+
   if (!isServer) {
     // svelte-ignore state_referenced_locally
     router.init<ResolvedComponent>({

--- a/packages/svelte/src/layoutProps.svelte.ts
+++ b/packages/svelte/src/layoutProps.svelte.ts
@@ -24,6 +24,9 @@ export function setLayoutPropsFor(name: string, props: Record<string, unknown>):
 
 export function resetLayoutProps(): void {
   store.reset()
+  const snapshot = store.get()
+  storeState.shared = snapshot.shared
+  storeState.named = snapshot.named
 }
 
 export const LAYOUT_CONTEXT_KEY = Symbol('inertia-layout')

--- a/packages/svelte/test-app/Layouts/SSRLayout.svelte
+++ b/packages/svelte/test-app/Layouts/SSRLayout.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+import { useLayoutProps } from '@inertiajs/svelte'
+import type { Snippet } from 'svelte'
+
+let { children }: { children: Snippet } = $props()
+
+const layoutProps = useLayoutProps({
+  title: 'Default Title',
+})
+</script>
+
+<div class="ssr-layout">
+  <h1 data-testid="layout-title">{layoutProps.title}</h1>
+  {@render children()}
+</div>

--- a/packages/svelte/test-app/Layouts/SSRLayout.svelte
+++ b/packages/svelte/test-app/Layouts/SSRLayout.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-import { useLayoutProps } from '@inertiajs/svelte'
-import type { Snippet } from 'svelte'
+  import { useLayoutProps } from '@inertiajs/svelte'
+  import type { Snippet } from 'svelte'
 
-let { children }: { children: Snippet } = $props()
+  let { children }: { children: Snippet } = $props()
 
-const layoutProps = useLayoutProps({
-  title: 'Default Title',
-})
+  const layoutProps = useLayoutProps({
+    title: 'Default Title',
+  })
 </script>
 
 <div class="ssr-layout">

--- a/packages/svelte/test-app/Pages/SSR/LayoutPropsA.svelte
+++ b/packages/svelte/test-app/Pages/SSR/LayoutPropsA.svelte
@@ -1,12 +1,12 @@
 <script lang="ts" module>
-import SSRLayout from '../../Layouts/SSRLayout.svelte'
-export const layout = SSRLayout
+  import SSRLayout from '../../Layouts/SSRLayout.svelte'
+  export const layout = SSRLayout
 </script>
 
 <script lang="ts">
-import { setLayoutProps } from '@inertiajs/svelte'
+  import { setLayoutProps } from '@inertiajs/svelte'
 
-setLayoutProps({ title: 'Page A Title' })
+  setLayoutProps({ title: 'Page A Title' })
 </script>
 
 <div>

--- a/packages/svelte/test-app/Pages/SSR/LayoutPropsA.svelte
+++ b/packages/svelte/test-app/Pages/SSR/LayoutPropsA.svelte
@@ -1,0 +1,14 @@
+<script lang="ts" module>
+import SSRLayout from '../../Layouts/SSRLayout.svelte'
+export const layout = SSRLayout
+</script>
+
+<script lang="ts">
+import { setLayoutProps } from '@inertiajs/svelte'
+
+setLayoutProps({ title: 'Page A Title' })
+</script>
+
+<div>
+  <p data-testid="page-content">Page A Content</p>
+</div>

--- a/packages/svelte/test-app/Pages/SSR/LayoutPropsB.svelte
+++ b/packages/svelte/test-app/Pages/SSR/LayoutPropsB.svelte
@@ -1,0 +1,8 @@
+<script lang="ts" module>
+import SSRLayout from '../../Layouts/SSRLayout.svelte'
+export const layout = SSRLayout
+</script>
+
+<div>
+  <p data-testid="page-content">Page B Content</p>
+</div>

--- a/packages/svelte/test-app/Pages/SSR/LayoutPropsB.svelte
+++ b/packages/svelte/test-app/Pages/SSR/LayoutPropsB.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" module>
-import SSRLayout from '../../Layouts/SSRLayout.svelte'
-export const layout = SSRLayout
+  import SSRLayout from '../../Layouts/SSRLayout.svelte'
+  export const layout = SSRLayout
 </script>
 
 <div>

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -122,6 +122,11 @@ const App: InertiaApp = defineComponent({
     key.value = undefined
 
     const isServer = typeof window === 'undefined'
+
+    if (isServer) {
+      resetLayoutProps()
+    }
+
     headManager = createHeadManager(isServer, titleCallback || ((title: string) => title), onHeadUpdate || (() => {}))
 
     if (!isServer) {

--- a/packages/vue3/src/layoutProps.ts
+++ b/packages/vue3/src/layoutProps.ts
@@ -18,6 +18,7 @@ export function setLayoutPropsFor(name: string, props: Record<string, unknown>):
 
 export function resetLayoutProps(): void {
   store.reset()
+  state.value = store.get()
 }
 
 export const LAYOUT_CONTEXT_KEY: InjectionKey<string | undefined> = Symbol('inertia-layout')

--- a/packages/vue3/test-app/Layouts/SSRLayout.vue
+++ b/packages/vue3/test-app/Layouts/SSRLayout.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { useLayoutProps } from '@inertiajs/vue3'
+
+const layoutProps = useLayoutProps({
+  title: 'Default Title',
+})
+</script>
+
+<template>
+  <div class="ssr-layout">
+    <h1 data-testid="layout-title">{{ layoutProps.title }}</h1>
+    <slot />
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/SSR/LayoutPropsA.vue
+++ b/packages/vue3/test-app/Pages/SSR/LayoutPropsA.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { setLayoutProps } from '@inertiajs/vue3'
+import SSRLayout from '../../Layouts/SSRLayout.vue'
+
+defineOptions({
+  layout: SSRLayout,
+})
+
+setLayoutProps({ title: 'Page A Title' })
+</script>
+
+<template>
+  <div>
+    <p data-testid="page-content">Page A Content</p>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/SSR/LayoutPropsB.vue
+++ b/packages/vue3/test-app/Pages/SSR/LayoutPropsB.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import SSRLayout from '../../Layouts/SSRLayout.vue'
+
+defineOptions({
+  layout: SSRLayout,
+})
+</script>
+
+<template>
+  <div>
+    <p data-testid="page-content">Page B Content</p>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -70,6 +70,20 @@ app.get('/ssr/page-with-script-element', (req, res) =>
   }),
 )
 
+app.get('/ssr/layout-props-a', (req, res) =>
+  inertia.renderSSR(req, res, {
+    component: 'SSR/LayoutPropsA',
+    props: {},
+  }),
+)
+
+app.get('/ssr/layout-props-b', (req, res) =>
+  inertia.renderSSR(req, res, {
+    component: 'SSR/LayoutPropsB',
+    props: {},
+  }),
+)
+
 // SSR auto-transform test routes (uses the Vite plugin SSR transform)
 app.get('/ssr-auto/page1', (req, res) =>
   inertia.renderSSRAuto(req, res, {

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -89,6 +89,40 @@ test.describe('SSR', () => {
   })
 })
 
+test.describe('layout props', () => {
+  test('it does not leak layout props between SSR requests', async ({ page, browserName }) => {
+    test.skip(browserName !== 'chromium', 'SSR store leak test only needs one browser')
+
+    const responseA = await page.request.get('/ssr/layout-props-a')
+    const htmlA = await responseA.text()
+
+    expect(htmlA).toContain('Page A Content')
+
+    const responseB = await page.request.get('/ssr/layout-props-b')
+    const htmlB = await responseB.text()
+
+    expect(htmlB).toContain('Page B Content')
+    expect(htmlB).toContain('Default Title')
+    expect(htmlB).not.toContain('Page A Title')
+  })
+
+  test('it hydrates without errors after setLayoutProps was used in a previous SSR request', async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'SSR store leak test only needs one browser')
+    consoleMessages.listen(page)
+
+    await page.request.get('/ssr/layout-props-a')
+    await page.goto('/ssr/layout-props-b')
+
+    await expect(page.getByTestId('layout-title')).toHaveText('Default Title')
+    await expect(page.getByTestId('page-content')).toHaveText('Page B Content')
+
+    expect(consoleMessages.errors).toHaveLength(0)
+  })
+})
+
 test.describe('SSR Auto Transform', () => {
   test.describe('Vite plugin SSR transform', () => {
     test('it renders HTML using the auto-transformed SSR entry', async ({ page }) => {

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -119,6 +119,21 @@ test.describe('layout props', () => {
     await expect(page.getByTestId('layout-title')).toHaveText('Default Title')
     await expect(page.getByTestId('page-content')).toHaveText('Page B Content')
 
+    const hydrationErrors = consoleMessages.messages.filter((msg) => msg.includes('Hydration'))
+    expect(hydrationErrors).toHaveLength(0)
+    expect(consoleMessages.errors).toHaveLength(0)
+  })
+
+  test('it hydrates without errors on a page that calls setLayoutProps', async ({ page, browserName }) => {
+    test.skip(browserName !== 'chromium', 'SSR store leak test only needs one browser')
+    consoleMessages.listen(page)
+
+    await page.goto('/ssr/layout-props-a')
+
+    await expect(page.getByTestId('page-content')).toHaveText('Page A Content')
+
+    const hydrationErrors = consoleMessages.messages.filter((msg) => msg.includes('Hydration'))
+    expect(hydrationErrors).toHaveLength(0)
     expect(consoleMessages.errors).toHaveLength(0)
   })
 })


### PR DESCRIPTION
The layout props store is a module-level singleton that persists across SSR requests. When page A sets layout props and page B doesn't, the server-rendered HTML for page B still contains page A's values. On the client the store starts fresh, causing hydration mismatches.

This resets the layout props store at the start of each SSR render in all three adapters and synchronizes the framework-specific reactive state so the reset is immediately reflected during rendering.

See #2963.