### PR TITLE
[3.x] Migrate from `lodash-es` to `es-toolkit`

### DIFF
--- a/.github/workflows/es2022-compatibility.yml
+++ b/.github/workflows/es2022-compatibility.yml
@@ -1,8 +1,8 @@
 name: Compatibility Checks
 on: [push, pull_request]
 jobs:
-  es2020-compatibility:
-    name: ES2020 (${{ matrix.adapter }})
+  es2022-compatibility:
+    name: ES2022 (${{ matrix.adapter }})
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -34,5 +34,5 @@ jobs:
         if: matrix.adapter != 'core'
         run: pnpm -r --filter ./packages/core build
 
-      - name: Validate ES2020 compatibility
-        run: pnpm -r --filter ./packages/${{ matrix.adapter }}* es2020-check
+      - name: Validate ES2022 compatibility
+        run: pnpm -r --filter ./packages/${{ matrix.adapter }}* es2022-check

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:test-app:react": "pnpx concurrently -c \"#c4b5fd,#ffa800\" \"cd tests/app && PACKAGE=react pnpm serve:watch\" \"cd packages/react/test-app && pnpm run dev\" --names=server,vite",
     "dev:test-app:svelte": "pnpx concurrently -c \"#c4b5fd,#ffa800\" \"cd tests/app && PACKAGE=svelte pnpm serve:watch\" \"cd packages/svelte/test-app && pnpm run dev\" --names=server,vite",
     "dev:test-app:vue": "pnpx concurrently -c \"#c4b5fd,#ffa800\" \"cd tests/app && PACKAGE=vue3 pnpm serve:watch\" \"cd packages/vue3/test-app && pnpm run dev\" --names=server,vite",
-    "es2020-check": "pnpm -r --filter './packages/*' es2020-check",
+    "es2022-check": "pnpm -r --filter './packages/*' es2022-check",
     "lint:test-app": "pnpm -r --filter './packages/*/test-app' lint",
     "lint:test-app:react": "cd packages/react/test-app && pnpm run lint",
     "lint:test-app:svelte": "cd packages/svelte/test-app && pnpm run lint",

--- a/packages/core/build.js
+++ b/packages/core/build.js
@@ -9,7 +9,7 @@ const config = {
   bundle: true,
   minify: false,
   sourcemap: withDeps ? false : true,
-  target: 'es2020',
+  target: 'es2022',
   plugins: [
     ...(withDeps ? [] : [nodeExternalsPlugin()]),
     {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,14 +55,13 @@
     "dev": "pnpx concurrently -c \"#ffcf00,#3178c6\" \"pnpm dev:build\" \"pnpm dev:types\" --names build,types",
     "dev:build": "./build.js --watch",
     "dev:types": "tsc --watch --preserveWatchOutput",
-    "es2020-check": "pnpm build:with-deps && es-check es2020 \"dist/index.js\" --checkFeatures --module --noCache --verbose",
+    "es2022-check": "pnpm build:with-deps && es-check es2022 \"dist/index.js\" --checkFeatures --module --noCache --verbose",
     "test": "vitest run"
   },
   "dependencies": {
     "@jridgewell/trace-mapping": "^0.3.31",
-    "@types/lodash-es": "^4.17.12",
-    "laravel-precognition": "2.0.0-beta.3",
-    "lodash-es": "^4.17.23"
+    "es-toolkit": "^1.33.0",
+    "laravel-precognition": "2.0.0-beta.3"
   },
   "peerDependencies": {
     "axios": "^1.13.2"

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,4 +1,4 @@
-import { get, has, set } from 'lodash-es'
+import { get, has, set } from 'es-toolkit/compat'
 import { InertiaAppConfig } from './types'
 
 // Generate all possible nested paths

--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -1,4 +1,4 @@
-import { get } from 'lodash-es'
+import { get } from 'es-toolkit/compat'
 import debounce from './debounce'
 import { fireNavigateEvent } from './events'
 import { history } from './history'

--- a/packages/core/src/formObject.ts
+++ b/packages/core/src/formObject.ts
@@ -1,4 +1,4 @@
-import { get, set } from 'lodash-es'
+import { get, set } from 'es-toolkit/compat'
 import { isFile } from './files'
 import { FormDataConvertible } from './types'
 

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, isEqual } from 'lodash-es'
+import { cloneDeep, isEqual } from 'es-toolkit'
 import { decryptHistory, encryptHistory, historySessionStorageKeys } from './encryption'
 import { eventHandler } from './eventHandler'
 import { page as currentPage } from './page'

--- a/packages/core/src/layout.ts
+++ b/packages/core/src/layout.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash-es'
+import { isEqual } from 'es-toolkit'
 
 export interface LayoutDefinition<Component> {
   component: Component

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, get, set } from 'lodash-es'
+import { cloneDeep } from 'es-toolkit'
+import { get, set } from 'es-toolkit/compat'
 import { eventHandler } from './eventHandler'
 import { fireNavigateEvent } from './events'
 import { history } from './history'

--- a/packages/core/src/prefetched.ts
+++ b/packages/core/src/prefetched.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, get } from 'lodash-es'
+import { cloneDeep } from 'es-toolkit'
+import { get } from 'es-toolkit/compat'
 import { objectsAreEqual } from './objectUtils'
 import { page as currentPage } from './page'
 import { Response } from './response'

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -1,4 +1,4 @@
-import { get } from 'lodash-es'
+import { get } from 'es-toolkit/compat'
 import {
   fireFinishEvent,
   fireNetworkErrorEvent,

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -1,4 +1,5 @@
-import { get, isEqual, set } from 'lodash-es'
+import { isEqual } from 'es-toolkit'
+import { get, set } from 'es-toolkit/compat'
 import { router } from '.'
 import dialog from './dialog'
 import {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, get, isEqual, set } from 'lodash-es'
+import { cloneDeep, isEqual } from 'es-toolkit'
+import { get, set } from 'es-toolkit/compat'
 import { progress } from '.'
 import { config } from './config'
 import { eventHandler } from './eventHandler'

--- a/packages/react/build.js
+++ b/packages/react/build.js
@@ -8,7 +8,7 @@ const withDeps = process.argv.slice(1).includes('--with-deps')
 
 // For regular builds, externalize all dependencies to keep the bundle size small (using nodeExternalsPlugin).
 // For builds with dependencies, only externalize peer dependencies and bundle everything
-// else so we can check ES2020 compatibility without checking framework code.
+// else so we can check ES2022 compatibility without checking framework code.
 let externalDependencies = undefined
 
 if (withDeps) {
@@ -20,7 +20,7 @@ const config = {
   bundle: true,
   minify: false,
   sourcemap: withDeps ? false : true,
-  target: 'es2020',
+  target: 'es2022',
   external: externalDependencies,
   plugins: [
     ...(withDeps ? [] : [nodeExternalsPlugin()]),

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,7 +48,7 @@
     "dev": "pnpx concurrently -c \"#ffcf00,#3178c6\" \"pnpm dev:build\" \"pnpm dev:types\" --names build,types",
     "dev:build": "./build.js --watch",
     "dev:types": "tsc --watch --preserveWatchOutput",
-    "es2020-check": "pnpm build:with-deps && es-check es2020 \"dist/index.js\" --checkFeatures --module --noCache --verbose"
+    "es2022-check": "pnpm build:with-deps && es-check es2022 \"dist/index.js\" --checkFeatures --module --noCache --verbose"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
@@ -67,8 +67,7 @@
   },
   "dependencies": {
     "@inertiajs/core": "workspace:*",
-    "@types/lodash-es": "^4.17.12",
-    "laravel-precognition": "2.0.0-beta.3",
-    "lodash-es": "^4.17.23"
+    "es-toolkit": "^1.33.0",
+    "laravel-precognition": "2.0.0-beta.3"
   }
 }

--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -1,5 +1,5 @@
 import { isSameUrlWithoutQueryOrHash } from '@inertiajs/core'
-import { get } from 'lodash-es'
+import { get } from 'es-toolkit/compat'
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { router } from '.'
 import usePage from './usePage'

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -14,8 +14,8 @@ import {
   UseFormUtils,
   VisitOptions,
 } from '@inertiajs/core'
+import { isEqual } from 'es-toolkit'
 import { NamedInputEvent, ValidationConfig } from 'laravel-precognition'
-import { isEqual } from 'lodash-es'
 import React, {
   createContext,
   createElement,

--- a/packages/react/src/Head.ts
+++ b/packages/react/src/Head.ts
@@ -1,4 +1,4 @@
-import { escape } from 'lodash-es'
+import { escape } from 'es-toolkit/compat'
 import React, { FunctionComponent, ReactElement, ReactNode, use, useEffect, useMemo } from 'react'
 import HeadContext from './HeadContext'
 

--- a/packages/react/src/WhenVisible.ts
+++ b/packages/react/src/WhenVisible.ts
@@ -1,5 +1,5 @@
 import { ReloadOptions, router } from '@inertiajs/core'
-import { get } from 'lodash-es'
+import { get } from 'es-toolkit/compat'
 import { createElement, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import usePage from './usePage'
 

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -19,8 +19,8 @@ import {
   UseFormWithPrecognitionArguments,
   VisitOptions,
 } from '@inertiajs/core'
+import { cloneDeep } from 'es-toolkit'
 import type { NamedInputEvent, PrecognitionPath, ValidationConfig, Validator } from 'laravel-precognition'
-import { cloneDeep } from 'lodash-es'
 import { useCallback, useRef, useState } from 'react'
 import { useIsomorphicLayoutEffect } from './react'
 import useFormState, { SetDataAction, SetDataByKeyValuePair, SetDataByMethod, SetDataByObject } from './useFormState'

--- a/packages/react/src/useFormState.ts
+++ b/packages/react/src/useFormState.ts
@@ -10,6 +10,8 @@ import {
   UseFormUtils,
   UseFormWithPrecognitionArguments,
 } from '@inertiajs/core'
+import { cloneDeep, isEqual } from 'es-toolkit'
+import { get, has, set } from 'es-toolkit/compat'
 import {
   createValidator,
   NamedInputEvent,
@@ -18,7 +20,6 @@ import {
   ValidationConfig,
   Validator,
 } from 'laravel-precognition'
-import { cloneDeep, get, has, isEqual, set } from 'lodash-es'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { config } from '.'
 

--- a/packages/react/src/useHttp.ts
+++ b/packages/react/src/useHttp.ts
@@ -24,8 +24,8 @@ import {
   UseHttpSubmitArguments,
   UseHttpSubmitOptions,
 } from '@inertiajs/core'
+import { cloneDeep } from 'es-toolkit'
 import { NamedInputEvent, toSimpleValidationErrors, ValidationConfig, Validator } from 'laravel-precognition'
-import { cloneDeep } from 'lodash-es'
 import { useCallback, useRef, useState } from 'react'
 import useFormState, { SetDataAction } from './useFormState'
 import useRemember from './useRemember'

--- a/packages/react/test-app/Pages/FormComponent/Precognition/BeforeValidation.tsx
+++ b/packages/react/test-app/Pages/FormComponent/Precognition/BeforeValidation.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@inertiajs/react'
-import { isEqual } from 'lodash-es'
+import { isEqual } from 'es-toolkit'
 
 export default function PrecognitionBefore() {
   const handleBeforeValidation = (

--- a/packages/react/test-app/Pages/FormHelper/Precognition/BeforeValidation.tsx
+++ b/packages/react/test-app/Pages/FormHelper/Precognition/BeforeValidation.tsx
@@ -1,5 +1,5 @@
 import { useForm } from '@inertiajs/react'
-import { isEqual } from 'lodash-es'
+import { isEqual } from 'es-toolkit'
 
 export default () => {
   const form = useForm({

--- a/packages/react/test-app/Pages/InfiniteScroll/Filtering.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/Filtering.tsx
@@ -1,5 +1,5 @@
 import { InfiniteScroll, Link, useForm } from '@inertiajs/react'
-import { debounce } from 'lodash-es'
+import { debounce } from 'es-toolkit'
 import { useEffect, useMemo } from 'react'
 import UserCard, { User } from './UserCard'
 

--- a/packages/react/test-app/Pages/InfiniteScroll/FilteringManual.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/FilteringManual.tsx
@@ -1,5 +1,5 @@
 import { InfiniteScroll, useForm } from '@inertiajs/react'
-import { debounce } from 'lodash-es'
+import { debounce } from 'es-toolkit'
 import { useEffect, useMemo } from 'react'
 import UserCard, { User } from './UserCard'
 

--- a/packages/react/test-app/Pages/InfiniteScroll/FilteringReset.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/FilteringReset.tsx
@@ -1,5 +1,5 @@
 import { InfiniteScroll, useForm } from '@inertiajs/react'
-import { debounce } from 'lodash-es'
+import { debounce } from 'es-toolkit'
 import { useEffect, useMemo } from 'react'
 import UserCard, { User } from './UserCard'
 

--- a/packages/react/test-app/eslint.config.js
+++ b/packages/react/test-app/eslint.config.js
@@ -35,11 +35,11 @@ export default [
     ...react.configs.flat.recommended,
     ...react.configs.flat['jsx-runtime'],
     languageOptions: {
-      ecmaVersion: 2020,
+      ecmaVersion: 2022,
       sourceType: 'module',
       globals: {
         ...globals.browser,
-        ...globals.es2020,
+        ...globals.es2022,
       },
     },
     rules: {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -41,7 +41,7 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "dev": "pnpm package --watch",
-    "es2020-check": "pnpm build:with-deps && es-check es2020 \"dist/**/*.js\" --checkFeatures --module --noCache --verbose",
+    "es2022-check": "pnpm build:with-deps && es-check es2022 \"dist/**/*.js\" --checkFeatures --module --noCache --verbose",
     "package": "svelte-kit sync && svelte-package --input src"
   },
   "devDependencies": {
@@ -63,8 +63,7 @@
   },
   "dependencies": {
     "@inertiajs/core": "workspace:*",
-    "@types/lodash-es": "^4.17.12",
-    "laravel-precognition": "2.0.0-beta.3",
-    "lodash-es": "^4.17.23"
+    "es-toolkit": "^1.33.0",
+    "laravel-precognition": "2.0.0-beta.3"
   }
 }

--- a/packages/svelte/src/components/Deferred.svelte
+++ b/packages/svelte/src/components/Deferred.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { isSameUrlWithoutQueryOrHash, router } from '@inertiajs/core'
-  import { get } from 'lodash-es'
+  import { get } from 'es-toolkit/compat'
   import { page } from '../index'
 
   interface Props {

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -16,7 +16,7 @@
     UseFormUtils,
   } from '@inertiajs/core'
   import { type NamedInputEvent, type ValidationConfig, type Validator } from 'laravel-precognition'
-  import { isEqual } from 'lodash-es'
+  import { isEqual } from 'es-toolkit'
   import { onMount } from 'svelte'
   import { setFormContext } from './formContext'
   import useForm from '../useForm.svelte'

--- a/packages/svelte/src/components/WhenVisible.svelte
+++ b/packages/svelte/src/components/WhenVisible.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { router, type ReloadOptions } from '@inertiajs/core'
-  import { get } from 'lodash-es'
+  import { get } from 'es-toolkit/compat'
   import { usePage } from '../page.svelte'
 
   interface Props {

--- a/packages/svelte/src/useForm.svelte.ts
+++ b/packages/svelte/src/useForm.svelte.ts
@@ -23,8 +23,8 @@ import type {
   VisitOptions,
 } from '@inertiajs/core'
 import { router, UseFormUtils } from '@inertiajs/core'
+import { cloneDeep } from 'es-toolkit'
 import type { NamedInputEvent, PrecognitionPath, ValidationConfig, Validator } from 'laravel-precognition'
-import { cloneDeep } from 'lodash-es'
 import useFormState, { type FormStateWithPrecognition, type InternalPrecognitionState } from './useFormState.svelte'
 
 // Reserved keys validation - logs console.error at runtime when form data keys conflict with form properties

--- a/packages/svelte/src/useFormState.svelte.ts
+++ b/packages/svelte/src/useFormState.svelte.ts
@@ -10,9 +10,10 @@ import type {
   UseFormWithPrecognitionArguments,
 } from '@inertiajs/core'
 import { router, UseFormUtils } from '@inertiajs/core'
+import { cloneDeep, isEqual } from 'es-toolkit'
+import { get, has, set } from 'es-toolkit/compat'
 import type { NamedInputEvent, ValidationConfig, Validator } from 'laravel-precognition'
 import { createValidator, resolveName, toSimpleValidationErrors } from 'laravel-precognition'
-import { cloneDeep, get, has, isEqual, set } from 'lodash-es'
 import { config } from '.'
 
 type TransformCallback<TForm> = (data: TForm) => object

--- a/packages/svelte/src/useHttp.svelte.ts
+++ b/packages/svelte/src/useHttp.svelte.ts
@@ -26,9 +26,9 @@ import {
   objectToFormData,
   UseFormUtils,
 } from '@inertiajs/core'
+import { cloneDeep } from 'es-toolkit'
 import type { NamedInputEvent, ValidationConfig, Validator } from 'laravel-precognition'
 import { toSimpleValidationErrors } from 'laravel-precognition'
-import { cloneDeep } from 'lodash-es'
 import useFormState, { type FormStateWithPrecognition, type InternalPrecognitionState } from './useFormState.svelte'
 
 export interface UseHttpProps<TForm extends object, TResponse = unknown> {

--- a/packages/svelte/src/useRemember.svelte.ts
+++ b/packages/svelte/src/useRemember.svelte.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import { cloneDeep } from 'lodash-es'
+import { cloneDeep } from 'es-toolkit'
 
 export default function useRemember<State extends object>(initialState: State, key?: string): State {
   const restored = router.restore(key) as State | undefined

--- a/packages/svelte/test-app/Pages/FormComponent/Precognition/BeforeValidation.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/Precognition/BeforeValidation.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { isEqual } from 'lodash-es'
+  import { isEqual } from 'es-toolkit'
   import { Form } from '@inertiajs/svelte'
 
   const handleBeforeValidation = (

--- a/packages/svelte/test-app/Pages/FormHelper/Precognition/BeforeValidation.svelte
+++ b/packages/svelte/test-app/Pages/FormHelper/Precognition/BeforeValidation.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { useForm } from '@inertiajs/svelte'
-  import { isEqual } from 'lodash-es'
+  import { isEqual } from 'es-toolkit'
 
   const form = useForm({
     name: '',

--- a/packages/svelte/test-app/eslint.config.js
+++ b/packages/svelte/test-app/eslint.config.js
@@ -16,11 +16,11 @@ export default ts.config(
   ...svelte.configs.recommended,
   {
     languageOptions: {
-      ecmaVersion: 2020,
+      ecmaVersion: 2022,
       sourceType: 'module',
       globals: {
         ...globals.browser,
-        ...globals.es2020,
+        ...globals.es2022,
       },
     },
   },

--- a/packages/svelte/vite-with-deps.config.js
+++ b/packages/svelte/vite-with-deps.config.js
@@ -14,6 +14,6 @@ export default defineConfig({
       // Only externalize Svelte (peer dependency) - bundle everything else
       external: (id) => id === 'svelte' || id.startsWith('svelte/'),
     },
-    target: 'es2020',
+    target: 'es2022',
   },
 })

--- a/packages/svelte/vite.config.js
+++ b/packages/svelte/vite.config.js
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   build: {
     minify: false,
-    target: 'es2020',
+    target: 'es2022',
   },
   plugins: [sveltekit()],
 })

--- a/packages/vite/build.js
+++ b/packages/vite/build.js
@@ -8,7 +8,7 @@ const config = {
   bundle: true,
   minify: false,
   sourcemap: true,
-  target: 'es2020',
+  target: 'es2022',
   plugins: [
     nodeExternalsPlugin(),
     {

--- a/packages/vue3/build.js
+++ b/packages/vue3/build.js
@@ -8,7 +8,7 @@ const withDeps = process.argv.slice(1).includes('--with-deps')
 
 // For regular builds, externalize all dependencies to keep the bundle size small (using nodeExternalsPlugin).
 // For builds with dependencies, only externalize peer dependencies and bundle everything
-// else so we can check ES2020 compatibility without checking framework code.
+// else so we can check ES2022 compatibility without checking framework code.
 let externalDependencies = undefined
 
 if (withDeps) {
@@ -20,7 +20,7 @@ const config = {
   bundle: true,
   minify: false,
   sourcemap: withDeps ? false : true,
-  target: 'es2020',
+  target: 'es2022',
   external: externalDependencies,
   plugins: [
     ...(withDeps ? [] : [nodeExternalsPlugin()]),

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -47,7 +47,7 @@
     "dev": "pnpx concurrently -c \"#ffcf00,#3178c6\" \"pnpm dev:build\" \"pnpm dev:types\" --names build,types",
     "dev:build": "./build.js --watch",
     "dev:types": "tsc --watch --preserveWatchOutput",
-    "es2020-check": "pnpm build:with-deps && es-check es2020 \"dist/index.js\" --checkFeatures --module --noCache --verbose"
+    "es2022-check": "pnpm build:with-deps && es-check es2022 \"dist/index.js\" --checkFeatures --module --noCache --verbose"
   },
   "devDependencies": {
     "axios": "^1.13.5",
@@ -62,8 +62,7 @@
   },
   "dependencies": {
     "@inertiajs/core": "workspace:*",
-    "@types/lodash-es": "^4.17.12",
-    "laravel-precognition": "2.0.0-beta.3",
-    "lodash-es": "^4.17.23"
+    "es-toolkit": "^1.33.0",
+    "laravel-precognition": "2.0.0-beta.3"
   }
 }

--- a/packages/vue3/src/deferred.ts
+++ b/packages/vue3/src/deferred.ts
@@ -1,5 +1,5 @@
 import { isSameUrlWithoutQueryOrHash, router } from '@inertiajs/core'
-import { get } from 'lodash-es'
+import { get } from 'es-toolkit/compat'
 import { defineComponent, onMounted, onUnmounted, ref, type SlotsType } from 'vue'
 import { usePage } from './app'
 

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -15,8 +15,8 @@ import {
   UseFormUtils,
   VisitOptions,
 } from '@inertiajs/core'
+import { isEqual } from 'es-toolkit'
 import { NamedInputEvent, ValidationConfig } from 'laravel-precognition'
-import { isEqual } from 'lodash-es'
 import {
   computed,
   defineComponent,

--- a/packages/vue3/src/head.ts
+++ b/packages/vue3/src/head.ts
@@ -1,4 +1,4 @@
-import { escape } from 'lodash-es'
+import { escape } from 'es-toolkit/compat'
 import { defineComponent, DefineComponent, onBeforeUnmount, VNode } from 'vue'
 import { headManager } from './app'
 

--- a/packages/vue3/src/remember.ts
+++ b/packages/vue3/src/remember.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import { cloneDeep } from 'lodash-es'
+import { cloneDeep } from 'es-toolkit'
 import { ComponentOptions } from 'vue'
 
 const remember: ComponentOptions = {

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -19,8 +19,8 @@ import {
   UseFormWithPrecognitionArguments,
   VisitOptions,
 } from '@inertiajs/core'
+import { cloneDeep } from 'es-toolkit'
 import { NamedInputEvent, PrecognitionPath, ValidationConfig, Validator } from 'laravel-precognition'
-import { cloneDeep } from 'lodash-es'
 import useFormState from './useFormState'
 
 // Reserved keys validation - logs console.error at runtime when form data keys conflict with form properties

--- a/packages/vue3/src/useFormState.ts
+++ b/packages/vue3/src/useFormState.ts
@@ -11,6 +11,8 @@ import {
   UseFormUtils,
   UseFormWithPrecognitionArguments,
 } from '@inertiajs/core'
+import { cloneDeep, isEqual } from 'es-toolkit'
+import { get, has, set } from 'es-toolkit/compat'
 import {
   createValidator,
   NamedInputEvent,
@@ -19,7 +21,6 @@ import {
   ValidationConfig,
   Validator,
 } from 'laravel-precognition'
-import { cloneDeep, get, has, isEqual, set } from 'lodash-es'
 import { reactive, watch } from 'vue'
 import { config } from '.'
 

--- a/packages/vue3/src/useHttp.ts
+++ b/packages/vue3/src/useHttp.ts
@@ -24,8 +24,8 @@ import {
   UseHttpSubmitArguments,
   UseHttpSubmitOptions,
 } from '@inertiajs/core'
+import { cloneDeep } from 'es-toolkit'
 import { NamedInputEvent, toSimpleValidationErrors, ValidationConfig, Validator } from 'laravel-precognition'
-import { cloneDeep } from 'lodash-es'
 import useFormState from './useFormState'
 
 export interface UseHttpProps<TForm extends object, TResponse = unknown> {

--- a/packages/vue3/src/useRemember.ts
+++ b/packages/vue3/src/useRemember.ts
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/core'
-import { cloneDeep } from 'lodash-es'
+import { cloneDeep } from 'es-toolkit'
 import { isReactive, reactive, ref, Ref, watch } from 'vue'
 
 export default function useRemember<T extends object>(

--- a/packages/vue3/src/whenVisible.ts
+++ b/packages/vue3/src/whenVisible.ts
@@ -1,5 +1,5 @@
 import { ReloadOptions, router } from '@inertiajs/core'
-import { get } from 'lodash-es'
+import { get } from 'es-toolkit/compat'
 import { computed, defineComponent, h, nextTick, onUnmounted, PropType, ref, SlotsType, watch } from 'vue'
 import { usePage } from './app'
 

--- a/packages/vue3/test-app/Pages/FormComponent/Precognition/BeforeValidation.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/Precognition/BeforeValidation.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Form } from '@inertiajs/vue3'
-import { isEqual } from 'lodash-es'
+import { isEqual } from 'es-toolkit'
 
 const handleBeforeValidation = (
   newRequest: { data: Record<string, unknown> | null; touched: string[] },

--- a/packages/vue3/test-app/Pages/FormHelper/Precognition/BeforeValidation.vue
+++ b/packages/vue3/test-app/Pages/FormHelper/Precognition/BeforeValidation.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useForm } from '@inertiajs/vue3'
-import { isEqual } from 'lodash-es'
+import { isEqual } from 'es-toolkit'
 
 const form = useForm({
   name: '',

--- a/packages/vue3/test-app/Pages/InfiniteScroll/Filtering.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/Filtering.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { InfiniteScroll, Link, useForm } from '@inertiajs/vue3'
-import { debounce } from 'lodash-es'
+import { debounce } from 'es-toolkit'
 import { watch } from 'vue'
 import { User, default as UserCard } from './UserCard.vue'
 

--- a/packages/vue3/test-app/Pages/InfiniteScroll/FilteringManual.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/FilteringManual.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { InfiniteScroll, useForm } from '@inertiajs/vue3'
-import { debounce } from 'lodash-es'
+import { debounce } from 'es-toolkit'
 import { watch } from 'vue'
 import { User, default as UserCard } from './UserCard.vue'
 

--- a/packages/vue3/test-app/Pages/InfiniteScroll/FilteringReset.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/FilteringReset.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { InfiniteScroll, useForm } from '@inertiajs/vue3'
-import { debounce } from 'lodash-es'
+import { debounce } from 'es-toolkit'
 import { watch } from 'vue'
 import { User, default as UserCard } from './UserCard.vue'
 

--- a/packages/vue3/test-app/eslint.config.js
+++ b/packages/vue3/test-app/eslint.config.js
@@ -15,11 +15,11 @@ export default defineConfigWithVueTs(
   vueTsConfigs.recommended,
   {
     languageOptions: {
-      ecmaVersion: 2020,
+      ecmaVersion: 2022,
       sourceType: 'module',
       globals: {
         ...globals.browser,
-        ...globals.es2020,
+        ...globals.es2022,
       },
       parserOptions: {
         projectService: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,15 +33,12 @@ importers:
       '@jridgewell/trace-mapping':
         specifier: ^0.3.31
         version: 0.3.31
-      '@types/lodash-es':
-        specifier: ^4.17.12
-        version: 4.17.12
+      es-toolkit:
+        specifier: ^1.33.0
+        version: 1.45.1
       laravel-precognition:
         specifier: 2.0.0-beta.3
         version: 2.0.0-beta.3(axios@1.13.5)
-      lodash-es:
-        specifier: ^4.17.23
-        version: 4.17.23
     devDependencies:
       '@types/node':
         specifier: ^24.10.13
@@ -70,15 +67,12 @@ importers:
       '@inertiajs/core':
         specifier: workspace:*
         version: link:../core
-      '@types/lodash-es':
-        specifier: ^4.17.12
-        version: 4.17.12
+      es-toolkit:
+        specifier: ^1.33.0
+        version: 1.45.1
       laravel-precognition:
         specifier: 2.0.0-beta.3
         version: 2.0.0-beta.3(axios@1.13.5)
-      lodash-es:
-        specifier: ^4.17.23
-        version: 4.17.23
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -174,15 +168,12 @@ importers:
       '@inertiajs/core':
         specifier: workspace:*
         version: link:../core
-      '@types/lodash-es':
-        specifier: ^4.17.12
-        version: 4.17.12
+      es-toolkit:
+        specifier: ^1.33.0
+        version: 1.45.1
       laravel-precognition:
         specifier: 2.0.0-beta.3
         version: 2.0.0-beta.3(axios@1.13.5)
-      lodash-es:
-        specifier: ^4.17.23
-        version: 4.17.23
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
@@ -309,15 +300,12 @@ importers:
       '@inertiajs/core':
         specifier: workspace:*
         version: link:../core
-      '@types/lodash-es':
-        specifier: ^4.17.12
-        version: 4.17.12
+      es-toolkit:
+        specifier: ^1.33.0
+        version: 1.45.1
       laravel-precognition:
         specifier: 2.0.0-beta.3
         version: 2.0.0-beta.3(axios@1.13.5)
-      lodash-es:
-        specifier: ^4.17.23
-        version: 4.17.23
     devDependencies:
       axios:
         specifier: ^1.13.5
@@ -1242,12 +1230,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/lodash-es@4.17.12':
-    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
-
-  '@types/lodash@4.17.24':
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
-
   '@types/node@24.10.13':
     resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
 
@@ -1799,6 +1781,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   esbuild-node-externals@1.20.1:
     resolution: {integrity: sha512-uVs+TC+PBiav2LoTz8WZT/ootINw9Rns5JJyVznlfZH1qOyZxWCPzeXklY04UtZut5qUeFFaEWtcH7XoMwiTTQ==}
@@ -4014,12 +3999,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/lodash-es@4.17.12':
-    dependencies:
-      '@types/lodash': 4.17.24
-
-  '@types/lodash@4.17.24': {}
-
   '@types/node@24.10.13':
     dependencies:
       undici-types: 7.16.0
@@ -4758,6 +4737,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.45.1: {}
 
   esbuild-node-externals@1.20.1(esbuild@0.27.3):
     dependencies:


### PR DESCRIPTION
See #2961 and https://github.com/laravel/precognition/pull/143