### PR TITLE
[3.x] Improve form state stability

### DIFF
--- a/packages/react/src/useFormState.ts
+++ b/packages/react/src/useFormState.ts
@@ -340,10 +340,7 @@ export default function useFormState<TForm extends object>(
     [touchedFields],
   )
 
-  const formRef = useRef({} as FormState<TForm>)
-  const form = formRef.current
-
-  Object.assign(form, {
+  const form = {
     data,
     setData: setDataFunction,
     isDirty,
@@ -359,7 +356,7 @@ export default function useFormState<TForm extends object>(
     setError,
     clearErrors,
     resetAndClearErrors,
-  })
+  } as FormState<TForm>
 
   const validate = (field?: string | NamedInputEvent | ValidationConfig, config?: ValidationConfig) => {
     if (typeof field === 'object' && !('target' in field)) {

--- a/packages/react/src/useFormState.ts
+++ b/packages/react/src/useFormState.ts
@@ -102,8 +102,8 @@ export interface UseFormStateReturn<TForm extends object> {
   precognitionEndpointRef: React.MutableRefObject<(() => UrlMethodPair) | null>
   dataRef: React.MutableRefObject<TForm>
   isMounted: React.MutableRefObject<boolean>
-  setProcessing: React.Dispatch<React.SetStateAction<boolean>>
-  setProgress: React.Dispatch<React.SetStateAction<Progress | null>>
+  setProcessing: (value: boolean) => void
+  setProgress: (value: Progress | null) => void
   markAsSuccessful: () => void
   clearErrors: (...fields: string[]) => void
   setError: (fieldOrFields: FormDataKeys<TForm> | FormDataErrors<TForm>, maybeValue?: ErrorValue) => void
@@ -130,16 +130,13 @@ export default function useFormState<TForm extends object>(
 
   const [data, setData] = useDataState ? useDataState() : useState(cloneDeep(initialData))
   const [errors, setErrors] = useErrorsState ? useErrorsState() : useState({} as FormDataErrors<TForm>)
-
-  const [hasErrors, setHasErrors] = useState(false)
-  const [processing, setProcessing] = useState(false)
-  const [progress, setProgress] = useState<Progress | null>(null)
+  const [processing, _setProcessing] = useState(false)
+  const [progress, _setProgress] = useState<Progress | null>(null)
   const [wasSuccessful, setWasSuccessful] = useState(false)
   const [recentlySuccessful, setRecentlySuccessful] = useState(false)
 
   const recentlySuccessfulTimeoutId = useRef<number>(undefined)
   const transformRef = useRef<UseFormTransformCallback<TForm>>((data) => data)
-  const isDirty = useMemo(() => !isEqual(data, defaults), [data, defaults])
   const defaultsCalledInOnSuccessRef = useRef(false)
 
   const validatorRef = useRef<Validator | null>(null)
@@ -160,6 +157,44 @@ export default function useFormState<TForm extends object>(
     return () => {
       isMounted.current = false
     }
+  }, [])
+
+  // Snapshot ref keeps state values accessible to the stable form object's getters.
+  // Reassigned each render so getters always return the latest React state.
+  const snapshotRef = useRef({
+    data,
+    defaults,
+    errors,
+    processing,
+    progress,
+    wasSuccessful,
+    recentlySuccessful,
+    validating,
+    touchedFields,
+    validFields,
+  })
+
+  snapshotRef.current = {
+    data,
+    defaults,
+    errors,
+    processing,
+    progress,
+    wasSuccessful,
+    recentlySuccessful,
+    validating,
+    touchedFields,
+    validFields,
+  }
+
+  const setProcessing = useCallback((value: boolean) => {
+    _setProcessing(value)
+    snapshotRef.current.processing = value
+  }, [])
+
+  const setProgress = useCallback((value: Progress | null) => {
+    _setProgress(value)
+    snapshotRef.current.progress = value
   }, [])
 
   const setDataFunction = useCallback(
@@ -251,14 +286,14 @@ export default function useFormState<TForm extends object>(
           ...errors,
           ...(typeof fieldOrFields === 'string' ? { [fieldOrFields]: maybeValue } : fieldOrFields),
         }
-        setHasErrors(Object.keys(newErrors).length > 0)
 
+        snapshotRef.current.errors = newErrors as FormDataErrors<TForm>
         validatorRef.current?.setErrors(newErrors)
 
         return newErrors
       })
     },
-    [setErrors, setHasErrors],
+    [setErrors],
   )
 
   const clearErrors = useCallback(
@@ -271,7 +306,8 @@ export default function useFormState<TForm extends object>(
           }),
           {},
         )
-        setHasErrors(Object.keys(newErrors).length > 0)
+
+        snapshotRef.current.errors = newErrors as FormDataErrors<TForm>
 
         if (validatorRef.current) {
           if (fields.length === 0) {
@@ -284,7 +320,7 @@ export default function useFormState<TForm extends object>(
         return newErrors as FormDataErrors<TForm>
       })
     },
-    [setErrors, setHasErrors],
+    [setErrors],
   )
 
   const resetAndClearErrors = useCallback(
@@ -295,23 +331,33 @@ export default function useFormState<TForm extends object>(
     [reset, clearErrors],
   )
 
+  const setWasSuccessfulWithSnapshot = useCallback((value: boolean) => {
+    setWasSuccessful(value)
+    snapshotRef.current.wasSuccessful = value
+  }, [])
+
+  const setRecentlySuccessfulWithSnapshot = useCallback((value: boolean) => {
+    setRecentlySuccessful(value)
+    snapshotRef.current.recentlySuccessful = value
+  }, [])
+
   const markAsSuccessful = useCallback(() => {
     clearErrors()
-    setWasSuccessful(true)
-    setRecentlySuccessful(true)
+    setWasSuccessfulWithSnapshot(true)
+    setRecentlySuccessfulWithSnapshot(true)
 
     recentlySuccessfulTimeoutId.current = window.setTimeout(() => {
       if (isMounted.current) {
-        setRecentlySuccessful(false)
+        setRecentlySuccessfulWithSnapshot(false)
       }
     }, config.get('form.recentlySuccessfulDuration'))
-  }, [clearErrors, setWasSuccessful, setRecentlySuccessful])
+  }, [clearErrors, setWasSuccessfulWithSnapshot, setRecentlySuccessfulWithSnapshot])
 
   const resetBeforeSubmit = useCallback(() => {
-    setWasSuccessful(false)
-    setRecentlySuccessful(false)
+    setWasSuccessfulWithSnapshot(false)
+    setRecentlySuccessfulWithSnapshot(false)
     clearTimeout(recentlySuccessfulTimeoutId.current)
-  }, [setWasSuccessful, setRecentlySuccessful])
+  }, [setWasSuccessfulWithSnapshot, setRecentlySuccessfulWithSnapshot])
 
   const finishProcessing = useCallback(() => {
     setProcessing(false)
@@ -340,23 +386,49 @@ export default function useFormState<TForm extends object>(
     [touchedFields],
   )
 
-  const form = {
-    data,
+  // Stable form object created once. Getters read from snapshotRef so they
+  // always return the latest React state without requiring a new object identity.
+  const form = useMemo(() => {
+    return {
+      get data() {
+        return snapshotRef.current.data
+      },
+      get isDirty() {
+        return !isEqual(snapshotRef.current.data, snapshotRef.current.defaults)
+      },
+      get errors() {
+        return snapshotRef.current.errors
+      },
+      get hasErrors() {
+        return Object.keys(snapshotRef.current.errors).length > 0
+      },
+      get processing() {
+        return snapshotRef.current.processing
+      },
+      get progress() {
+        return snapshotRef.current.progress
+      },
+      get wasSuccessful() {
+        return snapshotRef.current.wasSuccessful
+      },
+      get recentlySuccessful() {
+        return snapshotRef.current.recentlySuccessful
+      },
+    } as FormState<TForm>
+  }, [])
+
+  // Assign methods onto the stable object each render. Methods may have changing
+  // deps (e.g. reset depends on defaults) so we reassign them, but the object
+  // identity stays the same.
+  Object.assign(form, {
     setData: setDataFunction,
-    isDirty,
-    errors,
-    hasErrors,
-    processing,
-    progress,
-    wasSuccessful,
-    recentlySuccessful,
     transform: transformFunction,
     setDefaults: setDefaultsFunction,
     reset,
     setError,
     clearErrors,
     resetAndClearErrors,
-  } as FormState<TForm>
+  })
 
   const validate = (field?: string | NamedInputEvent | ValidationConfig, config?: ValidationConfig) => {
     if (typeof field === 'object' && !('target' in field)) {
@@ -407,13 +479,15 @@ export default function useFormState<TForm extends object>(
             : toSimpleValidationErrors(validator.errors())
 
           setErrors(validationErrors as FormDataErrors<TForm>)
-          setHasErrors(Object.keys(validationErrors).length > 0)
+          snapshotRef.current.errors = validationErrors as FormDataErrors<TForm>
           setValidFields(validator.valid())
         })
     }
 
     const precognitiveForm = Object.assign(form, {
-      validating,
+      get validating() {
+        return snapshotRef.current.validating
+      },
       validator: () => validatorRef.current!,
       valid,
       invalid,

--- a/packages/react/src/useFormState.ts
+++ b/packages/react/src/useFormState.ts
@@ -340,7 +340,10 @@ export default function useFormState<TForm extends object>(
     [touchedFields],
   )
 
-  const form = {
+  const formRef = useRef({} as FormState<TForm>)
+  const form = formRef.current
+
+  Object.assign(form, {
     data,
     setData: setDataFunction,
     isDirty,
@@ -356,7 +359,7 @@ export default function useFormState<TForm extends object>(
     setError,
     clearErrors,
     resetAndClearErrors,
-  } as FormState<TForm>
+  })
 
   const validate = (field?: string | NamedInputEvent | ValidationConfig, config?: ValidationConfig) => {
     if (typeof field === 'object' && !('target' in field)) {

--- a/packages/react/src/useHttp.ts
+++ b/packages/react/src/useHttp.ts
@@ -326,10 +326,8 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
     [submit],
   )
 
-  const formRef = useRef({} as UseHttpProps<TForm, TResponse>)
-  const form = formRef.current
-
-  Object.assign(form, baseForm, {
+  // Add useHttp-specific methods to the form object (mutate in place like Svelte)
+  Object.assign(baseForm, {
     response,
     submit: submitWithArgs,
     get: createSubmitMethod('get'),
@@ -353,6 +351,9 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
       return form
     },
   })
+
+  // Cast to the full form type (baseForm now has HTTP methods)
+  const form = baseForm as unknown as UseHttpProps<TForm, TResponse>
 
   // Wrap withPrecognition to return the correct type with HTTP methods
   const originalWithPrecognition = baseForm.withPrecognition

--- a/packages/react/src/useHttp.ts
+++ b/packages/react/src/useHttp.ts
@@ -326,8 +326,10 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
     [submit],
   )
 
-  // Add useHttp-specific methods to the form object (mutate in place like Svelte)
-  Object.assign(baseForm, {
+  const formRef = useRef({} as UseHttpProps<TForm, TResponse>)
+  const form = formRef.current
+
+  Object.assign(form, baseForm, {
     response,
     submit: submitWithArgs,
     get: createSubmitMethod('get'),
@@ -351,9 +353,6 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
       return form
     },
   })
-
-  // Cast to the full form type (baseForm now has HTTP methods)
-  const form = baseForm as unknown as UseHttpProps<TForm, TResponse>
 
   // Wrap withPrecognition to return the correct type with HTTP methods
   const originalWithPrecognition = baseForm.withPrecognition

--- a/packages/react/test-app/Pages/FormHelper/StableReference.tsx
+++ b/packages/react/test-app/Pages/FormHelper/StableReference.tsx
@@ -1,0 +1,28 @@
+import { useForm } from '@inertiajs/react'
+import { useCallback, useEffect, useRef } from 'react'
+
+export default () => {
+  const form = useForm({ name: '' })
+  const renderCount = useRef(0)
+
+  renderCount.current++
+
+  const submitForm = useCallback(() => {
+    form.post('/form-helper/stable-reference', {
+      preserveState: true,
+    })
+  }, [form])
+
+  useEffect(() => {
+    submitForm()
+  }, [submitForm])
+
+  return (
+    <div>
+      <h1>useForm Stable Reference Test</h1>
+      <div id="render-count">Render count: {renderCount.current}</div>
+      {form.recentlySuccessful && <div id="recently-successful">Recently successful</div>}
+      {form.wasSuccessful && <div id="was-successful">Was successful</div>}
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/UseHttp/StableReference.tsx
+++ b/packages/react/test-app/Pages/UseHttp/StableReference.tsx
@@ -1,0 +1,37 @@
+import { useHttp } from '@inertiajs/react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface SearchResponse {
+  items: string[]
+  total: number
+  query: string | null
+}
+
+export default () => {
+  const http = useHttp<{ query: string }, SearchResponse>({ query: '' })
+  const renderCount = useRef(0)
+  const [result, setResult] = useState<SearchResponse | null>(null)
+
+  renderCount.current++
+
+  const fetchData = useCallback(async () => {
+    try {
+      const data = await http.get('/api/data')
+      setResult(data)
+    } catch {
+      // ignore
+    }
+  }, [http])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  return (
+    <div>
+      <h1>useHttp Stable Reference Test</h1>
+      <div id="render-count">Render count: {renderCount.current}</div>
+      {result && <div id="result">Items: {result.items.join(', ')}</div>}
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/UseHttp/StableReference.tsx
+++ b/packages/react/test-app/Pages/UseHttp/StableReference.tsx
@@ -31,6 +31,7 @@ export default () => {
     <div>
       <h1>useHttp Stable Reference Test</h1>
       <div id="render-count">Render count: {renderCount.current}</div>
+      {http.recentlySuccessful && <div id="recently-successful">Recently successful</div>}
       {result && <div id="result">Items: {result.items.join(', ')}</div>}
     </div>
   )

--- a/packages/svelte/test-app/Pages/FormHelper/StableReference.svelte
+++ b/packages/svelte/test-app/Pages/FormHelper/StableReference.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { useForm } from '@inertiajs/svelte'
+
+  const form = useForm({ name: '' })
+
+  let effectRuns = 0
+  let count = $state(0)
+
+  $effect(() => {
+    effectRuns++
+    count = effectRuns
+
+    form.post('/form-helper/stable-reference', {
+      preserveState: true,
+    })
+  })
+</script>
+
+<div>
+  <h1>useForm Stable Reference Test</h1>
+  <div id="render-count">Render count: {count}</div>
+  {#if form.recentlySuccessful}
+    <div id="recently-successful">Recently successful</div>
+  {/if}
+  {#if form.wasSuccessful}
+    <div id="was-successful">Was successful</div>
+  {/if}
+</div>

--- a/packages/svelte/test-app/Pages/UseHttp/StableReference.svelte
+++ b/packages/svelte/test-app/Pages/UseHttp/StableReference.svelte
@@ -26,6 +26,9 @@
 <div>
   <h1>useHttp Stable Reference Test</h1>
   <div id="render-count">Render count: {count}</div>
+  {#if http.recentlySuccessful}
+    <div id="recently-successful">Recently successful</div>
+  {/if}
   {#if result}
     <div id="result">Items: {result.items.join(', ')}</div>
   {/if}

--- a/packages/svelte/test-app/Pages/UseHttp/StableReference.svelte
+++ b/packages/svelte/test-app/Pages/UseHttp/StableReference.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { useHttp } from '@inertiajs/svelte'
+
+  interface SearchResponse {
+    items: string[]
+    total: number
+    query: string | null
+  }
+
+  const http = useHttp<{ query: string }, SearchResponse>({ query: '' })
+
+  let effectRuns = 0
+  let count = $state(0)
+  let result: SearchResponse | null = $state(null)
+
+  $effect(() => {
+    effectRuns++
+    count = effectRuns
+
+    http.get('/api/data').then((data) => {
+      result = data
+    })
+  })
+</script>
+
+<div>
+  <h1>useHttp Stable Reference Test</h1>
+  <div id="render-count">Render count: {count}</div>
+  {#if result}
+    <div id="result">Items: {result.items.join(', ')}</div>
+  {/if}
+</div>

--- a/packages/vue3/test-app/Pages/FormHelper/StableReference.vue
+++ b/packages/vue3/test-app/Pages/FormHelper/StableReference.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3'
+import { computed, ref, watch } from 'vue'
+
+const form = useForm({ name: '' })
+
+const renderCount = ref(0)
+
+const submitForm = computed(() => {
+  return () =>
+    form.post('/form-helper/stable-reference', {
+      preserveState: true,
+    })
+})
+
+watch(
+  submitForm,
+  (fn) => {
+    renderCount.value++
+    fn()
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <div>
+    <h1>useForm Stable Reference Test</h1>
+    <div id="render-count">Render count: {{ renderCount }}</div>
+    <div v-if="form.recentlySuccessful" id="recently-successful">Recently successful</div>
+    <div v-if="form.wasSuccessful" id="was-successful">Was successful</div>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/UseHttp/StableReference.vue
+++ b/packages/vue3/test-app/Pages/UseHttp/StableReference.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { useHttp } from '@inertiajs/vue3'
+import { computed, ref, watch } from 'vue'
+
+interface SearchResponse {
+  items: string[]
+  total: number
+  query: string | null
+}
+
+const http = useHttp<{ query: string }, SearchResponse>({ query: '' })
+
+const renderCount = ref(0)
+const result = ref<SearchResponse | null>(null)
+
+const fetchData = computed(() => {
+  return () => http.get('/api/data')
+})
+
+watch(
+  fetchData,
+  async (fn) => {
+    renderCount.value++
+    try {
+      result.value = await fn()
+    } catch {
+      // ignore
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <div>
+    <h1>useHttp Stable Reference Test</h1>
+    <div id="render-count">Render count: {{ renderCount }}</div>
+    <div v-if="result" id="result">Items: {{ result.items.join(', ') }}</div>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/UseHttp/StableReference.vue
+++ b/packages/vue3/test-app/Pages/UseHttp/StableReference.vue
@@ -35,6 +35,7 @@ watch(
   <div>
     <h1>useHttp Stable Reference Test</h1>
     <div id="render-count">Render count: {{ renderCount }}</div>
+    <div v-if="http.recentlySuccessful" id="recently-successful">Recently successful</div>
     <div v-if="result" id="result">Items: {{ result.items.join(', ') }}</div>
   </div>
 </template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -3046,6 +3046,7 @@ app.get('/use-http/remember', (req, res) => inertia.render(req, res, { component
 app.get('/use-http/submit', (req, res) => inertia.render(req, res, { component: 'UseHttp/Submit' }))
 app.get('/use-http/optimistic', (req, res) => inertia.render(req, res, { component: 'UseHttp/Optimistic' }))
 app.get('/use-http/with-all-errors', (req, res) => inertia.render(req, res, { component: 'UseHttp/WithAllErrors' }))
+app.get('/use-http/stable-reference', (req, res) => inertia.render(req, res, { component: 'UseHttp/StableReference' }))
 
 app.get('/reload/concurrent-with-data', (req, res) => {
   const partialData = req.headers['x-inertia-partial-data']

--- a/tests/form-helper.spec.ts
+++ b/tests/form-helper.spec.ts
@@ -1040,6 +1040,19 @@ test.describe('Nested', () => {
   })
 })
 
+test('it returns a stable reference that does not cause infinite re-renders in dependency arrays', async ({ page }) => {
+  await page.goto('/form-helper/stable-reference')
+
+  await expect(page.locator('#was-successful')).toBeVisible()
+  await expect(page.locator('#recently-successful')).toBeVisible()
+  await expect(page.locator('#recently-successful')).not.toBeVisible()
+
+  const renderCount = await page.locator('#render-count').textContent()
+  const count = parseInt(renderCount!.replace('Render count: ', ''))
+
+  expect(count).toBeLessThan(7)
+})
+
 test.describe('React', () => {
   test.skip(process.env.PACKAGE !== 'react', 'Only for React')
 

--- a/tests/use-http.spec.ts
+++ b/tests/use-http.spec.ts
@@ -546,9 +546,8 @@ test.describe('useHttp', () => {
     await page.goto('/use-http/stable-reference')
 
     await expect(page.locator('#result')).toBeVisible()
-
-    // Wait for the recentlySuccessful timer (2s) to fire and settle
-    await page.waitForTimeout(2500)
+    await expect(page.locator('#recently-successful')).toBeVisible()
+    await expect(page.locator('#recently-successful')).not.toBeVisible()
 
     const renderCount = await page.locator('#render-count').textContent()
     const count = parseInt(renderCount!.replace('Render count: ', ''))

--- a/tests/use-http.spec.ts
+++ b/tests/use-http.spec.ts
@@ -540,6 +540,22 @@ test.describe('useHttp', () => {
     })
   })
 
+  test('it returns a stable reference that does not cause infinite re-renders in dependency arrays', async ({
+    page,
+  }) => {
+    await page.goto('/use-http/stable-reference')
+
+    await expect(page.locator('#result')).toBeVisible()
+
+    // Wait for the recentlySuccessful timer (2s) to fire and settle
+    await page.waitForTimeout(2500)
+
+    const renderCount = await page.locator('#render-count').textContent()
+    const count = parseInt(renderCount!.replace('Render count: ', ''))
+
+    expect(count).toBeLessThan(7)
+  })
+
   test('it handles 204 no content responses without errors', async ({ page }) => {
     await page.goto('/use-http/no-content')
 


### PR DESCRIPTION
The React `useForm` and `useHttp` hooks now return a more stable object reference.