### PR TITLE
[3.x] Allow overriding `useHttp` response type per method call

### DIFF
--- a/packages/react/src/useHttp.ts
+++ b/packages/react/src/useHttp.ts
@@ -59,11 +59,11 @@ export interface UseHttpProps<TForm extends object, TResponse = unknown> {
     (errors: FormDataErrors<TForm>): void
   }
   submit: (...args: UseHttpSubmitArguments<TResponse, TForm>) => Promise<TResponse>
-  get: (url: string, options?: UseHttpSubmitOptions<TResponse, TForm>) => Promise<TResponse>
-  post: (url: string, options?: UseHttpSubmitOptions<TResponse, TForm>) => Promise<TResponse>
-  put: (url: string, options?: UseHttpSubmitOptions<TResponse, TForm>) => Promise<TResponse>
-  patch: (url: string, options?: UseHttpSubmitOptions<TResponse, TForm>) => Promise<TResponse>
-  delete: (url: string, options?: UseHttpSubmitOptions<TResponse, TForm>) => Promise<TResponse>
+  get: <R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>) => Promise<R>
+  post: <R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>) => Promise<R>
+  put: <R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>) => Promise<R>
+  patch: <R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>) => Promise<R>
+  delete: <R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>) => Promise<R>
   cancel: () => void
   dontRemember: <K extends FormDataKeys<TForm>>(...fields: K[]) => UseHttpProps<TForm, TResponse>
   optimistic: (callback: (currentData: TForm) => Partial<TForm>) => UseHttpProps<TForm, TResponse>

--- a/packages/react/src/useHttp.ts
+++ b/packages/react/src/useHttp.ts
@@ -58,7 +58,7 @@ export interface UseHttpProps<TForm extends object, TResponse = unknown> {
     <K extends FormDataKeys<TForm>>(field: K, value: ErrorValue): void
     (errors: FormDataErrors<TForm>): void
   }
-  submit: (...args: UseHttpSubmitArguments<TResponse, TForm>) => Promise<TResponse>
+  submit: <R = TResponse>(...args: UseHttpSubmitArguments<R, TForm>) => Promise<R>
   get: <R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>) => Promise<R>
   post: <R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>) => Promise<R>
   put: <R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>) => Promise<R>

--- a/packages/react/test-app/Pages/UseHttp/Submit.tsx
+++ b/packages/react/test-app/Pages/UseHttp/Submit.tsx
@@ -16,9 +16,15 @@ export default () => {
     email: '',
   })
 
+  const untypedForm = useHttp<{ name: string; email: string }>({
+    name: '',
+    email: '',
+  })
+
   const [submitResult, setSubmitResult] = useState<UserResponse | null>(null)
   const [submitWithMethodResult, setSubmitWithMethodResult] = useState<UserResponse | null>(null)
   const [submitWithWayfinderResult, setSubmitWithWayfinderResult] = useState<UserResponse | null>(null)
+  const [submitOverrideResult, setSubmitOverrideResult] = useState<UserResponse | null>(null)
 
   const performSubmit = async () => {
     try {
@@ -44,6 +50,15 @@ export default () => {
       setSubmitWithWayfinderResult(result)
     } catch (e) {
       console.error('Submit with wayfinder failed:', e)
+    }
+  }
+
+  const performSubmitWithOverride = async () => {
+    try {
+      const result = await untypedForm.submit<UserResponse>('post', '/api/users')
+      setSubmitOverrideResult(result)
+    } catch (e) {
+      console.error('Submit with type override failed:', e)
     }
   }
 
@@ -108,6 +123,38 @@ export default () => {
           <div id="submit-wayfinder-result">
             PATCH Success - ID: {submitWithWayfinderResult.id}, Name: {submitWithWayfinderResult.user.name}, Email:{' '}
             {submitWithWayfinderResult.user.email}
+          </div>
+        )}
+      </section>
+
+      {/* Submit with response type override */}
+      <section id="submit-override-test">
+        <h2>Submit with response type override</h2>
+        <label>
+          Name
+          <input
+            type="text"
+            id="submit-override-name"
+            value={untypedForm.data.name}
+            onChange={(e) => untypedForm.setData('name', e.target.value)}
+          />
+        </label>
+        <label>
+          Email
+          <input
+            type="email"
+            id="submit-override-email"
+            value={untypedForm.data.email}
+            onChange={(e) => untypedForm.setData('email', e.target.value)}
+          />
+        </label>
+        <button onClick={performSubmitWithOverride} id="submit-override-button">
+          Submit (typed at call site)
+        </button>
+        {submitOverrideResult && (
+          <div id="submit-override-result">
+            Override Success - ID: {submitOverrideResult.id}, Name: {submitOverrideResult.user.name}, Email:{' '}
+            {submitOverrideResult.user.email}
           </div>
         )}
       </section>

--- a/packages/react/test-app/Pages/UseHttp/TypeScript/Types.tsx
+++ b/packages/react/test-app/Pages/UseHttp/TypeScript/Types.tsx
@@ -1,0 +1,67 @@
+// This component is used for checking the TypeScript implementation; there is no Playwright test depending on it.
+import { useHttp } from '@inertiajs/react'
+
+interface UserForm {
+  name: string
+  email: string
+}
+
+interface UserResponse {
+  id: number
+  name: string
+}
+
+interface OrderResponse {
+  orderId: string
+  total: number
+}
+
+async function typedAtCallSite() {
+  const form = useHttp<UserForm>({ name: '', email: '' })
+
+  // Default TResponse (unknown)
+  const unknown: unknown = await form.post('/users')
+
+  // Override TResponse per method
+  const user: UserResponse = await form.post<UserResponse>('/users')
+  const order: OrderResponse = await form.get<OrderResponse>('/orders/123')
+  const putUser: UserResponse = await form.put<UserResponse>('/users/1')
+  const patchUser: UserResponse = await form.patch<UserResponse>('/users/1')
+  const deleteResult: { deleted: boolean } = await form.delete<{ deleted: boolean }>('/users/1')
+
+  console.log(unknown, user, order, putUser, patchUser, deleteResult)
+}
+
+async function typedAtUseHttpLevel() {
+  const form = useHttp<UserForm, UserResponse>({ name: '', email: '' })
+
+  // Default TResponse is UserResponse
+  const user: UserResponse = await form.post('/users')
+
+  // Override TResponse per method
+  const order: OrderResponse = await form.get<OrderResponse>('/orders/123')
+
+  console.log(user, order)
+}
+
+async function typedOptionsCallbacks() {
+  const form = useHttp<UserForm>({ name: '', email: '' })
+
+  await form.post<UserResponse>('/users', {
+    onSuccess: (response) => {
+      const id: number = response.id
+      const name: string = response.name
+      console.log(id, name)
+    },
+  })
+}
+
+export default () => {
+  return (
+    <div>
+      {typedAtCallSite.toString()}
+      {typedAtUseHttpLevel.toString()}
+      {typedOptionsCallbacks.toString()}
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/UseHttp/TypeScript/Types.tsx
+++ b/packages/react/test-app/Pages/UseHttp/TypeScript/Types.tsx
@@ -16,47 +16,47 @@ interface OrderResponse {
   total: number
 }
 
-async function typedAtCallSite() {
-  const form = useHttp<UserForm>({ name: '', email: '' })
-
-  // Default TResponse (unknown)
-  const unknown: unknown = await form.post('/users')
-
-  // Override TResponse per method
-  const user: UserResponse = await form.post<UserResponse>('/users')
-  const order: OrderResponse = await form.get<OrderResponse>('/orders/123')
-  const putUser: UserResponse = await form.put<UserResponse>('/users/1')
-  const patchUser: UserResponse = await form.patch<UserResponse>('/users/1')
-  const deleteResult: { deleted: boolean } = await form.delete<{ deleted: boolean }>('/users/1')
-
-  console.log(unknown, user, order, putUser, patchUser, deleteResult)
-}
-
-async function typedAtUseHttpLevel() {
-  const form = useHttp<UserForm, UserResponse>({ name: '', email: '' })
-
-  // Default TResponse is UserResponse
-  const user: UserResponse = await form.post('/users')
-
-  // Override TResponse per method
-  const order: OrderResponse = await form.get<OrderResponse>('/orders/123')
-
-  console.log(user, order)
-}
-
-async function typedOptionsCallbacks() {
-  const form = useHttp<UserForm>({ name: '', email: '' })
-
-  await form.post<UserResponse>('/users', {
-    onSuccess: (response) => {
-      const id: number = response.id
-      const name: string = response.name
-      console.log(id, name)
-    },
-  })
-}
-
 export default () => {
+  const form = useHttp<UserForm>({ name: '', email: '' })
+  const typedForm = useHttp<UserForm, UserResponse>({ name: '', email: '' })
+
+  async function typedAtCallSite() {
+    // Default TResponse (unknown)
+    const unknown: unknown = await form.post('/users')
+
+    // Override TResponse per method
+    const user: UserResponse = await form.post<UserResponse>('/users')
+    const order: OrderResponse = await form.get<OrderResponse>('/orders/123')
+    const putUser: UserResponse = await form.put<UserResponse>('/users/1')
+    const patchUser: UserResponse = await form.patch<UserResponse>('/users/1')
+    const deleteResult: { deleted: boolean } = await form.delete<{ deleted: boolean }>('/users/1')
+
+    // Override TResponse on submit
+    const submitted: UserResponse = await form.submit<UserResponse>('post', '/users')
+
+    console.log(unknown, user, order, putUser, patchUser, deleteResult, submitted)
+  }
+
+  async function typedAtUseHttpLevel() {
+    // Default TResponse is UserResponse
+    const user: UserResponse = await typedForm.post('/users')
+
+    // Override TResponse per method
+    const order: OrderResponse = await typedForm.get<OrderResponse>('/orders/123')
+
+    console.log(user, order)
+  }
+
+  async function typedOptionsCallbacks() {
+    await form.post<UserResponse>('/users', {
+      onSuccess: (response) => {
+        const id: number = response.id
+        const name: string = response.name
+        console.log(id, name)
+      },
+    })
+  }
+
   return (
     <div>
       {typedAtCallSite.toString()}

--- a/packages/svelte/src/useHttp.svelte.ts
+++ b/packages/svelte/src/useHttp.svelte.ts
@@ -52,7 +52,7 @@ export interface UseHttpProps<TForm extends object, TResponse = unknown> {
   resetAndClearErrors<K extends FormDataKeys<TForm>>(...fields: K[]): this
   setError<K extends FormDataKeys<TForm>>(field: K, value: ErrorValue): this
   setError(errors: FormDataErrors<TForm>): this
-  submit(...args: UseHttpSubmitArguments<TResponse, TForm>): Promise<TResponse>
+  submit<R = TResponse>(...args: UseHttpSubmitArguments<R, TForm>): Promise<R>
   get<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
   post<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
   put<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>

--- a/packages/svelte/src/useHttp.svelte.ts
+++ b/packages/svelte/src/useHttp.svelte.ts
@@ -53,11 +53,11 @@ export interface UseHttpProps<TForm extends object, TResponse = unknown> {
   setError<K extends FormDataKeys<TForm>>(field: K, value: ErrorValue): this
   setError(errors: FormDataErrors<TForm>): this
   submit(...args: UseHttpSubmitArguments<TResponse, TForm>): Promise<TResponse>
-  get(url: string, options?: UseHttpSubmitOptions<TResponse, TForm>): Promise<TResponse>
-  post(url: string, options?: UseHttpSubmitOptions<TResponse, TForm>): Promise<TResponse>
-  put(url: string, options?: UseHttpSubmitOptions<TResponse, TForm>): Promise<TResponse>
-  patch(url: string, options?: UseHttpSubmitOptions<TResponse, TForm>): Promise<TResponse>
-  delete(url: string, options?: UseHttpSubmitOptions<TResponse, TForm>): Promise<TResponse>
+  get<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
+  post<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
+  put<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
+  patch<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
+  delete<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
   cancel(): void
   dontRemember<K extends FormDataKeys<TForm>>(...fields: K[]): this
   optimistic(callback: (currentData: TForm) => Partial<TForm>): this

--- a/packages/svelte/test-app/Pages/UseHttp/Submit.svelte
+++ b/packages/svelte/test-app/Pages/UseHttp/Submit.svelte
@@ -15,9 +15,15 @@
     email: '',
   })
 
+  const untypedForm = useHttp<{ name: string; email: string }>({
+    name: '',
+    email: '',
+  })
+
   let submitResult: UserResponse | null = $state(null)
   let submitWithMethodResult: UserResponse | null = $state(null)
   let submitWithWayfinderResult: UserResponse | null = $state(null)
+  let submitOverrideResult: UserResponse | null = $state(null)
 
   const performSubmit = async () => {
     try {
@@ -43,6 +49,15 @@
       submitWithWayfinderResult = result
     } catch (e) {
       console.error('Submit with wayfinder failed:', e)
+    }
+  }
+
+  const performSubmitWithOverride = async () => {
+    try {
+      const result = await untypedForm.submit<UserResponse>('post', '/api/users')
+      submitOverrideResult = result
+    } catch (e) {
+      console.error('Submit with type override failed:', e)
     }
   }
 </script>
@@ -92,6 +107,26 @@
     {#if submitWithWayfinderResult}
       <div id="submit-wayfinder-result">
         PATCH Success - ID: {submitWithWayfinderResult.id}, Name: {submitWithWayfinderResult.user.name}, Email: {submitWithWayfinderResult
+          .user.email}
+      </div>
+    {/if}
+  </section>
+
+  <!-- Submit with response type override -->
+  <section id="submit-override-test">
+    <h2>Submit with response type override</h2>
+    <label>
+      Name
+      <input type="text" id="submit-override-name" bind:value={untypedForm.name} />
+    </label>
+    <label>
+      Email
+      <input type="email" id="submit-override-email" bind:value={untypedForm.email} />
+    </label>
+    <button onclick={performSubmitWithOverride} id="submit-override-button">Submit (typed at call site)</button>
+    {#if submitOverrideResult}
+      <div id="submit-override-result">
+        Override Success - ID: {submitOverrideResult.id}, Name: {submitOverrideResult.user.name}, Email: {submitOverrideResult
           .user.email}
       </div>
     {/if}

--- a/packages/svelte/test-app/Pages/UseHttp/TypeScript/Types.svelte
+++ b/packages/svelte/test-app/Pages/UseHttp/TypeScript/Types.svelte
@@ -30,7 +30,10 @@
     const patchUser: UserResponse = await form.patch<UserResponse>('/users/1')
     const deleteResult: { deleted: boolean } = await form.delete<{ deleted: boolean }>('/users/1')
 
-    console.log(unknown, user, order, putUser, patchUser, deleteResult)
+    // Override TResponse on submit
+    const submitted: UserResponse = await form.submit<UserResponse>('post', '/users')
+
+    console.log(unknown, user, order, putUser, patchUser, deleteResult, submitted)
   }
 
   async function typedAtUseHttpLevel() {

--- a/packages/svelte/test-app/Pages/UseHttp/TypeScript/Types.svelte
+++ b/packages/svelte/test-app/Pages/UseHttp/TypeScript/Types.svelte
@@ -1,0 +1,61 @@
+<!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
+<script lang="ts">
+  import { useHttp } from '@inertiajs/svelte'
+
+  interface UserForm {
+    name: string
+    email: string
+  }
+
+  interface UserResponse {
+    id: number
+    name: string
+  }
+
+  interface OrderResponse {
+    orderId: string
+    total: number
+  }
+
+  async function typedAtCallSite() {
+    const form = useHttp<UserForm>({ name: '', email: '' })
+
+    // Default TResponse (unknown)
+    const unknown: unknown = await form.post('/users')
+
+    // Override TResponse per method
+    const user: UserResponse = await form.post<UserResponse>('/users')
+    const order: OrderResponse = await form.get<OrderResponse>('/orders/123')
+    const putUser: UserResponse = await form.put<UserResponse>('/users/1')
+    const patchUser: UserResponse = await form.patch<UserResponse>('/users/1')
+    const deleteResult: { deleted: boolean } = await form.delete<{ deleted: boolean }>('/users/1')
+
+    console.log(unknown, user, order, putUser, patchUser, deleteResult)
+  }
+
+  async function typedAtUseHttpLevel() {
+    const form = useHttp<UserForm, UserResponse>({ name: '', email: '' })
+
+    // Default TResponse is UserResponse
+    const user: UserResponse = await form.post('/users')
+
+    // Override TResponse per method
+    const order: OrderResponse = await form.get<OrderResponse>('/orders/123')
+
+    console.log(user, order)
+  }
+
+  async function typedOptionsCallbacks() {
+    const form = useHttp<UserForm>({ name: '', email: '' })
+
+    await form.post<UserResponse>('/users', {
+      onSuccess: (response) => {
+        const id: number = response.id
+        const name: string = response.name
+        console.log(id, name)
+      },
+    })
+  }
+</script>
+
+<div>{typedAtCallSite.toString()}{typedAtUseHttpLevel.toString()}{typedOptionsCallbacks.toString()}</div>

--- a/packages/vue3/src/useHttp.ts
+++ b/packages/vue3/src/useHttp.ts
@@ -47,7 +47,7 @@ export interface UseHttpProps<TForm extends object, TResponse = unknown> {
   resetAndClearErrors<K extends FormDataKeys<TForm>>(...fields: K[]): this
   setError<K extends FormDataKeys<TForm>>(field: K, value: ErrorValue): this
   setError(errors: FormDataErrors<TForm>): this
-  submit(...args: UseHttpSubmitArguments<TResponse, TForm>): Promise<TResponse>
+  submit<R = TResponse>(...args: UseHttpSubmitArguments<R, TForm>): Promise<R>
   get<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
   post<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
   put<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>

--- a/packages/vue3/src/useHttp.ts
+++ b/packages/vue3/src/useHttp.ts
@@ -48,11 +48,11 @@ export interface UseHttpProps<TForm extends object, TResponse = unknown> {
   setError<K extends FormDataKeys<TForm>>(field: K, value: ErrorValue): this
   setError(errors: FormDataErrors<TForm>): this
   submit(...args: UseHttpSubmitArguments<TResponse, TForm>): Promise<TResponse>
-  get(url: string, options?: UseHttpSubmitOptions<TResponse, TForm>): Promise<TResponse>
-  post(url: string, options?: UseHttpSubmitOptions<TResponse, TForm>): Promise<TResponse>
-  put(url: string, options?: UseHttpSubmitOptions<TResponse, TForm>): Promise<TResponse>
-  patch(url: string, options?: UseHttpSubmitOptions<TResponse, TForm>): Promise<TResponse>
-  delete(url: string, options?: UseHttpSubmitOptions<TResponse, TForm>): Promise<TResponse>
+  get<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
+  post<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
+  put<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
+  patch<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
+  delete<R = TResponse>(url: string, options?: UseHttpSubmitOptions<R, TForm>): Promise<R>
   cancel(): void
   dontRemember<K extends FormDataKeys<TForm>>(...fields: K[]): this
   optimistic(callback: (currentData: TForm) => Partial<TForm>): this

--- a/packages/vue3/test-app/Pages/UseHttp/Submit.vue
+++ b/packages/vue3/test-app/Pages/UseHttp/Submit.vue
@@ -17,9 +17,16 @@ const form = useHttp<{ name: string; email: string }, UserResponse>('post', '/ap
   email: '',
 })
 
+// Form without pre-configured response type
+const untypedForm = useHttp<{ name: string; email: string }>({
+  name: '',
+  email: '',
+})
+
 const submitResult = ref<UserResponse | null>(null)
 const submitWithMethodResult = ref<UserResponse | null>(null)
 const submitWithWayfinderResult = ref<UserResponse | null>(null)
+const submitOverrideResult = ref<UserResponse | null>(null)
 
 const performSubmit = async () => {
   try {
@@ -45,6 +52,15 @@ const performSubmitWithWayfinder = async () => {
     submitWithWayfinderResult.value = result
   } catch (e) {
     console.error('Submit with wayfinder failed:', e)
+  }
+}
+
+const performSubmitWithOverride = async () => {
+  try {
+    const result = await untypedForm.submit<UserResponse>('post', '/api/users')
+    submitOverrideResult.value = result
+  } catch (e) {
+    console.error('Submit with type override failed:', e)
   }
 }
 </script>
@@ -90,6 +106,24 @@ const performSubmitWithWayfinder = async () => {
       <div v-if="submitWithWayfinderResult" id="submit-wayfinder-result">
         PATCH Success - ID: {{ submitWithWayfinderResult.id }}, Name: {{ submitWithWayfinderResult.user.name }}, Email:
         {{ submitWithWayfinderResult.user.email }}
+      </div>
+    </section>
+
+    <!-- Submit with response type override -->
+    <section id="submit-override-test">
+      <h2>Submit with response type override</h2>
+      <label>
+        Name
+        <input type="text" id="submit-override-name" v-model="untypedForm.name" />
+      </label>
+      <label>
+        Email
+        <input type="email" id="submit-override-email" v-model="untypedForm.email" />
+      </label>
+      <button @click="performSubmitWithOverride" id="submit-override-button">Submit (typed at call site)</button>
+      <div v-if="submitOverrideResult" id="submit-override-result">
+        Override Success - ID: {{ submitOverrideResult.id }}, Name: {{ submitOverrideResult.user.name }}, Email:
+        {{ submitOverrideResult.user.email }}
       </div>
     </section>
   </div>

--- a/packages/vue3/test-app/Pages/UseHttp/TypeScript/Types.vue
+++ b/packages/vue3/test-app/Pages/UseHttp/TypeScript/Types.vue
@@ -1,0 +1,63 @@
+<!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
+<script setup lang="ts">
+import { useHttp } from '@inertiajs/vue3'
+
+interface UserForm {
+  name: string
+  email: string
+}
+
+interface UserResponse {
+  id: number
+  name: string
+}
+
+interface OrderResponse {
+  orderId: string
+  total: number
+}
+
+async function typedAtCallSite() {
+  const form = useHttp<UserForm>({ name: '', email: '' })
+
+  // Default TResponse (unknown)
+  const unknown: unknown = await form.post('/users')
+
+  // Override TResponse per method
+  const user: UserResponse = await form.post<UserResponse>('/users')
+  const order: OrderResponse = await form.get<OrderResponse>('/orders/123')
+  const putUser: UserResponse = await form.put<UserResponse>('/users/1')
+  const patchUser: UserResponse = await form.patch<UserResponse>('/users/1')
+  const deleteResult: { deleted: boolean } = await form.delete<{ deleted: boolean }>('/users/1')
+
+  console.log(unknown, user, order, putUser, patchUser, deleteResult)
+}
+
+async function typedAtUseHttpLevel() {
+  const form = useHttp<UserForm, UserResponse>({ name: '', email: '' })
+
+  // Default TResponse is UserResponse
+  const user: UserResponse = await form.post('/users')
+
+  // Override TResponse per method
+  const order: OrderResponse = await form.get<OrderResponse>('/orders/123')
+
+  console.log(user, order)
+}
+
+async function typedOptionsCallbacks() {
+  const form = useHttp<UserForm>({ name: '', email: '' })
+
+  await form.post<UserResponse>('/users', {
+    onSuccess: (response) => {
+      const id: number = response.id
+      const name: string = response.name
+      console.log(id, name)
+    },
+  })
+}
+</script>
+
+<template>
+  <div>{{ typedAtCallSite.toString() }}{{ typedAtUseHttpLevel.toString() }}{{ typedOptionsCallbacks.toString() }}</div>
+</template>

--- a/packages/vue3/test-app/Pages/UseHttp/TypeScript/Types.vue
+++ b/packages/vue3/test-app/Pages/UseHttp/TypeScript/Types.vue
@@ -30,7 +30,10 @@ async function typedAtCallSite() {
   const patchUser: UserResponse = await form.patch<UserResponse>('/users/1')
   const deleteResult: { deleted: boolean } = await form.delete<{ deleted: boolean }>('/users/1')
 
-  console.log(unknown, user, order, putUser, patchUser, deleteResult)
+  // Override TResponse on submit
+  const submitted: UserResponse = await form.submit<UserResponse>('post', '/users')
+
+  console.log(unknown, user, order, putUser, patchUser, deleteResult, submitted)
 }
 
 async function typedAtUseHttpLevel() {

--- a/tests/use-http.spec.ts
+++ b/tests/use-http.spec.ts
@@ -476,6 +476,19 @@ test.describe('useHttp', () => {
       await expect(page.locator('#submit-wayfinder-result')).toContainText('Name: Bob Smith')
       await expect(page.locator('#submit-wayfinder-result')).toContainText('Email: bob@example.com')
     })
+
+    test('it submits with response type override at the call site', async ({ page }) => {
+      await page.goto('/use-http/submit')
+
+      await page.fill('#submit-override-name', 'Alice Jones')
+      await page.fill('#submit-override-email', 'alice@example.com')
+      await page.click('#submit-override-button')
+
+      await expect(page.locator('#submit-override-result')).toBeVisible()
+      await expect(page.locator('#submit-override-result')).toContainText('Override Success - ID: 123')
+      await expect(page.locator('#submit-override-result')).toContainText('Name: Alice Jones')
+      await expect(page.locator('#submit-override-result')).toContainText('Email: alice@example.com')
+    })
   })
 
   test.describe('Optimistic', () => {


### PR DESCRIPTION
This PR adds a generic type parameter to each HTTP method and to `submit()` so the response type can be overridden at the call site:

```ts
const form = useHttp<UserForm>({ name: '', email: '' })

const user: UserResponse = await form.post<UserResponse>('/users')
const order: OrderResponse = await form.get<OrderResponse>('/orders/123')
```