### PR TITLE
[3.x] Allow history encryption to be unsupported in non-SSL environments

### DIFF
--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -23,7 +23,7 @@ export const historySessionStorageKeys = {
   iv: 'historyIv',
 }
 
-export const decryptHistory = async (data: any): Promise<any> => {
+export const decryptHistory = async (data: BufferSource): Promise<any> => {
   const iv = getIv()
   const storedKey = await getKeyFromSessionStorage()
 
@@ -61,7 +61,7 @@ const encryptData = async (iv: BufferSource, key: CryptoKey, data: any) => {
   )
 }
 
-const decryptData = async (iv: BufferSource, key: CryptoKey, data: any) => {
+const decryptData = async (iv: BufferSource, key: CryptoKey, data: BufferSource) => {
   if (typeof window.crypto.subtle === 'undefined') {
     console.warn('Decryption is not supported in this environment. SSL is required.')
 

--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -1,8 +1,19 @@
 import { SessionStorage } from './sessionStorage'
 
-export const encryptHistory = async (data: any): Promise<ArrayBuffer> => {
+let warned = false
+
+export const encryptHistory = async <T>(data: T): Promise<ArrayBuffer | T> => {
   if (typeof window === 'undefined') {
     throw new Error('Unable to encrypt history')
+  }
+
+  if (typeof window.crypto.subtle === 'undefined') {
+    if (!warned) {
+      console.warn('Encryption is not supported in this environment. SSL is required.')
+      warned = true
+    }
+
+    return data
   }
 
   const iv = getIv()
@@ -35,16 +46,6 @@ export const decryptHistory = async (data: BufferSource): Promise<any> => {
 }
 
 const encryptData = async (iv: BufferSource, key: CryptoKey, data: any) => {
-  if (typeof window === 'undefined') {
-    throw new Error('Unable to encrypt history')
-  }
-
-  if (typeof window.crypto.subtle === 'undefined') {
-    console.warn('Encryption is not supported in this environment. SSL is required.')
-
-    return Promise.resolve(data)
-  }
-
   const textEncoder = new TextEncoder()
   const str = JSON.stringify(data)
   const encoded = new Uint8Array(str.length * 3)
@@ -95,12 +96,6 @@ const getIv = (): BufferSource => {
 }
 
 const createKey = async () => {
-  if (typeof window.crypto.subtle === 'undefined') {
-    console.warn('Encryption is not supported in this environment. SSL is required.')
-
-    return Promise.resolve(null)
-  }
-
   return window.crypto.subtle.generateKey(
     {
       name: 'AES-GCM',
@@ -112,12 +107,6 @@ const createKey = async () => {
 }
 
 const saveKey = async (key: CryptoKey) => {
-  if (typeof window.crypto.subtle === 'undefined') {
-    console.warn('Encryption is not supported in this environment. SSL is required.')
-
-    return Promise.resolve()
-  }
-
   const keyData = await window.crypto.subtle.exportKey('raw', key)
 
   SessionStorage.set(historySessionStorageKeys.key, Array.from(new Uint8Array(keyData)))


### PR DESCRIPTION
### Problem
I'm using the `EncryptHistory` middleware on my Laravel backend, but my dev environment isn't using SSL. Unfortunately, Inertia throws an error under these conditions, and I am unable to use my app.

### Proposed Solution
Check if encryption is supported at the encryption entrypoint `encryptHistory` function, and log the warning once to let users know history encryption is not supported without SSL, but then continue without encrypting instead of throwing an error.

An alternative solution would be adjusting the server-side adapters to allow for a global history encryption kill switch (one that also turns off the Laravel middleware for example), but the approach I took here made the most sense to me.

This PR also updates a few parameter types to increase type safety.