### PR TITLE
[3.x] Fix React form not re-rendering memoized children on `setData`

### DIFF
--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -21,7 +21,7 @@ import {
 } from '@inertiajs/core'
 import { cloneDeep } from 'es-toolkit'
 import type { NamedInputEvent, PrecognitionPath, ValidationConfig, Validator } from 'laravel-precognition'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useIsomorphicLayoutEffect } from './react'
 import useFormState, { SetDataAction, SetDataByKeyValuePair, SetDataByMethod, SetDataByObject } from './useFormState'
 import useRemember from './useRemember'
@@ -136,6 +136,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
     setDefaultsState,
     transformRef,
     precognitionEndpointRef,
+    dataRef,
     isMounted,
     setProcessing,
     setProgress,
@@ -251,7 +252,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
       _options.optimistic = _options.optimistic ?? pendingOptimisticRef.current ?? undefined
       pendingOptimisticRef.current = null
 
-      const transformedData = transformRef.current(baseForm.data) as RequestPayload
+      const transformedData = transformRef.current(dataRef.current) as RequestPayload
 
       if (method === 'delete') {
         router.delete(url, { ..._options, data: transformedData })
@@ -259,7 +260,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
         router[method](url, transformedData, _options)
       }
     },
-    [baseForm.data, clearErrors, setError, transformRef],
+    [clearErrors, setError, transformRef],
   )
 
   const cancel = useCallback(() => {
@@ -268,20 +269,21 @@ export default function useForm<TForm extends FormDataType<TForm>>(
     }
   }, [])
 
-  const createSubmitMethod =
-    (method: Method) =>
-    (url: string, options: VisitOptions = {}) => {
-      submit(method, url, options)
-    }
+  const submitMethods = useMemo(
+    () => ({
+      get: (url: string, options: VisitOptions = {}) => submit('get', url, options),
+      post: (url: string, options: VisitOptions = {}) => submit('post', url, options),
+      put: (url: string, options: VisitOptions = {}) => submit('put', url, options),
+      patch: (url: string, options: VisitOptions = {}) => submit('patch', url, options),
+      delete: (url: string, options: VisitOptions = {}) => submit('delete', url, options),
+    }),
+    [submit],
+  )
 
-  // Add useForm-specific methods to the form object (mutate in place like Svelte)
+  // Add useForm-specific methods to the form object
   Object.assign(baseForm, {
     submit,
-    get: createSubmitMethod('get'),
-    post: createSubmitMethod('post'),
-    put: createSubmitMethod('put'),
-    patch: createSubmitMethod('patch'),
-    delete: createSubmitMethod('delete'),
+    ...submitMethods,
     cancel,
     dontRemember: <K extends FormDataKeys<TForm>>(...keys: K[]) => {
       excludeKeysRef.current = keys

--- a/packages/react/src/useFormState.ts
+++ b/packages/react/src/useFormState.ts
@@ -20,7 +20,7 @@ import {
   ValidationConfig,
   Validator,
 } from 'laravel-precognition'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { config } from '.'
 
 export type SetDataByObject<TForm> = (data: Partial<TForm>) => void
@@ -386,41 +386,15 @@ export default function useFormState<TForm extends object>(
     [touchedFields],
   )
 
-  // Stable form object created once. Getters read from snapshotRef so they
-  // always return the latest React state without requiring a new object identity.
-  const form = useMemo(() => {
-    return {
-      get data() {
-        return snapshotRef.current.data
-      },
-      get isDirty() {
-        return !isEqual(snapshotRef.current.data, snapshotRef.current.defaults)
-      },
-      get errors() {
-        return snapshotRef.current.errors
-      },
-      get hasErrors() {
-        return Object.keys(snapshotRef.current.errors).length > 0
-      },
-      get processing() {
-        return snapshotRef.current.processing
-      },
-      get progress() {
-        return snapshotRef.current.progress
-      },
-      get wasSuccessful() {
-        return snapshotRef.current.wasSuccessful
-      },
-      get recentlySuccessful() {
-        return snapshotRef.current.recentlySuccessful
-      },
-    } as FormState<TForm>
-  }, [])
-
-  // Assign methods onto the stable object each render. Methods may have changing
-  // deps (e.g. reset depends on defaults) so we reassign them, but the object
-  // identity stays the same.
-  Object.assign(form, {
+  const form = {
+    data,
+    isDirty: !isEqual(data, defaults),
+    errors,
+    hasErrors: Object.keys(errors).length > 0,
+    processing,
+    progress,
+    wasSuccessful,
+    recentlySuccessful,
     setData: setDataFunction,
     transform: transformFunction,
     setDefaults: setDefaultsFunction,
@@ -428,7 +402,7 @@ export default function useFormState<TForm extends object>(
     setError,
     clearErrors,
     resetAndClearErrors,
-  })
+  } as FormState<TForm>
 
   const validate = (field?: string | NamedInputEvent | ValidationConfig, config?: ValidationConfig) => {
     if (typeof field === 'object' && !('target' in field)) {
@@ -485,9 +459,7 @@ export default function useFormState<TForm extends object>(
     }
 
     const precognitiveForm = Object.assign(form, {
-      get validating() {
-        return snapshotRef.current.validating
-      },
+      validating,
       validator: () => validatorRef.current!,
       valid,
       invalid,

--- a/packages/react/src/useHttp.ts
+++ b/packages/react/src/useHttp.ts
@@ -26,7 +26,7 @@ import {
 } from '@inertiajs/core'
 import { cloneDeep } from 'es-toolkit'
 import { NamedInputEvent, toSimpleValidationErrors, ValidationConfig, Validator } from 'laravel-precognition'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import useFormState, { SetDataAction } from './useFormState'
 import useRemember from './useRemember'
 
@@ -311,12 +311,6 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
     }
   }, [])
 
-  const createSubmitMethod =
-    (method: Method) =>
-    async (url: string, options: UseHttpSubmitOptions<TResponse, TForm> = {}): Promise<TResponse> => {
-      return submit(method, url, options)
-    }
-
   const submitWithArgs = useCallback(
     (...args: UseHttpSubmitArguments<TResponse, TForm>): Promise<TResponse> => {
       const parsed = UseFormUtils.parseSubmitArguments(args as any, precognitionEndpointRef.current)
@@ -326,15 +320,27 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
     [submit],
   )
 
-  // Add useHttp-specific methods to the form object (mutate in place like Svelte)
+  const submitMethods = useMemo(
+    () => ({
+      get: async (url: string, options: UseHttpSubmitOptions<TResponse, TForm> = {}): Promise<TResponse> =>
+        submit('get', url, options),
+      post: async (url: string, options: UseHttpSubmitOptions<TResponse, TForm> = {}): Promise<TResponse> =>
+        submit('post', url, options),
+      put: async (url: string, options: UseHttpSubmitOptions<TResponse, TForm> = {}): Promise<TResponse> =>
+        submit('put', url, options),
+      patch: async (url: string, options: UseHttpSubmitOptions<TResponse, TForm> = {}): Promise<TResponse> =>
+        submit('patch', url, options),
+      delete: async (url: string, options: UseHttpSubmitOptions<TResponse, TForm> = {}): Promise<TResponse> =>
+        submit('delete', url, options),
+    }),
+    [submit],
+  )
+
+  // Add useHttp-specific methods to the form object
   Object.assign(baseForm, {
     response,
     submit: submitWithArgs,
-    get: createSubmitMethod('get'),
-    post: createSubmitMethod('post'),
-    put: createSubmitMethod('put'),
-    patch: createSubmitMethod('patch'),
-    delete: createSubmitMethod('delete'),
+    ...submitMethods,
     cancel,
     dontRemember: <K extends FormDataKeys<TForm>>(...keys: K[]) => {
       excludeKeysRef.current = keys

--- a/packages/react/test-app/Pages/FormHelper/SetDataRerender.tsx
+++ b/packages/react/test-app/Pages/FormHelper/SetDataRerender.tsx
@@ -1,0 +1,31 @@
+import { InertiaFormProps, useForm } from '@inertiajs/react'
+import { memo, useRef } from 'react'
+
+const MemoizedDisplay = memo(({ form }: { form: InertiaFormProps<{ position: string }> }) => {
+  return <div id="memo-value">Memo value: {form.data.position}</div>
+})
+
+export default () => {
+  const form = useForm({ position: 'initial' })
+  const renderCount = useRef(0)
+
+  renderCount.current++
+
+  const options = ['initial', 'goalkeeper', 'defender', 'midfielder', 'forward']
+
+  return (
+    <div>
+      <h1>setData Re-render Test</h1>
+      <div id="render-count">Render count: {renderCount.current}</div>
+      <div id="current-value">Current value: {form.data.position}</div>
+
+      <MemoizedDisplay form={form} />
+
+      {options.map((option) => (
+        <button key={option} onClick={() => form.setData('position', option)}>
+          Set {option}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/FormHelper/StableReference.tsx
+++ b/packages/react/test-app/Pages/FormHelper/StableReference.tsx
@@ -7,11 +7,13 @@ export default () => {
 
   renderCount.current++
 
+  const { post } = form
+
   const submitForm = useCallback(() => {
-    form.post('/form-helper/stable-reference', {
+    post('/form-helper/stable-reference', {
       preserveState: true,
     })
-  }, [form])
+  }, [post])
 
   useEffect(() => {
     submitForm()

--- a/packages/react/test-app/Pages/UseHttp/StableReference.tsx
+++ b/packages/react/test-app/Pages/UseHttp/StableReference.tsx
@@ -14,14 +14,16 @@ export default () => {
 
   renderCount.current++
 
+  const { get } = http
+
   const fetchData = useCallback(async () => {
     try {
-      const data = await http.get('/api/data')
+      const data = await get('/api/data')
       setResult(data)
     } catch {
       // ignore
     }
-  }, [http])
+  }, [get])
 
   useEffect(() => {
     fetchData()

--- a/tests/form-helper.spec.ts
+++ b/tests/form-helper.spec.ts
@@ -1056,6 +1056,23 @@ test('it returns a stable reference that does not cause infinite re-renders in d
 test.describe('React', () => {
   test.skip(process.env.PACKAGE !== 'react', 'Only for React')
 
+  test('it re-renders the component when setData is called programmatically', async ({ page }) => {
+    await page.goto('/form-helper/set-data-rerender')
+
+    await expect(page.locator('#current-value')).toHaveText('Current value: initial')
+    await expect(page.locator('#memo-value')).toHaveText('Memo value: initial')
+
+    await page.getByRole('button', { name: 'Set forward' }).click()
+
+    await expect(page.locator('#current-value')).toHaveText('Current value: forward')
+    await expect(page.locator('#memo-value')).toHaveText('Memo value: forward')
+
+    await page.getByRole('button', { name: 'Set goalkeeper' }).click()
+
+    await expect(page.locator('#current-value')).toHaveText('Current value: goalkeeper')
+    await expect(page.locator('#memo-value')).toHaveText('Memo value: goalkeeper')
+  })
+
   test('setDefaults callback in useEffect executes once per change', async ({ page }) => {
     await page.goto('/form-helper/effect-count')
 


### PR DESCRIPTION
The stable form object introduced in #2976 prevented memoized child components from updating when `setData` was called. The form object now changes identity when state changes, while individual methods like `form.post` and `form.setData` remain stable references.

Fixes #2983.