### PR TITLE
[3.x] Add generic type inference for <Form> `optimistic` and `transform` callbacks

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -742,12 +742,12 @@ export type FormComponentOptions = Pick<
   'preserveScroll' | 'preserveState' | 'preserveUrl' | 'replace' | 'only' | 'except' | 'reset' | 'viewTransition'
 >
 
-export type FormComponentOptimisticCallback<TProps = Page<SharedPageProps>['props']> = (
-  props: TProps,
-  formData: Record<string, FormDataConvertible>,
-) => Partial<TProps> | void
+export type FormComponentOptimisticCallback<
+  TProps = Page<SharedPageProps>['props'],
+  TForm = Record<string, FormDataConvertible>,
+> = (props: TProps, formData: TForm) => Partial<TProps> | void
 
-export type FormComponentProps = Partial<
+export type FormComponentProps<TForm = Record<string, FormDataConvertible>> = Partial<
   Pick<Visit, 'headers' | 'queryStringArrayFormat' | 'errorBag' | 'showProgress' | 'invalidateCacheTags'> &
     Omit<VisitCallbacks, 'onPrefetched' | 'onPrefetching'>
 > & {
@@ -755,8 +755,8 @@ export type FormComponentProps = Partial<
   action?: string | UrlMethodPair
   component?: string
   instant?: boolean
-  transform?: (data: Record<string, FormDataConvertible>) => Record<string, FormDataConvertible>
-  optimistic?: FormComponentOptimisticCallback
+  transform?: (data: TForm) => Record<string, FormDataConvertible>
+  optimistic?: FormComponentOptimisticCallback<Page<SharedPageProps>['props'], TForm>
   options?: FormComponentOptions
   onSubmitComplete?: (props: FormComponentOnSubmitCompleteArguments) => void
   disableWhileProcessing?: boolean

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -36,7 +36,7 @@ const deferStateUpdate = (callback: () => void) => {
   typeof React.startTransition === 'function' ? React.startTransition(callback) : setTimeout(callback, 0)
 }
 
-type FormProps<TForm extends object = Record<string, any>> = FormComponentProps &
+type FormProps<TForm extends object = Record<string, any>> = FormComponentProps<TForm> &
   Omit<React.FormHTMLAttributes<HTMLFormElement>, keyof FormComponentProps | 'children'> &
   Omit<React.AllHTMLAttributes<HTMLFormElement>, keyof FormComponentProps | 'children'> & {
     children: ReactNode | ((props: FormComponentSlotProps<TForm>) => ReactNode)

--- a/packages/react/test-app/Pages/FormComponent/TypeScript/Optimistic.tsx
+++ b/packages/react/test-app/Pages/FormComponent/TypeScript/Optimistic.tsx
@@ -1,0 +1,48 @@
+// This component is used for checking the TypeScript implementation; there is no Playwright test depending on it.
+import { Form } from '@inertiajs/react'
+
+interface UserForm {
+  name: string
+  email: string
+}
+
+export default () => {
+  return (
+    <div>
+      <Form<UserForm>
+        action="/users"
+        method="post"
+        optimistic={(props, formData) => {
+          const name: string = formData.name
+          const email: string = formData.email
+
+          // @ts-expect-error - 'invalid_field' should not exist on UserForm
+          console.log(formData.invalid_field)
+
+          return { ...props, user: { name, email } }
+        }}
+        transform={(data) => {
+          const name: string = data.name
+          const email: string = data.email
+
+          return { name, email }
+        }}
+      >
+        <input name="name" />
+        <input name="email" />
+        <button type="submit">Submit</button>
+      </Form>
+
+      <Form
+        action="/users"
+        method="post"
+        optimistic={(_props, formData) => {
+          // Without a generic, formData is Record<string, FormDataConvertible>
+          console.log(formData.anything)
+        }}
+      >
+        <button type="submit">Submit</button>
+      </Form>
+    </div>
+  )
+}

--- a/packages/svelte/src/components/createForm.ts
+++ b/packages/svelte/src/components/createForm.ts
@@ -1,9 +1,11 @@
-import type { FormComponentSlotProps } from '@inertiajs/core'
+import type { FormComponentProps, FormComponentSlotProps } from '@inertiajs/core'
 import type { Component, ComponentProps, Snippet } from 'svelte'
 import Form from './Form.svelte'
 
 type TypedFormComponent<TForm extends Record<string, any>> = Component<
-  Omit<ComponentProps<typeof Form>, 'children'> & {
+  Omit<ComponentProps<typeof Form>, 'children' | 'optimistic' | 'transform'> & {
+    optimistic?: FormComponentProps<TForm>['optimistic']
+    transform?: FormComponentProps<TForm>['transform']
     children?: Snippet<[FormComponentSlotProps<TForm>]>
   }
 >

--- a/packages/svelte/test-app/Pages/FormComponent/TypeScript/Optimistic.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/TypeScript/Optimistic.svelte
@@ -1,0 +1,32 @@
+<!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
+<script lang="ts">
+  import { createForm } from '@inertiajs/svelte'
+
+  interface UserForm {
+    name: string
+    email: string
+  }
+
+  const Form = createForm<UserForm>()
+</script>
+
+<div>
+  <Form
+    action="/users"
+    method="post"
+    optimistic={(props, formData) => {
+      const name: string = formData.name
+      const email: string = formData.email
+      return { ...props, user: { name, email } }
+    }}
+    transform={(data) => {
+      const name: string = data.name
+      const email: string = data.email
+      return { name, email }
+    }}
+  >
+    <input name="name" />
+    <input name="email" />
+    <button type="submit">Submit</button>
+  </Form>
+</div>

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -402,8 +402,12 @@ export function useFormContext<TForm extends object = Record<string, any>>(): Fo
   return inject(FormContextKey) as FormComponentRef<TForm> | undefined
 }
 
-type TypedFormComponent<TForm extends Record<string, any>> = typeof Form & {
-  new (): {
+type TypedFormComponent<TForm extends Record<string, any>> = Omit<typeof Form, 'new'> & {
+  new (...args: ConstructorParameters<typeof Form>): Omit<InstanceType<typeof Form>, '$props' | '$slots'> & {
+    $props: Omit<InstanceType<typeof Form>['$props'], 'optimistic' | 'transform'> & {
+      optimistic?: FormComponentProps<TForm>['optimistic']
+      transform?: FormComponentProps<TForm>['transform']
+    }
     $slots: {
       default: (props: FormComponentSlotProps<TForm>) => any
     }

--- a/packages/vue3/test-app/Pages/FormComponent/TypeScript/Optimistic.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/TypeScript/Optimistic.vue
@@ -1,0 +1,38 @@
+<!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
+<script setup lang="ts">
+import { createForm } from '@inertiajs/vue3'
+
+interface UserForm {
+  name: string
+  email: string
+}
+
+const Form = createForm<UserForm>()
+</script>
+
+<template>
+  <div>
+    <Form
+      action="/users"
+      method="post"
+      :optimistic="
+        (props, formData) => {
+          const name: string = formData.name
+          const email: string = formData.email
+          return { ...props, user: { name, email } }
+        }
+      "
+      :transform="
+        (data) => {
+          const name: string = data.name
+          const email: string = data.email
+          return { name, email }
+        }
+      "
+    >
+      <input name="name" />
+      <input name="email" />
+      <button type="submit">Submit</button>
+    </Form>
+  </div>
+</template>


### PR DESCRIPTION
This PR adds generic type inference for the `optimistic` and `transform` callbacks on the Form component. The generic is now threaded through each adapter's `createForm<TForm>()` helper and React's `<Form<TForm>>`.

Fixes #2988.