### PR TITLE
[3.x] Rename `networkError` event detail key to `error`

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -15,8 +15,8 @@ export const fireErrorEvent: GlobalEventTrigger<'error'> = (errors) => {
   return fireEvent('error', { detail: { errors } })
 }
 
-export const fireNetworkErrorEvent: GlobalEventTrigger<'networkError'> = (exception) => {
-  return fireEvent('networkError', { cancelable: true, detail: { exception } })
+export const fireNetworkErrorEvent: GlobalEventTrigger<'networkError'> = (error) => {
+  return fireEvent('networkError', { cancelable: true, detail: { error } })
 }
 
 export const fireFinishEvent: GlobalEventTrigger<'finish'> = (visit) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -406,7 +406,7 @@ export type GlobalEventsMap<T extends RequestPayload = RequestPayload> = {
   networkError: {
     parameters: [Error]
     details: {
-      exception: Error
+      error: Error
     }
     result: boolean | void
   }

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -81,8 +81,8 @@ const assertResponseObject = async (response) => {
 }
 
 const assertExceptionObject = async (detail) => {
-  await expect(detail.exception).toBeDefined()
-  await expect(detail.exception.code).toBe('ERR_NETWORK')
+  await expect(detail.error).toBeDefined()
+  await expect(detail.error.code).toBe('ERR_NETWORK')
 }
 
 const assertGlobalFinishEvent = async (event) => {


### PR DESCRIPTION
This PR renames the `networkError` event's detail key from `exception` to `error`. 

Every other event in the system uses a semantically matching detail key (`error` has `errors`, `flash` has `flash`), and `networkError` was the only one with a mismatch.