### PR TITLE
[3.x] Fix `PagesOption` type and make `setup`/`withApp` mutually exclusive

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -537,7 +537,8 @@ type PagesOption =
   | {
       path: string
       extension?: string | string[]
-      transform?: (name: string) => string
+      lazy?: boolean
+      transform?: (name: string, page: Page) => string
     }
 
 export type ProgressOptions = {

--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -30,6 +30,8 @@ type ComponentResolver = (
   page?: Page<SharedPageProps>,
 ) => ReactComponent | Promise<ReactComponent> | { default: ReactComponent }
 
+type ReactWithApp = (app: ReactElement, options: { ssr: boolean }) => ReactElement
+
 type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForCSR<
   SharedProps,
   ComponentResolver,
@@ -38,7 +40,7 @@ type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOp
   ReactInertiaAppConfig
 > & {
   strictMode?: undefined
-  withApp?: (app: ReactElement, options: { ssr: boolean }) => ReactElement
+  withApp?: never
 }
 
 type InertiaAppOptionsForSSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForSSR<
@@ -50,20 +52,25 @@ type InertiaAppOptionsForSSR<SharedProps extends PageProps> = CreateInertiaAppOp
 > & {
   render: typeof renderToString
   strictMode?: undefined
-  withApp?: (app: ReactElement, options: { ssr: boolean }) => ReactElement
+  withApp?: never
 }
 
-type InertiaAppOptionsAuto<SharedProps extends PageProps> = CreateInertiaAppOptions<
-  ComponentResolver,
-  SetupOptions<HTMLElement | null, SharedProps>,
-  ReactElement | void,
-  ReactInertiaAppConfig
+type InertiaAppOptionsAuto<SharedProps extends PageProps> = Omit<
+  CreateInertiaAppOptions<
+    ComponentResolver,
+    SetupOptions<HTMLElement | null, SharedProps>,
+    ReactElement | void,
+    ReactInertiaAppConfig
+  >,
+  'setup'
 > & {
   page?: Page<SharedProps>
   render?: undefined
   strictMode?: boolean
-  withApp?: (app: ReactElement, options: { ssr: boolean }) => ReactElement
-}
+} & (
+    | { setup?: undefined; withApp?: ReactWithApp }
+    | { setup: (options: SetupOptions<HTMLElement | null, SharedProps>) => ReactElement | void; withApp?: never }
+  )
 
 type RenderToString = (element: ReactElement) => string
 

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -24,6 +24,8 @@ type SetupOptions<SharedProps extends PageProps> = {
   props: InertiaAppProps<SharedProps>
 }
 
+type SvelteWithApp = (context: Map<any, any>, options: { ssr: boolean }) => void
+
 type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForCSR<
   SharedProps,
   ComponentResolver,
@@ -31,18 +33,23 @@ type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOp
   SvelteRenderResult | void,
   SvelteInertiaAppConfig
 > & {
-  withApp?: (context: Map<any, any>, options: { ssr: boolean }) => void
+  withApp?: never
 }
 
-type InertiaAppOptionsAuto<SharedProps extends PageProps> = CreateInertiaAppOptions<
-  ComponentResolver,
-  SetupOptions<SharedProps>,
-  SvelteRenderResult | void,
-  SvelteInertiaAppConfig
+type InertiaAppOptionsAuto<SharedProps extends PageProps> = Omit<
+  CreateInertiaAppOptions<
+    ComponentResolver,
+    SetupOptions<SharedProps>,
+    SvelteRenderResult | void,
+    SvelteInertiaAppConfig
+  >,
+  'setup'
 > & {
   page?: Page<SharedProps>
-  withApp?: (context: Map<any, any>, options: { ssr: boolean }) => void
-}
+} & (
+    | { setup?: undefined; withApp?: SvelteWithApp }
+    | { setup: (options: SetupOptions<SharedProps>) => SvelteRenderResult | void; withApp?: never }
+  )
 
 type SvelteServerRender = (
   component: typeof App,

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -29,6 +29,8 @@ type SetupOptions<ElementType, SharedProps extends PageProps> = {
   plugin: Plugin
 }
 
+type VueWithApp = (app: VueApp, options: { ssr: boolean }) => void
+
 type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForCSR<
   SharedProps,
   ComponentResolver,
@@ -36,7 +38,7 @@ type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOp
   void,
   VueInertiaAppConfig
 > & {
-  withApp?: (app: VueApp, options: { ssr: boolean }) => void
+  withApp?: never
 }
 
 type InertiaAppOptionsForSSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForSSR<
@@ -47,19 +49,24 @@ type InertiaAppOptionsForSSR<SharedProps extends PageProps> = CreateInertiaAppOp
   VueInertiaAppConfig
 > & {
   render: (app: VueApp) => Promise<string>
-  withApp?: (app: VueApp, options: { ssr: boolean }) => void
+  withApp?: never
 }
 
-type InertiaAppOptionsAuto<SharedProps extends PageProps> = CreateInertiaAppOptions<
-  ComponentResolver,
-  SetupOptions<HTMLElement | null, SharedProps>,
-  VueApp | void,
-  VueInertiaAppConfig
+type InertiaAppOptionsAuto<SharedProps extends PageProps> = Omit<
+  CreateInertiaAppOptions<
+    ComponentResolver,
+    SetupOptions<HTMLElement | null, SharedProps>,
+    VueApp | void,
+    VueInertiaAppConfig
+  >,
+  'setup'
 > & {
   page?: Page<SharedProps>
   render?: undefined
-  withApp?: (app: VueApp, options: { ssr: boolean }) => void
-}
+} & (
+    | { setup?: undefined; withApp?: VueWithApp }
+    | { setup: (options: SetupOptions<HTMLElement | null, SharedProps>) => VueApp | void; withApp?: never }
+  )
 
 type RenderToString = (app: VueApp) => Promise<string>
 


### PR DESCRIPTION
This PR fixes the `PagesOption` type which was out of sync with its implementation. Additionally, `setup` and `withApp` on `createInertiaApp` are now mutually exclusive at the type level.