### PR TITLE
[3.x] Fix Svelte Form ignoring global `withAllErrors` config

### DIFF
--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -20,6 +20,7 @@
   import { onMount } from 'svelte'
   import { setFormContext } from './formContext'
   import useForm from '../useForm.svelte'
+  import { config } from '..'
 
   const noop = () => undefined
 
@@ -82,7 +83,7 @@
     validateFiles = false,
     validationTimeout = 1500,
     optimistic,
-    withAllErrors = false,
+    withAllErrors = null,
     component = undefined,
     instant = false,
     children,
@@ -292,7 +293,7 @@
       form.withoutFileValidation()
     }
 
-    if (withAllErrors) {
+    if (withAllErrors ?? config.get('form.withAllErrors')) {
       form.withAllErrors()
     }
   })


### PR DESCRIPTION
This PR fixes the Svelte `<Form>` component to respect the global `config.form.withAllErrors` setting. The prop now defaults to `null` and falls back to `config.get('form.withAllErrors')`, matching the pattern used by the React and Vue adapters.

Should probably be backported to v2 as well.