### PR TITLE
[3.x] Rename `handleErrors` SSR option to `formatErrors`

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -57,7 +57,7 @@ type RouteHandler = (request: IncomingMessage, response: ServerResponse) => Prom
 type ServerOptions = {
   port?: number
   cluster?: boolean
-  handleErrors?: boolean
+  formatErrors?: boolean
 }
 type Port = number
 
@@ -71,7 +71,7 @@ const readableToString: (readable: IncomingMessage) => Promise<string> = (readab
 
 export default (render: AppCallback, options?: Port | ServerOptions): AppCallback => {
   const opts = typeof options === 'number' ? { port: options } : options
-  const { port = 13714, cluster: useCluster = false, handleErrors = true } = opts ?? {}
+  const { port = 13714, cluster: useCluster = false, formatErrors = true } = opts ?? {}
 
   const log = (message: string) => {
     console.log(
@@ -107,7 +107,7 @@ export default (render: AppCallback, options?: Port | ServerOptions): AppCallbac
     // Suppress framework warnings during render (they clutter the output)
     const originalWarn = console.warn
 
-    if (handleErrors) {
+    if (formatErrors) {
       console.warn = () => {}
     }
 
@@ -119,7 +119,7 @@ export default (render: AppCallback, options?: Port | ServerOptions): AppCallbac
     } catch (e) {
       const error = e as Error
 
-      if (!handleErrors) {
+      if (!formatErrors) {
         throw error
       }
 

--- a/packages/core/src/ssrErrors.ts
+++ b/packages/core/src/ssrErrors.ts
@@ -267,10 +267,10 @@ function makeRelative(path: string, root?: string): string {
 export function formatConsoleError(
   classified: ClassifiedSSRError,
   root?: string,
-  handleErrors: boolean = true,
+  formatErrors: boolean = true,
   suppressedWarnings: string[] = [],
 ): string {
-  if (!handleErrors) {
+  if (!formatErrors) {
     const component = classified.component ? `[${classified.component}]` : ''
     return `SSR Error ${component}: ${classified.error}`
   }

--- a/packages/core/tests/ssrErrors.test.ts
+++ b/packages/core/tests/ssrErrors.test.ts
@@ -234,7 +234,7 @@ describe('SSR Errors', () => {
       expect(sourceLine).not.toContain('/Users/dev/project')
     })
 
-    it('returns one-liner when handleErrors is false', () => {
+    it('returns one-liner when formatErrors is false', () => {
       const classified = classifySSRError(new Error('window is not defined'), 'Dashboard')
       const output = formatConsoleError(classified, undefined, false)
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -129,7 +129,7 @@ export default function inertia(options: InertiaPluginOptions = {}): Plugin {
         result =
           wrapWithServerBootstrap(
             result,
-            { port: ssr.port, cluster: ssr.cluster, handleErrors: ssr.handleErrors },
+            { port: ssr.port, cluster: ssr.cluster, formatErrors: ssr.formatErrors },
             frameworks,
           ) ?? result
       }
@@ -147,7 +147,7 @@ export default function inertia(options: InertiaPluginOptions = {}): Plugin {
           return next()
         }
 
-        await handleSSRRequest(server, entry!, req, res, ssr.handleErrors ?? true)
+        await handleSSRRequest(server, entry!, req, res, ssr.formatErrors ?? true)
       })
 
       server.config.logger.info(`Inertia SSR dev endpoint: ${SSR_ENDPOINT}`)

--- a/packages/vite/src/ssr.ts
+++ b/packages/vite/src/ssr.ts
@@ -46,7 +46,7 @@ export interface InertiaSSROptions {
    * When enabled, SSR errors are formatted with hints instead of thrown raw.
    * Defaults to true.
    */
-  handleErrors?: boolean
+  formatErrors?: boolean
 
   /**
    * Enable sourcemaps for SSR builds so error stacks map to original files.
@@ -95,7 +95,7 @@ export async function handleSSRRequest(
   entry: string,
   req: IncomingMessage,
   res: ServerResponse,
-  handleErrors: boolean = true,
+  formatErrors: boolean = true,
 ): Promise<void> {
   let component: string | undefined
   let url: string | undefined
@@ -109,7 +109,7 @@ export async function handleSSRRequest(
     const message = args[0]?.toString() ?? ''
 
     if (message.includes('[Vue warn]') || message.includes('at <')) {
-      if (handleErrors) {
+      if (formatErrors) {
         suppressedWarnings.push(args.map(String).join(' '))
       }
 
@@ -140,7 +140,7 @@ export async function handleSSRRequest(
     res.setHeader('Content-Type', 'application/json')
     res.end(JSON.stringify(result))
   } catch (error) {
-    handleSSRError(server, res, error as Error, component, url, handleErrors, suppressedWarnings)
+    handleSSRError(server, res, error as Error, component, url, formatErrors, suppressedWarnings)
   } finally {
     console.warn = originalWarn
   }
@@ -201,18 +201,18 @@ function handleSSRError(
   error: Error,
   component?: string,
   url?: string,
-  handleErrors: boolean = true,
+  formatErrors: boolean = true,
   suppressedWarnings: string[] = [],
 ): void {
   server.ssrFixStacktrace(error)
 
-  if (!handleErrors) {
+  if (!formatErrors) {
     throw error
   }
 
   const classified = classifySSRError(error, component, url)
 
-  server.config.logger.error(formatConsoleError(classified, server.config.root, handleErrors, suppressedWarnings))
+  server.config.logger.error(formatConsoleError(classified, server.config.root, formatErrors, suppressedWarnings))
 
   res.setHeader('Content-Type', 'application/json')
   res.statusCode = 500

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -111,5 +111,5 @@ export interface SSROptions {
    * When disabled, errors are thrown raw for debugging.
    * Defaults to true.
    */
-  handleErrors?: boolean
+  formatErrors?: boolean
 }

--- a/packages/vite/tests/ssr.test.ts
+++ b/packages/vite/tests/ssr.test.ts
@@ -334,10 +334,10 @@ describe('SSR', () => {
       expect(loggedMessage).toContain('Hint')
     })
 
-    it('includes stack trace when handleErrors is enabled', async () => {
+    it('includes stack trace when formatErrors is enabled', async () => {
       mockExistsSync.mockImplementation((path: string) => path.endsWith('resources/js/ssr.ts'))
 
-      const plugin = inertia({ ssr: { handleErrors: true } })
+      const plugin = inertia({ ssr: { formatErrors: true } })
       const logger = createMockLogger()
       const server = createMockServer(logger)
 
@@ -360,10 +360,10 @@ describe('SSR', () => {
       expect(loggedMessage).toContain('Dashboard.vue:10')
     })
 
-    it('throws raw error when handleErrors is disabled', async () => {
+    it('throws raw error when formatErrors is disabled', async () => {
       mockExistsSync.mockImplementation((path: string) => path.endsWith('resources/js/ssr.ts'))
 
-      const plugin = inertia({ ssr: { handleErrors: false } })
+      const plugin = inertia({ ssr: { formatErrors: false } })
       const logger = createMockLogger()
       const server = createMockServer(logger)
 


### PR DESCRIPTION
This PR renames the `handleErrors` option to `formatErrors` on both the Vite plugin's SSR configuration and the production SSR server.