### PR TITLE
[3.x] Guard against `void` return from `useHttp` optimistic callback

### DIFF
--- a/packages/svelte/src/useHttp.svelte.ts
+++ b/packages/svelte/src/useHttp.svelte.ts
@@ -173,9 +173,11 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
       snapshot = cloneDeep(form.data())
       const optimisticData = options.optimistic(cloneDeep(snapshot))
 
-      Object.keys(optimisticData).forEach((key) => {
-        ;(baseForm as any)[key] = (optimisticData as any)[key]
-      })
+      if (optimisticData) {
+        Object.keys(optimisticData).forEach((key) => {
+          ;(baseForm as any)[key] = (optimisticData as any)[key]
+        })
+      }
     }
 
     setFormState('processing', true)

--- a/packages/vue3/src/useHttp.ts
+++ b/packages/vue3/src/useHttp.ts
@@ -173,9 +173,11 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
       snapshot = cloneDeep(form.data())
       const optimisticData = options.optimistic(cloneDeep(snapshot))
 
-      Object.keys(optimisticData).forEach((key) => {
-        ;(form as any)[key] = (optimisticData as any)[key]
-      })
+      if (optimisticData) {
+        Object.keys(optimisticData).forEach((key) => {
+          ;(form as any)[key] = (optimisticData as any)[key]
+        })
+      }
     }
 
     form.processing = true


### PR DESCRIPTION
This PR fixes a TypeScript build error in the Vue and Svelte `useHttp` implementations where the `optimistic` callback's return value was passed directly to `Object.keys()` without guarding for `void`.