### PR TITLE
[3.x] Resolve pages at `@`

### DIFF
--- a/packages/vite/src/pagesTransform.ts
+++ b/packages/vite/src/pagesTransform.ts
@@ -215,7 +215,7 @@ function buildResolver(
 }
 
 function buildDefaultResolver(extensions: string[], extractDefault: boolean, eager: boolean = false): string {
-  return buildResolver(['./pages', './Pages'], extensions, extractDefault, eager)
+  return buildResolver(['./pages', './Pages', '@/pages', '@/Pages'], extensions, extractDefault, eager)
 }
 
 function buildGlob(directory: string, extensions: string[]): string {

--- a/packages/vite/tests/pagesTransform.test.ts
+++ b/packages/vite/tests/pagesTransform.test.ts
@@ -152,8 +152,8 @@ export default createInertiaApp({ pages: { lazy: true } })`
       expect(transform(code)).toMatchInlineSnapshot(`
         "import { createInertiaApp } from '@inertiajs/vue3'
         export default createInertiaApp({ resolve: async (name, page) => {
-            const pages = import.meta.glob(['./pages/**/*.vue', './Pages/**/*.vue'], { eager: false })
-            const module = await (pages[\`./pages/\${name}.vue\`] || pages[\`./Pages/\${name}.vue\`])?.()
+            const pages = import.meta.glob(['./pages/**/*.vue', './Pages/**/*.vue', '@/pages/**/*.vue', '@/Pages/**/*.vue'], { eager: false })
+            const module = await (pages[\`./pages/\${name}.vue\`] || pages[\`./Pages/\${name}.vue\`] || pages[\`@/pages/\${name}.vue\`] || pages[\`@/Pages/\${name}.vue\`])?.()
             if (!module) throw new Error(\`Page not found: \${name}\`)
             return module.default ?? module
           } })"
@@ -169,8 +169,8 @@ export default createInertiaApp()`
       expect(transform(code)).toMatchInlineSnapshot(`
         "import { createInertiaApp } from '@inertiajs/vue3'
         export default createInertiaApp({ resolve: async (name, page) => {
-            const pages = import.meta.glob(['./pages/**/*.vue', './Pages/**/*.vue'], { eager: false })
-            const module = await (pages[\`./pages/\${name}.vue\`] || pages[\`./Pages/\${name}.vue\`])?.()
+            const pages = import.meta.glob(['./pages/**/*.vue', './Pages/**/*.vue', '@/pages/**/*.vue', '@/Pages/**/*.vue'], { eager: false })
+            const module = await (pages[\`./pages/\${name}.vue\`] || pages[\`./Pages/\${name}.vue\`] || pages[\`@/pages/\${name}.vue\`] || pages[\`@/Pages/\${name}.vue\`])?.()
             if (!module) throw new Error(\`Page not found: \${name}\`)
             return module.default ?? module
           } })"
@@ -184,8 +184,8 @@ export default createInertiaApp({})`
       expect(transform(code)).toMatchInlineSnapshot(`
         "import { createInertiaApp } from '@inertiajs/vue3'
         export default createInertiaApp({ resolve: async (name, page) => {
-            const pages = import.meta.glob(['./pages/**/*.vue', './Pages/**/*.vue'], { eager: false })
-            const module = await (pages[\`./pages/\${name}.vue\`] || pages[\`./Pages/\${name}.vue\`])?.()
+            const pages = import.meta.glob(['./pages/**/*.vue', './Pages/**/*.vue', '@/pages/**/*.vue', '@/Pages/**/*.vue'], { eager: false })
+            const module = await (pages[\`./pages/\${name}.vue\`] || pages[\`./Pages/\${name}.vue\`] || pages[\`@/pages/\${name}.vue\`] || pages[\`@/Pages/\${name}.vue\`])?.()
             if (!module) throw new Error(\`Page not found: \${name}\`)
             return module.default ?? module
           } })"
@@ -199,8 +199,8 @@ export default createInertiaApp({ title: t => t })`
       expect(transform(code)).toMatchInlineSnapshot(`
         "import { createInertiaApp } from '@inertiajs/vue3'
         export default createInertiaApp({ resolve: async (name, page) => {
-            const pages = import.meta.glob(['./pages/**/*.vue', './Pages/**/*.vue'], { eager: false })
-            const module = await (pages[\`./pages/\${name}.vue\`] || pages[\`./Pages/\${name}.vue\`])?.()
+            const pages = import.meta.glob(['./pages/**/*.vue', './Pages/**/*.vue', '@/pages/**/*.vue', '@/Pages/**/*.vue'], { eager: false })
+            const module = await (pages[\`./pages/\${name}.vue\`] || pages[\`./Pages/\${name}.vue\`] || pages[\`@/pages/\${name}.vue\`] || pages[\`@/Pages/\${name}.vue\`])?.()
             if (!module) throw new Error(\`Page not found: \${name}\`)
             return module.default ?? module
           }, title: t => t })"


### PR DESCRIPTION
This PR makes the default resolver to also search `@/pages` and `@/Pages` in addition to `./pages` and `./Pages`.

This makes zero-config page resolution work for setups where pages live under the `@` alias, and not just next to inertia entry point.