### PR TITLE
[3.x] Resolve pages at @

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -82,6 +82,7 @@ export default function inertia(options: InertiaPluginOptions = {}): Plugin {
   const frameworks = { ...defaultFrameworks, ...toFrameworkRecord(options.frameworks) }
 
   let entry: string | null = null
+  let hasAtAlias = false
 
   return {
     name: '@inertiajs/vite',
@@ -107,6 +108,8 @@ export default function inertia(options: InertiaPluginOptions = {}): Plugin {
     },
 
     configResolved(config) {
+      hasAtAlias = config.resolve.alias.some((a) => a.find === '@')
+
       if (ssrDisabled) {
         return
       }
@@ -134,7 +137,7 @@ export default function inertia(options: InertiaPluginOptions = {}): Plugin {
           ) ?? result
       }
 
-      return transformPageResolution(result, frameworks) ?? (result !== code ? result : null)
+      return transformPageResolution(result, frameworks, hasAtAlias) ?? (result !== code ? result : null)
     },
 
     configureServer(server) {

--- a/packages/vite/src/pagesTransform.ts
+++ b/packages/vite/src/pagesTransform.ts
@@ -40,7 +40,11 @@ import { type NodeWithPos, ParsedCode, extractBoolean, extractString, extractStr
 import type { FrameworkConfig } from './types'
 
 /** Returns the transformed code, or null if no transformation was needed. */
-export function transformPageResolution(code: string, frameworks: Record<string, FrameworkConfig>): string | null {
+export function transformPageResolution(
+  code: string,
+  frameworks: Record<string, FrameworkConfig>,
+  hasAtAlias: boolean = false,
+): string | null {
   if (!code.includes('InertiaApp')) {
     return null
   }
@@ -61,11 +65,11 @@ export function transformPageResolution(code: string, frameworks: Record<string,
   const extractDefault = framework.config.extractDefault ?? true
 
   if (parsed.pagesProperty) {
-    return replacePages(code, parsed.pagesProperty, extensions, extractDefault)
+    return replacePages(code, parsed.pagesProperty, extensions, extractDefault, hasAtAlias)
   }
 
   if (parsed.callWithoutResolver) {
-    return injectResolver(code, parsed.callWithoutResolver, extensions, extractDefault)
+    return injectResolver(code, parsed.callWithoutResolver, extensions, extractDefault, hasAtAlias)
   }
 
   return null
@@ -82,6 +86,7 @@ function replacePages(
   property: NodeWithPos<Property>,
   defaultExtensions: string[],
   extractDefault: boolean,
+  hasAtAlias: boolean = false,
 ): string {
   const config = extractPagesConfig(property.value, code)
 
@@ -99,7 +104,7 @@ function replacePages(
 
   const resolver = config.directory
     ? buildResolver(config.directory.replace(/\/$/, ''), extensions, extractDefault, eager, config.transform)
-    : buildDefaultResolver(extensions, extractDefault, eager)
+    : buildDefaultResolver(extensions, extractDefault, eager, hasAtAlias)
 
   return code.slice(0, property.start) + resolver + code.slice(property.end)
 }
@@ -117,8 +122,9 @@ function injectResolver(
   call: { callEnd: number; options?: { start: number; end: number; isEmpty: boolean } },
   extensions: string[],
   extractDefault: boolean,
+  hasAtAlias: boolean = false,
 ): string {
-  const resolver = buildDefaultResolver(extensions, extractDefault)
+  const resolver = buildDefaultResolver(extensions, extractDefault, false, hasAtAlias)
 
   if (!call.options) {
     return code.slice(0, call.callEnd - 1) + `{ ${resolver} })` + code.slice(call.callEnd)
@@ -214,8 +220,15 @@ function buildResolver(
   }`
 }
 
-function buildDefaultResolver(extensions: string[], extractDefault: boolean, eager: boolean = false): string {
-  return buildResolver(['./pages', './Pages'], extensions, extractDefault, eager)
+function buildDefaultResolver(
+  extensions: string[],
+  extractDefault: boolean,
+  eager: boolean = false,
+  hasAtAlias: boolean = false,
+): string {
+  const directories = ['./pages', './Pages', ...(hasAtAlias ? ['@/pages', '@/Pages'] : [])]
+
+  return buildResolver(directories, extensions, extractDefault, eager)
 }
 
 function buildGlob(directory: string, extensions: string[]): string {

--- a/packages/vite/tests/pagesTransform.test.ts
+++ b/packages/vite/tests/pagesTransform.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { defaultFrameworks } from '../src/frameworks/index'
 import { transformPageResolution } from '../src/pagesTransform'
 
-const transform = (code: string) => transformPageResolution(code, defaultFrameworks)
+const transform = (code: string, hasAtAlias: boolean = false) =>
+  transformPageResolution(code, defaultFrameworks, hasAtAlias)
 
 describe('Pages Transform', () => {
   describe('returns null when no transform needed', () => {
@@ -307,6 +308,44 @@ export default createInertiaApp({
 
         // Footer comment"
       `)
+    })
+  })
+
+  describe('@ alias support', () => {
+    it('includes @/pages and @/Pages when hasAtAlias is true', () => {
+      const code = `import { createInertiaApp } from '@inertiajs/vue3'
+export default createInertiaApp()`
+
+      const result = transform(code, true)
+      expect(result).toContain('@/pages/')
+      expect(result).toContain('@/Pages/')
+    })
+
+    it('does not include @/pages when hasAtAlias is false', () => {
+      const code = `import { createInertiaApp } from '@inertiajs/vue3'
+export default createInertiaApp()`
+
+      const result = transform(code)
+      expect(result).not.toContain('@/pages/')
+      expect(result).not.toContain('@/Pages/')
+    })
+
+    it('includes @/pages for pages object without path', () => {
+      const code = `import { createInertiaApp } from '@inertiajs/vue3'
+export default createInertiaApp({ pages: { lazy: true } })`
+
+      const result = transform(code, true)
+      expect(result).toContain('@/pages/')
+      expect(result).toContain('@/Pages/')
+    })
+
+    it('does not include @/pages when explicit path is set', () => {
+      const code = `import { createInertiaApp } from '@inertiajs/vue3'
+export default createInertiaApp({ pages: './Custom' })`
+
+      const result = transform(code, true)
+      expect(result).not.toContain('@/pages/')
+      expect(result).toContain('./Custom/')
     })
   })
 })

--- a/packages/vite/tests/ssr.test.ts
+++ b/packages/vite/tests/ssr.test.ts
@@ -857,7 +857,15 @@ function createMockConfig(
   ssr: boolean,
   { base = '/' }: { base?: string } = {},
 ): ResolvedConfig {
-  return { root: '/project', logger, plugins: [], build: { ssr }, command: 'build', base } as unknown as ResolvedConfig
+  return {
+    root: '/project',
+    logger,
+    plugins: [],
+    build: { ssr },
+    command: 'build',
+    base,
+    resolve: { alias: [] },
+  } as unknown as ResolvedConfig
 }
 
 function createMockServer(


### PR DESCRIPTION
This PR makes the default resolver to also search `@/pages` and `@/Pages` in addition to `./pages` and `./Pages`.

This makes zero-config page resolution work for setups where pages live under the `@` alias, and not just next to inertia entry point.