### PR TITLE
[2.x] Fix Svelte Form ignoring global `withAllErrors` config

### DIFF
--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -256,6 +256,10 @@
     } else {
       form.withoutFileValidation()
     }
+
+    if (withAllErrors ?? config.get('form.withAllErrors')) {
+      form.withAllErrors()
+    }
   }
 
   $: slotErrors = $form.errors as Errors

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -80,7 +80,6 @@ app.get('/ssr/infinite-scroll', (req, res) => {
   })
 })
 
-
 // Intercepts all CSS and JS assets (including files loaded via code splitting)
 app.get(/.*\.(?:js|css)$/, (req, res) => {
   const filePath = path.resolve(__dirname, '../../packages/', inertia.package, 'test-app/dist', req.path.substring(1))


### PR DESCRIPTION
Backport of #2998.