### PR TITLE
[3.x] Support anonymous arrow functions as React layout components

### DIFF
--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -26,20 +26,7 @@ import PageContext from './PageContext'
 import { LayoutFunction, ReactComponent, ReactPageHandlerArgs } from './types'
 
 function isComponent(value: unknown): value is ReactComponent {
-  if (!value) {
-    return false
-  }
-
-  if (typeof value === 'object' && '$$typeof' in value) {
-    return true
-  }
-
-  if (typeof value === 'function') {
-    const fn = value as Function & { displayName?: string; prototype?: { isReactComponent?: boolean } }
-    return fn.prototype?.isReactComponent === true || fn.name !== '' || fn.displayName !== undefined
-  }
-
-  return false
+  return typeof value === 'function' || (typeof value === 'object' && value !== null && '$$typeof' in value)
 }
 
 function isRenderFunction(value: unknown): boolean {
@@ -49,6 +36,14 @@ function isRenderFunction(value: unknown): boolean {
 
   const fn = value as Function
   return fn.length === 1 && typeof fn.prototype === 'undefined'
+}
+
+function isLayoutResolver(value: unknown): boolean {
+  return (
+    typeof value === 'function' &&
+    (value as Function).length <= 1 &&
+    typeof (value as Function).prototype === 'undefined'
+  )
 }
 
 let currentIsInitialPage = true
@@ -166,11 +161,7 @@ export default function App<SharedProps extends PageProps = PageProps>({
       let callbackProps: Record<string, unknown> | null = null
       const layoutValue = Component.layout
 
-      if (
-        typeof layoutValue === 'function' &&
-        (layoutValue as Function).length <= 1 &&
-        typeof (layoutValue as Function).prototype === 'undefined'
-      ) {
+      if (isLayoutResolver(layoutValue)) {
         const result = (layoutValue as Function)(props)
 
         if (isValidElement(result)) {

--- a/packages/react/test-app/app.tsx
+++ b/packages/react/test-app/app.tsx
@@ -59,6 +59,16 @@ createInertiaApp({
   ...(params.has('withDefaultLayout') && {
     layout: () => DefaultLayout,
   }),
+  ...(params.has('withAnonymousDefaultLayout') && {
+    layout:
+      () =>
+      ({ children }: { children: React.ReactNode }) => (
+        <div id="default-layout">
+          <span>Default Layout</span>
+          {children}
+        </div>
+      ),
+  }),
   ...(params.has('withDefaultAppLayout') && {
     layout: () => AppLayout,
   }),

--- a/tests/default-layout.spec.ts
+++ b/tests/default-layout.spec.ts
@@ -36,6 +36,14 @@ test('it applies the default layout after navigating to a page without its own l
   await expect(page.locator('#page-layout')).not.toBeVisible()
 })
 
+test('it supports anonymous arrow functions as layout components', async ({ page }) => {
+  await page.goto('/default-layout?withAnonymousDefaultLayout')
+
+  await expect(page.locator('#default-layout')).toBeVisible()
+  await expect(page.getByText('Default Layout')).toBeVisible()
+  await expect(page.locator('#text')).toHaveText('DefaultLayout/Index')
+})
+
 test('it supports a callback that conditionally returns a layout', async ({ page }) => {
   await page.goto('/default-layout?withDefaultLayoutCallback')
 

--- a/tests/default-layout.spec.ts
+++ b/tests/default-layout.spec.ts
@@ -37,6 +37,8 @@ test('it applies the default layout after navigating to a page without its own l
 })
 
 test('it supports anonymous arrow functions as layout components', async ({ page }) => {
+  test.skip(process.env.PACKAGE !== 'react', 'React-only test')
+
   await page.goto('/default-layout?withAnonymousDefaultLayout')
 
   await expect(page.locator('#default-layout')).toBeVisible()


### PR DESCRIPTION
The `layout` option in `createInertiaApp()` now supports anonymous arrow functions as layout components in the React adapter.

```jsx
createInertiaApp({
    layout: () => ({ children }) => (
        <>{children}<Sidebar /></>
    ),
})
```