### PR TITLE
fix: prevent explicit undefined values from overwriting visit defaults (#3018)

### DIFF
--- a/packages/core/src/objectUtils.ts
+++ b/packages/core/src/objectUtils.ts
@@ -1,3 +1,15 @@
+export const stripTopLevelUndefined = <T extends Record<string, unknown>>(obj: T): T => {
+  const result = {} as T
+
+  for (const key of Object.keys(obj) as (keyof T)[]) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key]
+    }
+  }
+
+  return result
+}
+
 export const objectsAreEqual = <T extends Record<string, any>>(
   obj1: T,
   obj2: T,

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -631,6 +631,19 @@ export class Router {
       ? defaultVisitOptionsCallback(href.toString(), cloneDeep(options)) || {}
       : {}
 
+    // Strip explicit undefined values so they don't overwrite defaults during spread.
+    // TypeScript's Partial<> allows { only: undefined } which would overwrite the
+    // default [] and later crash on .length access (see #3018).
+    const stripUndefined = <T extends Record<string, unknown>>(obj: T): Partial<T> => {
+      const result: Partial<T> = {}
+      for (const key of Object.keys(obj) as (keyof T)[]) {
+        if (obj[key] !== undefined) {
+          result[key] = obj[key]
+        }
+      }
+      return result
+    }
+
     const mergedOptions: Visit = {
       method: 'get',
       data: {},
@@ -654,8 +667,8 @@ export class Router {
       viewTransition: false,
       component: null,
       pageProps: null,
-      ...options,
-      ...configuredOptions,
+      ...stripUndefined(options),
+      ...stripUndefined(configuredOptions),
     }
 
     const [url, _data] = transformUrlAndData(

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -6,6 +6,7 @@ import { eventHandler } from './eventHandler'
 import { fireBeforeEvent, fireFlashEvent } from './events'
 import { history } from './history'
 import { InitialVisit } from './initialVisit'
+import { stripTopLevelUndefined } from './objectUtils'
 import { page as currentPage } from './page'
 import { polls } from './polls'
 import { prefetchedRequests } from './prefetched'
@@ -631,19 +632,6 @@ export class Router {
       ? defaultVisitOptionsCallback(href.toString(), cloneDeep(options)) || {}
       : {}
 
-    // Strip explicit undefined values so they don't overwrite defaults during spread.
-    // TypeScript's Partial<> allows { only: undefined } which would overwrite the
-    // default [] and later crash on .length access (see #3018).
-    const stripUndefined = <T extends Record<string, unknown>>(obj: T): Partial<T> => {
-      const result: Partial<T> = {}
-      for (const key of Object.keys(obj) as (keyof T)[]) {
-        if (obj[key] !== undefined) {
-          result[key] = obj[key]
-        }
-      }
-      return result
-    }
-
     const mergedOptions: Visit = {
       method: 'get',
       data: {},
@@ -667,8 +655,8 @@ export class Router {
       viewTransition: false,
       component: null,
       pageProps: null,
-      ...stripUndefined(options),
-      ...stripUndefined(configuredOptions),
+      ...stripTopLevelUndefined(options),
+      ...stripTopLevelUndefined(configuredOptions),
     }
 
     const [url, _data] = transformUrlAndData(


### PR DESCRIPTION
## Problem

When visit options contain explicit `undefined` values (e.g. `{ only: undefined }`), the spread operator overwrites the default `[]` with `undefined`, causing a runtime crash:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
```

This happens when options are built dynamically with conditional spreads or wrapper functions that pass through undefined. TypeScript's `Partial<Visit>` allows this without error.

## Reproduction

```ts
router.visit('/some-url', { only: undefined })
// => TypeError: Cannot read properties of undefined (reading 'length')
```

## Fix

Added a `stripUndefined` helper that removes keys with `undefined` values from `options` and `configuredOptions` before they're spread into `mergedOptions`. This ensures defaults (`only: []`, `except: []`, `reset: []`) are preserved.

This is a minimal, surgical fix — 12 lines added, no behavior changes for correctly-formed options.

Fixes #3018