### PR TITLE
[3.x] Fix `WhenVisible` crash during SSR

### DIFF
--- a/packages/vue3/src/whenVisible.ts
+++ b/packages/vue3/src/whenVisible.ts
@@ -51,6 +51,10 @@ export default defineComponent({
     }
 
     function registerObserver() {
+      if (typeof window === 'undefined') {
+        return
+      }
+
       observer.value?.disconnect()
 
       observer.value = new IntersectionObserver(


### PR DESCRIPTION
React and Svelte are not affected since their observer setup runs in client-only lifecycle hooks.

Fixes #3017.