### PR TITLE
[3.x] Remove plain <title> when Head component sets a title

### DIFF
--- a/packages/core/src/head.ts
+++ b/packages/core/src/head.ts
@@ -39,6 +39,10 @@ const Renderer = {
       this.isInertiaManagedElement(element as Element),
     )
 
+    if (sourceElements.some((element) => element instanceof HTMLTitleElement)) {
+      document.head.querySelectorAll('title:not([data-inertia])').forEach((title) => title.remove())
+    }
+
     targetElements.forEach((targetElement) => {
       const index = this.findMatchingElementIndex(targetElement as Element, sourceElements)
       if (index === -1) {
@@ -52,7 +56,9 @@ const Renderer = {
       }
     })
 
-    sourceElements.forEach((element) => document.head.appendChild(element))
+    sourceElements.forEach((element) => {
+      document.head.appendChild(element)
+    })
   }, 1),
 }
 

--- a/tests/app/helpers.js
+++ b/tests/app/helpers.js
@@ -86,6 +86,24 @@ module.exports = {
         .replace("'{{ placeholder }}'", JSON.stringify(data)),
     )
   },
+  renderWithPlainTitle: (req, res, data) => {
+    data = buildPageData(req, data)
+    data = processPartialProps(req, data)
+
+    if (req.get('X-Inertia')) {
+      res.header('Vary', 'Accept')
+      res.header('X-Inertia', true)
+      return res.status(200).json(data)
+    }
+
+    return res.status(200).send(
+      fs
+        .readFileSync(path.resolve(__dirname, '../../packages/', package, 'test-app/dist/index.html'))
+        .toString()
+        .replace(' {{ headAttribute }}', '')
+        .replace("'{{ placeholder }}'", JSON.stringify(data)),
+    )
+  },
   renderUnified: (req, res, data) => {
     data = buildPageData(req, data)
     data = processPartialProps(req, data)

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -3476,6 +3476,10 @@ app.get('/nested-props/deferred-with-siblings', (req, res) => {
   )
 })
 
+app.get('/head/plain-title', (req, res) =>
+  inertia.renderWithPlainTitle(req, res, { component: 'Head/Dataset' }),
+)
+
 app.all('*page', (req, res) => inertia.render(req, res))
 
 // Send errors to the console (instead of crashing the server)

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -3476,9 +3476,7 @@ app.get('/nested-props/deferred-with-siblings', (req, res) => {
   )
 })
 
-app.get('/head/plain-title', (req, res) =>
-  inertia.renderWithPlainTitle(req, res, { component: 'Head/Dataset' }),
-)
+app.get('/head/plain-title', (req, res) => inertia.renderWithPlainTitle(req, res, { component: 'Head/Dataset' }))
 
 app.all('*page', (req, res) => inertia.render(req, res))
 

--- a/tests/head.spec.ts
+++ b/tests/head.spec.ts
@@ -31,6 +31,22 @@ test.describe('Head component', () => {
     expect(titles.allHaveInertiaAttribute).toBe(true)
   })
 
+  test('replaces a plain title element without data-inertia attribute', async ({ page }) => {
+    await page.goto('/head/plain-title')
+    await page.waitForSelector('title[data-inertia]', { state: 'attached' })
+
+    const titles = await page.evaluate(() => {
+      const allTitles = Array.from(document.querySelectorAll('title'))
+      return {
+        total: allTitles.length,
+        inertiaTitle: allTitles.find((t) => t.hasAttribute('data-inertia'))?.textContent,
+      }
+    })
+
+    expect(titles.total).toBe(1)
+    expect(titles.inertiaTitle).toBe('Test Head Component')
+  })
+
   test('renders the title tag and children with proper escaping', async ({ page }) => {
     await page.goto('/head')
     await page.waitForSelector('title[data-inertia]', { state: 'attached' })


### PR DESCRIPTION
When the server-side template includes a plain `<title>` tag (without `data-inertia`), the `<Head>` component's title was ignored because the head manager only touches elements it owns. This resulted in two `<title>` elements in the document, with the browser using the server-rendered one.

The head manager now removes any plain `<title>` elements before inserting its own Inertia-managed title. If the `<Head>` component doesn't set a title, the server-rendered one is left untouched.

Fixes inertiajs/inertia#3020.