### PR TITLE
[3.x] Fix `defineOptions({ layout: [...] })` type error with nested layouts

### DIFF
--- a/packages/vue3/src/types.ts
+++ b/packages/vue3/src/types.ts
@@ -30,7 +30,11 @@ declare module 'vue' {
   }
 
   export interface ComponentCustomOptions {
-    layout?: LayoutCallbackReturn<DefineComponent<any, any, any>> | ((props: any) => any) | LayoutRenderFunction
+    layout?:
+      | LayoutCallbackReturn<DefineComponent<any, any, any>>
+      | Component[]
+      | ((props: any) => any)
+      | LayoutRenderFunction
     remember?:
       | string
       | string[]

--- a/packages/vue3/test-app/Layouts/TypedLayoutA.vue
+++ b/packages/vue3/test-app/Layouts/TypedLayoutA.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+}>()
+</script>
+
+<template>
+  <div>
+    <slot />
+  </div>
+</template>

--- a/packages/vue3/test-app/Layouts/TypedLayoutB.vue
+++ b/packages/vue3/test-app/Layouts/TypedLayoutB.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineProps<{
+  count: number
+}>()
+</script>
+
+<template>
+  <div>
+    <slot />
+  </div>
+</template>

--- a/packages/vue3/test-app/Layouts/TypedLayoutC.vue
+++ b/packages/vue3/test-app/Layouts/TypedLayoutC.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineProps<{
+  active: boolean
+}>()
+</script>
+
+<template>
+  <div>
+    <slot />
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/TypeScriptNestedLayouts.vue
+++ b/packages/vue3/test-app/Pages/TypeScriptNestedLayouts.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+// This component is used for checking the TypeScript implementation; there is no Playwright test depending on it.
+import TypedLayoutA from '@/Layouts/TypedLayoutA.vue'
+import TypedLayoutB from '@/Layouts/TypedLayoutB.vue'
+import TypedLayoutC from '@/Layouts/TypedLayoutC.vue'
+
+defineOptions({
+  layout: [TypedLayoutA, TypedLayoutB, TypedLayoutC],
+})
+</script>
+
+<template>
+  <div />
+</template>


### PR DESCRIPTION
This PR fixes a `vue-tsc` type error when passing three or more components with distinct typed props to `defineOptions({ layout: [...] })`.

Fixes #3012.