### PR TITLE
[3.x] Fix flash data re-firing on partial reloads

### DIFF
--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -426,10 +426,11 @@ export class Response {
       }
     }
 
-    // Preserve flash data and merge with new flash data on non-deferred requests
-    pageResponse.flash = {
-      ...currentPage.get().flash,
-      ...(this.requestParams.isDeferredPropsRequest() ? {} : pageResponse.flash),
+    // Preserve flash data on deferred props requests (background fetches that replay
+    // the same flash from the initial load), but let regular partial reloads use
+    // whatever the server sent (which may be empty, clearing stale flash)
+    if (this.requestParams.isDeferredPropsRequest()) {
+      pageResponse.flash = { ...currentPage.get().flash }
     }
 
     const currentOriginalDeferred = currentPage.get().initialDeferredProps

--- a/packages/react/test-app/Pages/Flash/Partial.tsx
+++ b/packages/react/test-app/Pages/Flash/Partial.tsx
@@ -21,6 +21,10 @@ export default ({ count }: { count: number }) => {
     router.reload({ only: ['count'], data: { flashType: 'different', count: Date.now() } })
   }
 
+  const reloadWithoutFlash = () => {
+    router.reload({ only: ['count'], data: { flashType: 'none', count: Date.now() } })
+  }
+
   return (
     <div>
       <span id="flash">{JSON.stringify(page.flash)}</span>
@@ -29,6 +33,7 @@ export default ({ count }: { count: number }) => {
 
       <button onClick={reloadWithSameFlash}>Reload with same flash</button>
       <button onClick={reloadWithDifferentFlash}>Reload with different flash</button>
+      <button onClick={reloadWithoutFlash}>Reload without flash</button>
     </div>
   )
 }

--- a/packages/svelte/test-app/Pages/Flash/Partial.svelte
+++ b/packages/svelte/test-app/Pages/Flash/Partial.svelte
@@ -20,6 +20,10 @@
   const reloadWithDifferentFlash = () => {
     router.reload({ only: ['count'], data: { flashType: 'different', count: Date.now() } })
   }
+
+  const reloadWithoutFlash = () => {
+    router.reload({ only: ['count'], data: { flashType: 'none', count: Date.now() } })
+  }
 </script>
 
 <div>
@@ -29,4 +33,5 @@
 
   <button onclick={reloadWithSameFlash}>Reload with same flash</button>
   <button onclick={reloadWithDifferentFlash}>Reload with different flash</button>
+  <button onclick={reloadWithoutFlash}>Reload without flash</button>
 </div>

--- a/packages/vue3/test-app/Pages/Flash/Partial.vue
+++ b/packages/vue3/test-app/Pages/Flash/Partial.vue
@@ -20,6 +20,10 @@ const reloadWithSameFlash = () => {
 const reloadWithDifferentFlash = () => {
   router.reload({ only: ['count'], data: { flashType: 'different', count: Date.now() } })
 }
+
+const reloadWithoutFlash = () => {
+  router.reload({ only: ['count'], data: { flashType: 'none', count: Date.now() } })
+}
 </script>
 
 <template>
@@ -30,5 +34,6 @@ const reloadWithDifferentFlash = () => {
 
     <button @click="reloadWithSameFlash">Reload with same flash</button>
     <button @click="reloadWithDifferentFlash">Reload with different flash</button>
+    <button @click="reloadWithoutFlash">Reload without flash</button>
   </div>
 </template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2445,13 +2445,17 @@ app.get('/flash/partial', (req, res) => {
 
   let flash = { message: 'Initial flash' }
   if (req.headers['x-inertia-partial-data']) {
-    flash = flashType === 'different' ? { message: `Updated flash ${count}` } : { message: 'Initial flash' }
+    if (flashType === 'different') {
+      flash = { message: `Updated flash ${count}` }
+    } else if (flashType === 'none') {
+      flash = {}
+    }
   }
 
   inertia.render(req, res, {
     component: 'Flash/Partial',
     props: { count },
-    flash,
+    flash: Object.keys(flash).length > 0 ? flash : undefined,
   })
 })
 const getOncePropsData = (req, prop = 'foo') => {

--- a/tests/flash.spec.ts
+++ b/tests/flash.spec.ts
@@ -78,6 +78,22 @@ test.describe('Flash Data', () => {
     await expect(page.locator('#flash-event-count')).toHaveText('2')
   })
 
+  test('does not re-fire flash event on partial reload when server sends no flash', async ({ page }) => {
+    await page.goto('/flash/partial')
+
+    await expect(page.locator('#flash')).toContainText('Initial flash')
+    await expect(page.locator('#flash-event-count')).toHaveText('1')
+
+    const initialCount = await page.locator('#count').textContent()
+    const responsePromise = page.waitForResponse((res) => res.url().includes('/flash/partial'))
+    await page.getByRole('button', { name: 'Reload without flash' }).click()
+    await responsePromise
+
+    await expect(page.locator('#count')).not.toHaveText(initialCount!)
+    await expect(page.locator('#flash')).toHaveText('{}')
+    await expect(page.locator('#flash-event-count')).toHaveText('1')
+  })
+
   test.describe('Requests', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/flash/events')


### PR DESCRIPTION
During partial reloads, flash data from the current page was always merged into the response. This meant that if the server didn't send flash on a partial reload (the normal Laravel behavior, since session flash is aged after the first request), the old flash data survived and the flash event fired again.

This changes the merge logic so that existing flash data is only preserved for deferred props requests (background fetches that replay the same flash from the initial load). Regular partial reloads now use whatever the server sent, which correctly clears stale flash when the server omits it.

Fixes #3015.