### PR TITLE
[3.x] Populate `percentage` in upload progress events

### DIFF
--- a/packages/core/src/axiosHttpClient.ts
+++ b/packages/core/src/axiosHttpClient.ts
@@ -35,6 +35,7 @@ function normalizeHeaders(headers: unknown): HttpResponseHeaders {
 function toHttpProgressEvent(axiosEvent: AxiosProgressEvent): HttpProgressEvent {
   return {
     progress: axiosEvent.progress,
+    percentage: axiosEvent.progress ? Math.round(axiosEvent.progress * 100) : 0,
     loaded: axiosEvent.loaded,
     total: axiosEvent.total,
   }

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -152,7 +152,6 @@ export class Request {
 
   protected onProgress(progress: HttpProgressEvent): void {
     if (this.requestParams.data() instanceof FormData) {
-      progress.percentage = progress.progress ? Math.round(progress.progress * 100) : 0
       fireProgressEvent(progress)
       this.requestParams.all().onProgress(progress)
     }

--- a/packages/core/src/xhrHttpClient.ts
+++ b/packages/core/src/xhrHttpClient.ts
@@ -123,8 +123,11 @@ export class XhrHttpClient implements HttpClient {
 
       if (config.onUploadProgress) {
         xhr.upload.onprogress = (event: ProgressEvent) => {
+          const progress = event.lengthComputable ? event.loaded / event.total : undefined
+
           config.onUploadProgress!({
-            progress: event.lengthComputable ? event.loaded / event.total : undefined,
+            progress,
+            percentage: progress ? Math.round(progress * 100) : 0,
             loaded: event.loaded,
             total: event.lengthComputable ? event.total : undefined,
           })

--- a/tests/use-http.spec.ts
+++ b/tests/use-http.spec.ts
@@ -254,6 +254,20 @@ test.describe('useHttp', () => {
       await expect(page.locator('#upload-result')).toContainText('file2.txt')
     })
 
+    test('it reports upload progress with percentage', async ({ page }) => {
+      await page.goto('/use-http/file-upload')
+
+      await page.setInputFiles('#upload-file', {
+        name: 'large-file.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.alloc(1024 * 1024, 'a'),
+      })
+      await page.click('#upload-button')
+
+      await expect(page.locator('#upload-result')).toBeVisible()
+      await expect(page.locator('#upload-progress')).toContainText('Progress: 100%')
+    })
+
     test('it uses multipart/form-data for file uploads', async ({ page }) => {
       await page.goto('/use-http/file-upload')
 


### PR DESCRIPTION
The `percentage` field on `HttpProgressEvent` was only populated for `useForm` uploads, not for `useHttp`. This moves the calculation into the XHR and Axios HTTP clients so both get it consistently.

Fixes #3029.