### PR TITLE
[3.x] Add test for optional scroll props

### DIFF
--- a/packages/react/test-app/Pages/InfiniteScroll/OptionalWhenVisible.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/OptionalWhenVisible.tsx
@@ -1,0 +1,46 @@
+import { InfiniteScroll, usePage, WhenVisible } from '@inertiajs/react'
+import UserCard, { User } from './UserCard'
+
+const Users = () => {
+  const { users } = usePage<{ users: { data: User[] } }>().props
+
+  return (
+    <InfiniteScroll
+      data="users"
+      style={{ display: 'grid', gap: '20px' }}
+      manual
+      previous={({ loading, fetch, hasMore }) => (
+        <>
+          <p>Has more previous items: {hasMore.toString()}</p>
+          <button onClick={fetch}>{loading ? 'Loading previous items...' : 'Load previous items'}</button>
+        </>
+      )}
+      next={({ loading, fetch, hasMore }) => (
+        <>
+          <p>Has more next items: {hasMore.toString()}</p>
+          <button onClick={fetch}>{loading ? 'Loading next items...' : 'Load next items'}</button>
+        </>
+      )}
+    >
+      {users.data.map((user) => (
+        <UserCard key={user.id} user={user} />
+      ))}
+    </InfiniteScroll>
+  )
+}
+
+export default ({ users }: { users?: { data: User[] } }) => {
+  return (
+    <div>
+      <h1>Optional Scroll Prop + WhenVisible</h1>
+
+      <div id="initial-state">Users prop present: {(!!users).toString()}</div>
+
+      <div style={{ marginTop: '2000px' }}>
+        <WhenVisible data="users" fallback={<div>Loading optional scroll prop...</div>}>
+          <Users />
+        </WhenVisible>
+      </div>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/InfiniteScroll/OptionalWhenVisible.svelte
+++ b/packages/svelte/test-app/Pages/InfiniteScroll/OptionalWhenVisible.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { InfiniteScroll, WhenVisible } from '@inertiajs/svelte'
+  import UserCard, { type User } from './UserCard.svelte'
+
+  interface Props {
+    users: { data: User[] } | undefined
+  }
+
+  let { users }: Props = $props()
+</script>
+
+<div>
+  <h1>Optional Scroll Prop + WhenVisible</h1>
+
+  <div id="initial-state">Users prop present: {!!users}</div>
+
+  <div style="margin-top: 2000px">
+    <WhenVisible data="users">
+      {#snippet fallback()}
+        <div>Loading optional scroll prop...</div>
+      {/snippet}
+
+      <InfiniteScroll data="users" style="display: grid; gap: 20px" manual>
+        {#snippet previous({ hasMore, loading, fetch })}
+          <div>
+            <p>Has more previous items: {hasMore}</p>
+            <button onclick={fetch}>
+              {loading ? 'Loading previous items...' : 'Load previous items'}
+            </button>
+          </div>
+        {/snippet}
+
+        {#each users?.data ?? [] as user (user.id)}
+          <UserCard {user} />
+        {/each}
+
+        {#snippet next({ hasMore, loading, fetch })}
+          <div>
+            <p>Has more next items: {hasMore}</p>
+            <button onclick={fetch}>
+              {loading ? 'Loading next items...' : 'Load next items'}
+            </button>
+          </div>
+        {/snippet}
+      </InfiniteScroll>
+    </WhenVisible>
+  </div>
+</div>

--- a/packages/vue3/test-app/Pages/InfiniteScroll/OptionalWhenVisible.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/OptionalWhenVisible.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { InfiniteScroll, WhenVisible } from '@inertiajs/vue3'
+import { User, default as UserCard } from './UserCard.vue'
+
+defineProps<{
+  users?: { data: User[] }
+}>()
+</script>
+
+<template>
+  <div>
+    <h1>Optional Scroll Prop + WhenVisible</h1>
+
+    <div id="initial-state">Users prop present: {{ !!users }}</div>
+
+    <div style="margin-top: 2000px">
+      <WhenVisible data="users">
+        <template #fallback>
+          <div>Loading optional scroll prop...</div>
+        </template>
+
+        <InfiniteScroll data="users" style="display: grid; gap: 20px" manual>
+          <template #previous="{ loading, fetch, hasMore }">
+            <p>Has more previous items: {{ hasMore }}</p>
+
+            <button @click="fetch">
+              {{ loading ? 'Loading previous items...' : 'Load previous items' }}
+            </button>
+          </template>
+
+          <UserCard v-for="user in users!.data" :key="user.id" :user="user" />
+
+          <template #next="{ loading, fetch, hasMore }">
+            <p>Has more next items: {{ hasMore }}</p>
+
+            <button @click="fetch">
+              {{ loading ? 'Loading next items...' : 'Load next items' }}
+            </button>
+          </template>
+        </InfiniteScroll>
+      </WhenVisible>
+    </div>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2347,6 +2347,34 @@ app.get('/infinite-scroll/deferred', (req, res) => {
   )
 })
 
+// Optional scroll prop via WhenVisible - simulates Inertia::optional(fn() => Inertia::scroll(...))
+app.get('/infinite-scroll/optional-when-visible', (req, res) => {
+  const page = req.query.page ? parseInt(req.query.page) : 1
+  const partialReload = !!req.headers['x-inertia-partial-data']
+  const shouldAppend = req.headers['x-inertia-infinite-scroll-merge-intent'] !== 'prepend'
+  const { paginated, scrollProp } = paginateUsers(page, 15, 40, false)
+
+  if (!partialReload) {
+    // Initial page load - no users prop and no scrollProps (optional prop excluded)
+    return inertia.render(req, res, {
+      component: 'InfiniteScroll/OptionalWhenVisible',
+      props: {},
+    })
+  }
+
+  // WhenVisible partial reload - send both the data AND scrollProps
+  setTimeout(
+    () =>
+      inertia.render(req, res, {
+        component: 'InfiniteScroll/OptionalWhenVisible',
+        props: { users: paginated },
+        [shouldAppend ? 'mergeProps' : 'prependProps']: ['users.data'],
+        scrollProps: { users: scrollProp },
+      }),
+    250,
+  )
+})
+
 let infiniteScrollPreserveErrorsState = {}
 
 app.get('/infinite-scroll/preserve-errors', (req, res) => {

--- a/tests/infinite-scroll.spec.ts
+++ b/tests/infinite-scroll.spec.ts
@@ -2477,6 +2477,39 @@ test.describe('Deferred scroll props', () => {
   })
 })
 
+test.describe('Optional scroll props via WhenVisible', () => {
+  test('it loads optional scroll props via WhenVisible and enables InfiniteScroll', async ({ page }) => {
+    requests.listen(page)
+
+    await page.goto('/infinite-scroll/optional-when-visible')
+
+    await expect(page.getByText('Users prop present: false')).toBeVisible()
+    await expect(page.getByText('User 1')).toBeHidden()
+
+    await page.evaluate(() => (window as any).scrollTo(0, 3000))
+    await expect(page.getByText('Loading optional scroll prop...')).toBeVisible()
+
+    await page.waitForResponse(page.url())
+    await expect(page.getByText('Loading optional scroll prop...')).toBeHidden()
+
+    await expect(page.getByText('User 1', { exact: true })).toBeVisible()
+    await expect(page.getByText('User 15')).toBeVisible()
+    await expect(page.getByText('User 16')).toBeHidden()
+
+    await expect(page.getByText('Has more next items: true')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Load next items' }).click()
+    await expect(page.getByText('Loading next items...')).toBeVisible()
+
+    await expect(page.getByText('User 16')).toBeVisible()
+    await expect(page.getByText('User 30')).toBeVisible()
+    await expect(page.getByText('Loading next items...')).toBeHidden()
+
+    const pageRequests = infiniteScrollRequests()
+    expect(pageRequests.length).toBe(2)
+  })
+})
+
 test('it preserves validation errors when InfiniteScroll loads more data', async ({ page }) => {
   await page.goto('/infinite-scroll/preserve-errors')
 


### PR DESCRIPTION
This PR adds tests confirming that `InfiniteScroll` works with optional scroll props loaded via a partial reload.