### PR TITLE
[3.x] Warm up lazy-loaded page dependencies in Vite plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:ssr:react": "PACKAGE=react SSR=true npx playwright test",
     "test:ssr:svelte": "PACKAGE=svelte SSR=true npx playwright test",
     "test:ssr:vue": "PACKAGE=vue3 SSR=true npx playwright test",
+    "test:vite": "cd packages/vite && pnpm test",
     "playground:react": "cd playgrounds/react && ./init.sh && composer run dev",
     "playground:svelte": "cd playgrounds/svelte5 && ./init.sh && composer run dev",
     "playground:vue": "cd playgrounds/vue3 && ./init.sh && composer run dev",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -37,7 +37,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@inertiajs/core": "workspace:*"
+    "@inertiajs/core": "workspace:*",
+    "tinyglobby": "^0.2.15"
   },
   "peerDependencies": {
     "vite": "^7.0.0 || ^8.0.0"

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -17,8 +17,9 @@
  */
 
 import { existsSync } from 'node:fs'
-import { resolve } from 'node:path'
-import type { Plugin } from 'vite'
+import { dirname, resolve } from 'node:path'
+import { glob } from 'tinyglobby'
+import type { Plugin, ViteDevServer } from 'vite'
 import { defaultFrameworks } from './frameworks/index'
 import { transformPageResolution } from './pagesTransform'
 import { handleSSRRequest, InertiaSSROptions, resolveSSREntry, SSR_ENDPOINT, SSR_ENTRY_CANDIDATES } from './ssr'
@@ -76,12 +77,26 @@ function toFrameworkRecord(input?: FrameworkConfig | FrameworkConfig[]): Record<
   return Object.fromEntries(configs.map((config) => [config.package, config]))
 }
 
+/**
+ * Warm up page component files so Vite discovers their dependencies upfront.
+ *
+ * The pages shorthand (or default) is transformed into import.meta.glob during the transform
+ * hook, which is too late for Vite's initial dependency scanner. Without warmup, first
+ * navigation to a lazy-loaded page can trigger a disruptive re-optimization.
+ */
+async function warmupPageFiles(server: ViteDevServer, sourceFile: string, pageGlobs: string[]): Promise<void> {
+  const files = await glob(pageGlobs, { cwd: dirname(sourceFile), absolute: true })
+
+  files.forEach((file) => server.warmupRequest(file))
+}
+
 export default function inertia(options: InertiaPluginOptions = {}): Plugin {
   const ssrDisabled = options.ssr === false
   const ssr = typeof options.ssr === 'string' ? { entry: options.ssr } : options.ssr || {}
   const frameworks = { ...defaultFrameworks, ...toFrameworkRecord(options.frameworks) }
 
   let entry: string | null = null
+  let devServer: ViteDevServer | null = null
 
   return {
     name: '@inertiajs/vite',
@@ -134,10 +149,22 @@ export default function inertia(options: InertiaPluginOptions = {}): Plugin {
           ) ?? result
       }
 
-      return transformPageResolution(result, frameworks) ?? (result !== code ? result : null)
+      const pageTransform = transformPageResolution(result, frameworks)
+
+      if (pageTransform) {
+        if (devServer && pageTransform.pageGlobs.length > 0) {
+          warmupPageFiles(devServer, id, pageTransform.pageGlobs).catch(() => {})
+        }
+
+        return pageTransform.code
+      }
+
+      return result !== code ? result : null
     },
 
     configureServer(server) {
+      devServer = server
+
       if (!entry) {
         return
       }

--- a/packages/vite/src/pagesTransform.ts
+++ b/packages/vite/src/pagesTransform.ts
@@ -39,8 +39,16 @@ import type { Property } from 'estree'
 import { type NodeWithPos, ParsedCode, extractBoolean, extractString, extractStringArray } from './astUtils'
 import type { FrameworkConfig } from './types'
 
-/** Returns the transformed code, or null if no transformation was needed. */
-export function transformPageResolution(code: string, frameworks: Record<string, FrameworkConfig>): string | null {
+export interface PageTransformResult {
+  code: string
+  pageGlobs: string[]
+}
+
+/** Returns the transformed code with page globs, or null if no transformation was needed. */
+export function transformPageResolution(
+  code: string,
+  frameworks: Record<string, FrameworkConfig>,
+): PageTransformResult | null {
   if (!code.includes('InertiaApp')) {
     return null
   }
@@ -61,11 +69,18 @@ export function transformPageResolution(code: string, frameworks: Record<string,
   const extractDefault = framework.config.extractDefault ?? true
 
   if (parsed.pagesProperty) {
-    return replacePages(code, parsed.pagesProperty, extensions, extractDefault)
+    const result = replacePages(code, parsed.pagesProperty, extensions, extractDefault)
+
+    return result ? { code: result.code, pageGlobs: result.globs } : null
   }
 
   if (parsed.callWithoutResolver) {
-    return injectResolver(code, parsed.callWithoutResolver, extensions, extractDefault)
+    const defaultGlobs = buildDefaultGlobs(extensions)
+
+    return {
+      code: injectResolver(code, parsed.callWithoutResolver, extensions, extractDefault),
+      pageGlobs: defaultGlobs,
+    }
   }
 
   return null
@@ -82,11 +97,11 @@ function replacePages(
   property: NodeWithPos<Property>,
   defaultExtensions: string[],
   extractDefault: boolean,
-): string {
+): { code: string; globs: string[] } | null {
   const config = extractPagesConfig(property.value, code)
 
   if (!config) {
-    return code
+    return null
   }
 
   const extensions = config.extensions
@@ -97,11 +112,17 @@ function replacePages(
 
   const eager = !(config.lazy ?? true)
 
-  const resolver = config.directory
-    ? buildResolver(config.directory.replace(/\/$/, ''), extensions, extractDefault, eager, config.transform)
-    : buildDefaultResolver(extensions, extractDefault, eager)
+  const directories = config.directory
+    ? [config.directory.replace(/\/$/, '')]
+    : ['./pages', './Pages']
 
-  return code.slice(0, property.start) + resolver + code.slice(property.end)
+  const resolver = buildResolver(directories, extensions, extractDefault, eager, config.transform)
+  const globs = directories.map((d) => buildGlob(d, extensions))
+
+  return {
+    code: code.slice(0, property.start) + resolver + code.slice(property.end),
+    globs,
+  }
 }
 
 /**
@@ -214,8 +235,14 @@ function buildResolver(
   }`
 }
 
+const DEFAULT_PAGE_DIRECTORIES = ['./pages', './Pages']
+
 function buildDefaultResolver(extensions: string[], extractDefault: boolean, eager: boolean = false): string {
-  return buildResolver(['./pages', './Pages'], extensions, extractDefault, eager)
+  return buildResolver(DEFAULT_PAGE_DIRECTORIES, extensions, extractDefault, eager)
+}
+
+function buildDefaultGlobs(extensions: string[]): string[] {
+  return DEFAULT_PAGE_DIRECTORIES.map((d) => buildGlob(d, extensions))
 }
 
 function buildGlob(directory: string, extensions: string[]): string {

--- a/packages/vite/src/pagesTransform.ts
+++ b/packages/vite/src/pagesTransform.ts
@@ -112,9 +112,7 @@ function replacePages(
 
   const eager = !(config.lazy ?? true)
 
-  const directories = config.directory
-    ? [config.directory.replace(/\/$/, '')]
-    : ['./pages', './Pages']
+  const directories = config.directory ? [config.directory.replace(/\/$/, '')] : ['./pages', './Pages']
 
   const resolver = buildResolver(directories, extensions, extractDefault, eager, config.transform)
   const globs = directories.map((d) => buildGlob(d, extensions))

--- a/packages/vite/tests/pages.test.ts
+++ b/packages/vite/tests/pages.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
 import inertia from '../src'
 
 describe('plugin', () => {
@@ -176,3 +178,77 @@ function transform(code: string): string | null {
   const plugin = inertia()
   return plugin.transform!(code, 'app.ts') as string | null
 }
+
+describe('page warmup', () => {
+  const tmpDir = resolve(__dirname, '.tmp-warmup-test')
+  const pagesDir = join(tmpDir, 'Pages')
+
+  function setup() {
+    mkdirSync(join(pagesDir, 'Auth'), { recursive: true })
+    writeFileSync(join(pagesDir, 'Home.vue'), '<template>Home</template>')
+    writeFileSync(join(pagesDir, 'About.vue'), '<template>About</template>')
+    writeFileSync(join(pagesDir, 'Auth', 'Login.vue'), '<template>Login</template>')
+  }
+
+  function cleanup() {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+
+  it('calls warmupRequest for all page files', async () => {
+    setup()
+
+    try {
+      const warmupRequest = vi.fn()
+      const plugin = inertia({ ssr: false })
+
+      plugin.configureServer!({ warmupRequest } as any)
+
+      const appFile = join(tmpDir, 'app.ts')
+      const code = `import { createInertiaApp } from '@inertiajs/vue3'
+export default createInertiaApp()`
+
+      plugin.transform!(code, appFile)
+
+      await vi.waitFor(() => {
+        expect(warmupRequest).toHaveBeenCalledTimes(3)
+      })
+
+      const warmedFiles = warmupRequest.mock.calls.map((call: any) => call[0]).sort()
+
+      expect(warmedFiles).toEqual([
+        join(pagesDir, 'About.vue'),
+        join(pagesDir, 'Auth', 'Login.vue'),
+        join(pagesDir, 'Home.vue'),
+      ])
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('does not call warmupRequest when server is not available', () => {
+    const plugin = inertia({ ssr: false })
+
+    const code = `import { createInertiaApp } from '@inertiajs/vue3'
+export default createInertiaApp({ pages: './Pages' })`
+
+    const result = plugin.transform!(code, 'app.ts')
+
+    expect(result).not.toBeNull()
+  })
+
+  it('handles glob errors gracefully', async () => {
+    const warmupRequest = vi.fn()
+    const plugin = inertia({ ssr: false })
+
+    plugin.configureServer!({ warmupRequest } as any)
+
+    const code = `import { createInertiaApp } from '@inertiajs/vue3'
+export default createInertiaApp({ pages: './NonExistentDir' })`
+
+    plugin.transform!(code, '/some/fake/path/app.ts')
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(warmupRequest).not.toHaveBeenCalled()
+  })
+})

--- a/packages/vite/tests/pagesTransform.test.ts
+++ b/packages/vite/tests/pagesTransform.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { defaultFrameworks } from '../src/frameworks/index'
 import { transformPageResolution } from '../src/pagesTransform'
 
-const transform = (code: string) => transformPageResolution(code, defaultFrameworks)
+const transformFull = (code: string) => transformPageResolution(code, defaultFrameworks)
+const transform = (code: string) => transformFull(code)?.code ?? null
 
 describe('Pages Transform', () => {
   describe('returns null when no transform needed', () => {
@@ -307,6 +308,43 @@ export default createInertiaApp({
 
         // Footer comment"
       `)
+    })
+  })
+
+  describe('pageGlobs', () => {
+    it('returns default globs when no pages property', () => {
+      const code = `import { createInertiaApp } from '@inertiajs/vue3'
+export default createInertiaApp()`
+
+      expect(transformFull(code)?.pageGlobs).toEqual(['./pages/**/*.vue', './Pages/**/*.vue'])
+    })
+
+    it('returns globs for custom directory', () => {
+      const code = `import { createInertiaApp } from '@inertiajs/vue3'
+export default createInertiaApp({ pages: './Views' })`
+
+      expect(transformFull(code)?.pageGlobs).toEqual(['./Views/**/*.vue'])
+    })
+
+    it('returns globs for custom directory via path option', () => {
+      const code = `import { createInertiaApp } from '@inertiajs/react'
+export default createInertiaApp({ pages: { path: './CustomPages' } })`
+
+      expect(transformFull(code)?.pageGlobs).toEqual(['./CustomPages/**/*{.tsx,.jsx}'])
+    })
+
+    it('returns globs with custom extensions', () => {
+      const code = `import { createInertiaApp } from '@inertiajs/react'
+export default createInertiaApp({ pages: { path: './Pages', extension: '.tsx' } })`
+
+      expect(transformFull(code)?.pageGlobs).toEqual(['./Pages/**/*.tsx'])
+    })
+
+    it('returns default globs for pages object without path', () => {
+      const code = `import { createInertiaApp } from '@inertiajs/vue3'
+export default createInertiaApp({ pages: { lazy: true } })`
+
+      expect(transformFull(code)?.pageGlobs).toEqual(['./pages/**/*.vue', './Pages/**/*.vue'])
     })
   })
 })

--- a/packages/vite/tests/ssrTransform.test.ts
+++ b/packages/vite/tests/ssrTransform.test.ts
@@ -4,7 +4,7 @@ import { transformPageResolution } from '../src/pagesTransform'
 import { findInertiaAppExport, wrapWithServerBootstrap } from '../src/ssrTransform'
 
 const wrap = (code: string, options = {}) => wrapWithServerBootstrap(code, options, defaultFrameworks)
-const transformPages = (code: string) => transformPageResolution(code, defaultFrameworks)
+const transformPages = (code: string) => transformPageResolution(code, defaultFrameworks)?.code ?? null
 
 describe('SSR Transform', () => {
   describe('findInertiaAppExport', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       '@inertiajs/core':
         specifier: workspace:*
         version: link:../core
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.15
     devDependencies:
       '@types/estree':
         specifier: ^1.0.8
@@ -4508,7 +4511,7 @@ snapshots:
       alien-signals: 3.1.2
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   '@vue/reactivity@3.5.29':
     dependencies:
@@ -6461,8 +6464,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 


### PR DESCRIPTION
The Inertia Vite plugin transforms the `pages` shorthand into `import.meta.glob` during the `transform` hook, which runs after Vite's initial dependency scanner. This means dependencies that are only imported in lazy-loaded page components aren't pre-bundled at startup. When a user first navigates to such a page, Vite re-optimizes all dependencies mid-session, which can cause duplicate module instances and broken React hooks.

The plugin now warms up all page component files after the transform, using the same glob patterns it generates for `import.meta.glob`. This forces Vite to discover their dependencies upfront, preventing the disruptive re-optimization during navigation. Custom page directories and extensions are fully supported since the warmup uses the exact globs from the resolved `pages` config.

Fixes #3034.