### PR TITLE
[2.x] Bump lodash-es from 4.17.3 to 4.18.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,7 @@
     "@types/lodash-es": "^4.17.12",
     "axios": "^1.13.5",
     "laravel-precognition": "^1.0.2",
-    "lodash-es": "^4.17.23",
+    "lodash-es": "^4.18.1",
     "qs": "^6.15.0"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -71,6 +71,6 @@
     "@inertiajs/core": "workspace:*",
     "@types/lodash-es": "^4.17.12",
     "laravel-precognition": "^1.0.2",
-    "lodash-es": "^4.17.23"
+    "lodash-es": "^4.18.1"
   }
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -65,6 +65,6 @@
     "@inertiajs/core": "workspace:*",
     "@types/lodash-es": "^4.17.12",
     "laravel-precognition": "^1.0.2",
-    "lodash-es": "^4.17.23"
+    "lodash-es": "^4.18.1"
   }
 }

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -66,6 +66,6 @@
     "@inertiajs/core": "workspace:*",
     "@types/lodash-es": "^4.17.12",
     "laravel-precognition": "^1.0.2",
-    "lodash-es": "^4.17.23"
+    "lodash-es": "^4.18.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       lodash-es:
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.18.1
+        version: 4.18.1
       qs:
         specifier: ^6.15.0
         version: 6.15.0
@@ -81,8 +81,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       lodash-es:
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.18.1
+        version: 4.18.1
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -182,8 +182,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       lodash-es:
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.18.1
+        version: 4.18.1
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.3.1
@@ -280,8 +280,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       lodash-es:
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.18.1
+        version: 4.18.1
     devDependencies:
       axios:
         specifier: ^1.13.5
@@ -2364,8 +2364,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -5181,7 +5181,7 @@ snapshots:
   laravel-precognition@1.0.2:
     dependencies:
       axios: 1.13.5
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
     transitivePeerDependencies:
       - debug
 
@@ -5259,7 +5259,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.23: {}
+  lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
 


### PR DESCRIPTION
lodash vulnerable to Code Injection via `_.template` imports key names

### Description

The fix for CVE-2026-4800 added validation for the variable option in _.template but did not apply the same validation to options.imports key names. Both paths flow into the same Function() constructor sink.

When an application passes untrusted input as options.imports key names, an attacker can inject default-parameter expressions that execute arbitrary code at template compilation time.
Additionally, _.template uses assignInWith to merge imports, which enumerates inherited properties via for..in. If Object.prototype has been polluted by any other vector, the polluted keys are copied into the imports object and passed to Function().

Severity: High
CVSS: v3.1  - 8.1
 
Report type: Dependency Scanning
Scanner: GitLab SBoM Vulnerability Scanner

### Links 
- https://cna.openjsf.org/security-advisories.html
- https://github.com/advisories/GHSA-r5fr-rjxr-66jc
- https://github.com/lodash/lodash
- https://github.com/lodash/lodash/security/advisories/GHSA-r5fr-rjxr-66jc
- https://nvd.nist.gov/vuln/detail/CVE-2026-4800

Solution Upgrade to version 4.18.0 or above.