### PR TITLE
[3.x] Infer form data keys in `resetOnSuccess` and `resetOnError`

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -759,7 +759,7 @@ export type FormComponentProps<TForm = Record<string, FormDataConvertible>> = Pa
   transform?: (data: TForm) => Record<string, FormDataConvertible>
   optimistic?: FormComponentOptimisticCallback<Page<SharedPageProps>['props'], TForm>
   options?: FormComponentOptions
-  onSubmitComplete?: (props: FormComponentOnSubmitCompleteArguments) => void
+  onSubmitComplete?: (props: FormComponentOnSubmitCompleteArguments<TForm & object>) => void
   disableWhileProcessing?: boolean
   resetOnSuccess?: boolean | NoInfer<FormDataKeys<TForm>>[]
   resetOnError?: boolean | NoInfer<FormDataKeys<TForm>>[]

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -761,8 +761,8 @@ export type FormComponentProps<TForm = Record<string, FormDataConvertible>> = Pa
   options?: FormComponentOptions
   onSubmitComplete?: (props: FormComponentOnSubmitCompleteArguments) => void
   disableWhileProcessing?: boolean
-  resetOnSuccess?: boolean | FormDataKeys<TForm>[]
-  resetOnError?: boolean | FormDataKeys<TForm>[]
+  resetOnSuccess?: boolean | NoInfer<FormDataKeys<TForm>>[]
+  resetOnError?: boolean | NoInfer<FormDataKeys<TForm>>[]
   setDefaultsOnSuccess?: boolean
   validateFiles?: boolean
   validationTimeout?: number

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -761,8 +761,8 @@ export type FormComponentProps<TForm = Record<string, FormDataConvertible>> = Pa
   options?: FormComponentOptions
   onSubmitComplete?: (props: FormComponentOnSubmitCompleteArguments) => void
   disableWhileProcessing?: boolean
-  resetOnSuccess?: boolean | string[]
-  resetOnError?: boolean | string[]
+  resetOnSuccess?: boolean | FormDataKeys<TForm>[]
+  resetOnError?: boolean | FormDataKeys<TForm>[]
   setDefaultsOnSuccess?: boolean
   validateFiles?: boolean
   validationTimeout?: number

--- a/packages/react/test-app/Pages/FormComponent/TypeScript/Types.tsx
+++ b/packages/react/test-app/Pages/FormComponent/TypeScript/Types.tsx
@@ -1,66 +1,58 @@
 // This component is used for checking the TypeScript implementation; there is no Playwright test depending on it.
-import { FormComponentOnSubmitCompleteArguments, FormComponentProps, FormComponentSlotProps } from '@inertiajs/core'
+import { Form } from '@inertiajs/react'
 
 interface UserForm {
   name: string
   email: string
 }
 
-function renderFormContent(props: FormComponentSlotProps<UserForm>) {
-  const { errors, getData, clearErrors } = props
-
-  console.log(errors.name, errors.email)
-
-  const data = getData()
-  console.log(data.name, data.email)
-
-  clearErrors('name', 'email')
-
-  // @ts-expect-error - 'invalid_field' should not be a valid key
-  clearErrors('invalid_field')
-
-  return <div>Form content</div>
-}
-
-function handleSubmitComplete(props: FormComponentOnSubmitCompleteArguments<UserForm>) {
-  const { reset, defaults } = props
-
-  reset('name')
-  reset('email')
-
-  // @ts-expect-error - 'invalid_field' should not be a valid key
-  reset('invalid_field')
-
-  defaults()
-}
-
-function checkResetProps() {
-  const valid: FormComponentProps<UserForm> = {
-    resetOnSuccess: ['name', 'email'],
-    resetOnError: ['name'],
-  }
-
-  const validBoolean: FormComponentProps<UserForm> = {
-    resetOnSuccess: true,
-    resetOnError: false,
-  }
-
-  const invalid: FormComponentProps<UserForm> = {
-    // @ts-expect-error - 'invalid_field' should not be a valid key
-    resetOnSuccess: ['invalid_field'],
-    // @ts-expect-error - 'another_invalid' should not be a valid key
-    resetOnError: ['another_invalid'],
-  }
-
-  return { valid, validBoolean, invalid }
-}
-
 export default () => {
   return (
     <div>
-      {renderFormContent.toString()}
-      {handleSubmitComplete.toString()}
-      {checkResetProps.toString()}
+      <Form<UserForm>
+        method="post"
+        action="/form-component/types"
+        resetOnSuccess={['name', 'email']}
+        resetOnError={['name']}
+        onSubmitComplete={({ reset }) => {
+          reset('name')
+          reset('email')
+        }}
+      >
+        {({ errors, getData, clearErrors }) => {
+          console.log(errors.name, errors.email)
+
+          const data = getData()
+          console.log(data.name, data.email)
+
+          clearErrors('name', 'email')
+
+          // @ts-expect-error - 'invalid_field' should not be a valid key
+          clearErrors('invalid_field')
+
+          return <div>Form content</div>
+        }}
+      </Form>
+
+      <Form<UserForm>
+        method="post"
+        action="/form-component/types"
+        resetOnSuccess={true}
+        resetOnError={false}
+      >
+        {() => <div>Boolean reset</div>}
+      </Form>
+
+      <Form<UserForm>
+        method="post"
+        action="/form-component/types"
+        // @ts-expect-error - 'invalid_field' should not be a valid key
+        resetOnSuccess={['invalid_field']}
+        // @ts-expect-error - 'another_invalid' should not be a valid key
+        resetOnError={['another_invalid']}
+      >
+        {() => <div>Invalid fields</div>}
+      </Form>
     </div>
   )
 }

--- a/packages/react/test-app/Pages/FormComponent/TypeScript/Types.tsx
+++ b/packages/react/test-app/Pages/FormComponent/TypeScript/Types.tsx
@@ -34,12 +34,7 @@ export default () => {
         }}
       </Form>
 
-      <Form<UserForm>
-        method="post"
-        action="/form-component/types"
-        resetOnSuccess={true}
-        resetOnError={false}
-      >
+      <Form<UserForm> method="post" action="/form-component/types" resetOnSuccess={true} resetOnError={false}>
         {() => <div>Boolean reset</div>}
       </Form>
 

--- a/packages/react/test-app/Pages/FormComponent/TypeScript/Types.tsx
+++ b/packages/react/test-app/Pages/FormComponent/TypeScript/Types.tsx
@@ -1,5 +1,5 @@
 // This component is used for checking the TypeScript implementation; there is no Playwright test depending on it.
-import { FormComponentOnSubmitCompleteArguments, FormComponentSlotProps } from '@inertiajs/core'
+import { FormComponentOnSubmitCompleteArguments, FormComponentProps, FormComponentSlotProps } from '@inertiajs/core'
 
 interface UserForm {
   name: string
@@ -34,11 +34,33 @@ function handleSubmitComplete(props: FormComponentOnSubmitCompleteArguments<User
   defaults()
 }
 
+function checkResetProps() {
+  const valid: FormComponentProps<UserForm> = {
+    resetOnSuccess: ['name', 'email'],
+    resetOnError: ['name'],
+  }
+
+  const validBoolean: FormComponentProps<UserForm> = {
+    resetOnSuccess: true,
+    resetOnError: false,
+  }
+
+  const invalid: FormComponentProps<UserForm> = {
+    // @ts-expect-error - 'invalid_field' should not be a valid key
+    resetOnSuccess: ['invalid_field'],
+    // @ts-expect-error - 'another_invalid' should not be a valid key
+    resetOnError: ['another_invalid'],
+  }
+
+  return { valid, validBoolean, invalid }
+}
+
 export default () => {
   return (
     <div>
       {renderFormContent.toString()}
       {handleSubmitComplete.toString()}
+      {checkResetProps.toString()}
     </div>
   )
 }

--- a/packages/react/test-app/Pages/FormComponent/TypeScript/Types.tsx
+++ b/packages/react/test-app/Pages/FormComponent/TypeScript/Types.tsx
@@ -17,6 +17,9 @@ export default () => {
         onSubmitComplete={({ reset }) => {
           reset('name')
           reset('email')
+
+          // @ts-expect-error - 'invalid_field' should not be a valid key
+          reset('invalid_field')
         }}
       >
         {({ errors, getData, clearErrors }) => {
@@ -34,12 +37,7 @@ export default () => {
         }}
       </Form>
 
-      <Form<UserForm>
-        method="post"
-        action="/form-component/types"
-        resetOnSuccess={true}
-        resetOnError={false}
-      >
+      <Form<UserForm> method="post" action="/form-component/types" resetOnSuccess={true} resetOnError={false}>
         {() => <div>Boolean reset</div>}
       </Form>
 

--- a/packages/svelte/src/components/createForm.ts
+++ b/packages/svelte/src/components/createForm.ts
@@ -3,11 +3,15 @@ import type { Component, ComponentProps, Snippet } from 'svelte'
 import Form from './Form.svelte'
 
 type TypedFormComponent<TForm extends Record<string, any>> = Component<
-  Omit<ComponentProps<typeof Form>, 'children' | 'optimistic' | 'transform' | 'resetOnSuccess' | 'resetOnError'> & {
+  Omit<
+    ComponentProps<typeof Form>,
+    'children' | 'optimistic' | 'transform' | 'resetOnSuccess' | 'resetOnError' | 'onSubmitComplete'
+  > & {
     optimistic?: FormComponentProps<TForm>['optimistic']
     transform?: FormComponentProps<TForm>['transform']
     resetOnSuccess?: FormComponentProps<TForm>['resetOnSuccess']
     resetOnError?: FormComponentProps<TForm>['resetOnError']
+    onSubmitComplete?: FormComponentProps<TForm>['onSubmitComplete']
     children?: Snippet<[FormComponentSlotProps<TForm>]>
   }
 >

--- a/packages/svelte/src/components/createForm.ts
+++ b/packages/svelte/src/components/createForm.ts
@@ -3,9 +3,11 @@ import type { Component, ComponentProps, Snippet } from 'svelte'
 import Form from './Form.svelte'
 
 type TypedFormComponent<TForm extends Record<string, any>> = Component<
-  Omit<ComponentProps<typeof Form>, 'children' | 'optimistic' | 'transform'> & {
+  Omit<ComponentProps<typeof Form>, 'children' | 'optimistic' | 'transform' | 'resetOnSuccess' | 'resetOnError'> & {
     optimistic?: FormComponentProps<TForm>['optimistic']
     transform?: FormComponentProps<TForm>['transform']
+    resetOnSuccess?: FormComponentProps<TForm>['resetOnSuccess']
+    resetOnError?: FormComponentProps<TForm>['resetOnError']
     children?: Snippet<[FormComponentSlotProps<TForm>]>
   }
 >

--- a/packages/svelte/test-app/Pages/FormComponent/TypeScript/Types.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/TypeScript/Types.svelte
@@ -1,6 +1,6 @@
 <!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
 <script lang="ts">
-  import type { FormComponentSlotProps, FormComponentOnSubmitCompleteArguments } from '@inertiajs/core'
+  import type { FormComponentProps, FormComponentSlotProps, FormComponentOnSubmitCompleteArguments } from '@inertiajs/core'
 
   interface UserForm {
     name: string
@@ -34,6 +34,27 @@
 
     defaults()
   }
+
+  function checkResetProps() {
+    const valid: FormComponentProps<UserForm> = {
+      resetOnSuccess: ['name', 'email'],
+      resetOnError: ['name'],
+    }
+
+    const validBoolean: FormComponentProps<UserForm> = {
+      resetOnSuccess: true,
+      resetOnError: false,
+    }
+
+    const invalid: FormComponentProps<UserForm> = {
+      // @ts-expect-error - 'invalid_field' should not be a valid key
+      resetOnSuccess: ['invalid_field'],
+      // @ts-expect-error - 'another_invalid' should not be a valid key
+      resetOnError: ['another_invalid'],
+    }
+
+    return { valid, validBoolean, invalid }
+  }
 </script>
 
-<div>{renderFormContent.toString()}{handleSubmitComplete.toString()}</div>
+<div>{renderFormContent.toString()}{handleSubmitComplete.toString()}{checkResetProps.toString()}</div>

--- a/packages/svelte/test-app/Pages/FormComponent/TypeScript/Types.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/TypeScript/Types.svelte
@@ -1,6 +1,10 @@
 <!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
 <script lang="ts">
-  import type { FormComponentProps, FormComponentSlotProps, FormComponentOnSubmitCompleteArguments } from '@inertiajs/core'
+  import type {
+    FormComponentProps,
+    FormComponentSlotProps,
+    FormComponentOnSubmitCompleteArguments,
+  } from '@inertiajs/core'
 
   interface UserForm {
     name: string

--- a/packages/svelte/test-app/Pages/FormComponent/TypeScript/Types.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/TypeScript/Types.svelte
@@ -1,5 +1,6 @@
 <!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
 <script lang="ts">
+  import type { FormComponentOnSubmitCompleteArguments } from '@inertiajs/core'
   import { createForm } from '@inertiajs/svelte'
 
   interface UserForm {
@@ -8,12 +9,25 @@
   }
 
   const TypedForm = createForm<UserForm>()
+
+  function handleSubmitComplete({ reset }: FormComponentOnSubmitCompleteArguments<UserForm>) {
+    reset('name')
+    reset('email')
+  }
 </script>
 
-<TypedForm method="post" action="/form-component/types" resetOnSuccess={['name', 'email']} resetOnError={['name']}>
+<TypedForm
+  method="post"
+  action="/form-component/types"
+  resetOnSuccess={['name', 'email']}
+  resetOnError={['name']}
+  onSubmitComplete={handleSubmitComplete}
+>
   {#snippet children({ errors, getData, clearErrors, reset })}
-    {errors.name} {errors.email}
-    {getData().name} {getData().email}
+    {errors.name}
+    {errors.email}
+    {getData().name}
+    {getData().email}
     {clearErrors('name', 'email')}
     {reset('name')}
     {reset('email')}

--- a/packages/svelte/test-app/Pages/FormComponent/TypeScript/Types.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/TypeScript/Types.svelte
@@ -1,64 +1,26 @@
 <!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
 <script lang="ts">
-  import type {
-    FormComponentProps,
-    FormComponentSlotProps,
-    FormComponentOnSubmitCompleteArguments,
-  } from '@inertiajs/core'
+  import { createForm } from '@inertiajs/svelte'
 
   interface UserForm {
     name: string
     email: string
   }
 
-  function renderFormContent(props: FormComponentSlotProps<UserForm>) {
-    const { errors, getData, clearErrors } = props
-
-    console.log(errors.name, errors.email)
-
-    const data = getData()
-    console.log(data.name, data.email)
-
-    clearErrors('name', 'email')
-
-    // @ts-expect-error - 'invalid_field' should not be a valid key
-    clearErrors('invalid_field')
-
-    return 'Form content'
-  }
-
-  function handleSubmitComplete(props: FormComponentOnSubmitCompleteArguments<UserForm>) {
-    const { reset, defaults } = props
-
-    reset('name')
-    reset('email')
-
-    // @ts-expect-error - 'invalid_field' should not be a valid key
-    reset('invalid_field')
-
-    defaults()
-  }
-
-  function checkResetProps() {
-    const valid: FormComponentProps<UserForm> = {
-      resetOnSuccess: ['name', 'email'],
-      resetOnError: ['name'],
-    }
-
-    const validBoolean: FormComponentProps<UserForm> = {
-      resetOnSuccess: true,
-      resetOnError: false,
-    }
-
-    const invalid: FormComponentProps<UserForm> = {
-      // @ts-expect-error - 'invalid_field' should not be a valid key
-      resetOnSuccess: ['invalid_field'],
-      // @ts-expect-error - 'another_invalid' should not be a valid key
-      resetOnError: ['another_invalid'],
-    }
-
-    return { valid, validBoolean, invalid }
-  }
+  const TypedForm = createForm<UserForm>()
 </script>
 
-<div>{renderFormContent.toString()}{handleSubmitComplete.toString()}{checkResetProps.toString()}</div>
+<TypedForm method="post" action="/form-component/types" resetOnSuccess={['name', 'email']} resetOnError={['name']}>
+  {#snippet children({ errors, getData, clearErrors, reset })}
+    {errors.name} {errors.email}
+    {getData().name} {getData().email}
+    {clearErrors('name', 'email')}
+    {reset('name')}
+    {reset('email')}
+    <div>Form content</div>
+  {/snippet}
+</TypedForm>
+
+<TypedForm method="post" action="/form-component/types" resetOnSuccess={true} resetOnError={false}>
+  <div>Boolean reset</div>
+</TypedForm>

--- a/packages/svelte/test-app/Pages/FormComponent/TypeScript/Types.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/TypeScript/Types.svelte
@@ -12,8 +12,10 @@
 
 <TypedForm method="post" action="/form-component/types" resetOnSuccess={['name', 'email']} resetOnError={['name']}>
   {#snippet children({ errors, getData, clearErrors, reset })}
-    {errors.name} {errors.email}
-    {getData().name} {getData().email}
+    {errors.name}
+    {errors.email}
+    {getData().name}
+    {getData().email}
     {clearErrors('name', 'email')}
     {reset('name')}
     {reset('email')}

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -404,7 +404,10 @@ export function useFormContext<TForm extends object = Record<string, any>>(): Fo
 
 type TypedFormComponent<TForm extends Record<string, any>> = Omit<typeof Form, 'new'> & {
   new (...args: ConstructorParameters<typeof Form>): Omit<InstanceType<typeof Form>, '$props' | '$slots'> & {
-    $props: Omit<InstanceType<typeof Form>['$props'], 'optimistic' | 'transform' | 'resetOnSuccess' | 'resetOnError'> & {
+    $props: Omit<
+      InstanceType<typeof Form>['$props'],
+      'optimistic' | 'transform' | 'resetOnSuccess' | 'resetOnError'
+    > & {
       optimistic?: FormComponentProps<TForm>['optimistic']
       transform?: FormComponentProps<TForm>['transform']
       resetOnSuccess?: FormComponentProps<TForm>['resetOnSuccess']

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -404,9 +404,11 @@ export function useFormContext<TForm extends object = Record<string, any>>(): Fo
 
 type TypedFormComponent<TForm extends Record<string, any>> = Omit<typeof Form, 'new'> & {
   new (...args: ConstructorParameters<typeof Form>): Omit<InstanceType<typeof Form>, '$props' | '$slots'> & {
-    $props: Omit<InstanceType<typeof Form>['$props'], 'optimistic' | 'transform'> & {
+    $props: Omit<InstanceType<typeof Form>['$props'], 'optimistic' | 'transform' | 'resetOnSuccess' | 'resetOnError'> & {
       optimistic?: FormComponentProps<TForm>['optimistic']
       transform?: FormComponentProps<TForm>['transform']
+      resetOnSuccess?: FormComponentProps<TForm>['resetOnSuccess']
+      resetOnError?: FormComponentProps<TForm>['resetOnError']
     }
     $slots: {
       default: (props: FormComponentSlotProps<TForm>) => any

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -404,11 +404,15 @@ export function useFormContext<TForm extends object = Record<string, any>>(): Fo
 
 type TypedFormComponent<TForm extends Record<string, any>> = Omit<typeof Form, 'new'> & {
   new (...args: ConstructorParameters<typeof Form>): Omit<InstanceType<typeof Form>, '$props' | '$slots'> & {
-    $props: Omit<InstanceType<typeof Form>['$props'], 'optimistic' | 'transform' | 'resetOnSuccess' | 'resetOnError'> & {
+    $props: Omit<
+      InstanceType<typeof Form>['$props'],
+      'optimistic' | 'transform' | 'resetOnSuccess' | 'resetOnError' | 'onSubmitComplete'
+    > & {
       optimistic?: FormComponentProps<TForm>['optimistic']
       transform?: FormComponentProps<TForm>['transform']
       resetOnSuccess?: FormComponentProps<TForm>['resetOnSuccess']
       resetOnError?: FormComponentProps<TForm>['resetOnError']
+      onSubmitComplete?: FormComponentProps<TForm>['onSubmitComplete']
     }
     $slots: {
       default: (props: FormComponentSlotProps<TForm>) => any

--- a/packages/vue3/test-app/Pages/FormComponent/TypeScript/Types.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/TypeScript/Types.vue
@@ -1,62 +1,37 @@
 <!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
 <script setup lang="ts">
-import { FormComponentOnSubmitCompleteArguments, FormComponentProps, FormComponentSlotProps } from '@inertiajs/core'
+import { createForm } from '@inertiajs/vue3'
 
 interface UserForm {
   name: string
   email: string
 }
 
-function renderFormContent(props: FormComponentSlotProps<UserForm>) {
-  const { errors, getData, clearErrors } = props
-
-  console.log(errors.name, errors.email)
-
-  const data = getData()
-  console.log(data.name, data.email)
-
-  clearErrors('name', 'email')
-
-  // @ts-expect-error - 'invalid_field' should not be a valid key
-  clearErrors('invalid_field')
-
-  return 'Form content'
-}
-
-function handleSubmitComplete(props: FormComponentOnSubmitCompleteArguments<UserForm>) {
-  const { reset, defaults } = props
-
-  reset('name')
-  reset('email')
-
-  // @ts-expect-error - 'invalid_field' should not be a valid key
-  reset('invalid_field')
-
-  defaults()
-}
-
-function checkResetProps() {
-  const valid: FormComponentProps<UserForm> = {
-    resetOnSuccess: ['name', 'email'],
-    resetOnError: ['name'],
-  }
-
-  const validBoolean: FormComponentProps<UserForm> = {
-    resetOnSuccess: true,
-    resetOnError: false,
-  }
-
-  const invalid: FormComponentProps<UserForm> = {
-    // @ts-expect-error - 'invalid_field' should not be a valid key
-    resetOnSuccess: ['invalid_field'],
-    // @ts-expect-error - 'another_invalid' should not be a valid key
-    resetOnError: ['another_invalid'],
-  }
-
-  return { valid, validBoolean, invalid }
-}
+const TypedForm = createForm<UserForm>()
 </script>
 
 <template>
-  <div>{{ renderFormContent.toString() }}{{ handleSubmitComplete.toString() }}{{ checkResetProps.toString() }}</div>
+  <div>
+    <TypedForm
+      method="post"
+      action="/form-component/types"
+      :reset-on-success="['name', 'email']"
+      :reset-on-error="['name']"
+    >
+      <template #default="{ errors, getData, clearErrors, reset }">
+        {{ errors.name }} {{ errors.email }}
+        {{ getData().name }} {{ getData().email }}
+        {{ clearErrors('name', 'email') }}
+        {{ reset('name') }}
+        {{ reset('email') }}
+        <div>Form content</div>
+      </template>
+    </TypedForm>
+
+    <TypedForm method="post" action="/form-component/types" :reset-on-success="true" :reset-on-error="false">
+      <template #default>
+        <div>Boolean reset</div>
+      </template>
+    </TypedForm>
+  </div>
 </template>

--- a/packages/vue3/test-app/Pages/FormComponent/TypeScript/Types.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/TypeScript/Types.vue
@@ -19,8 +19,7 @@ const TypedForm = createForm<UserForm>()
       :reset-on-error="['name']"
     >
       <template #default="{ errors, getData, clearErrors, reset }">
-        {{ errors.name }} {{ errors.email }}
-        {{ getData().name }} {{ getData().email }}
+        {{ errors.name }} {{ errors.email }} {{ getData().name }} {{ getData().email }}
         {{ clearErrors('name', 'email') }}
         {{ reset('name') }}
         {{ reset('email') }}

--- a/packages/vue3/test-app/Pages/FormComponent/TypeScript/Types.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/TypeScript/Types.vue
@@ -1,5 +1,6 @@
 <!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
 <script setup lang="ts">
+import type { FormComponentOnSubmitCompleteArguments } from '@inertiajs/core'
 import { createForm } from '@inertiajs/vue3'
 
 interface UserForm {
@@ -8,6 +9,11 @@ interface UserForm {
 }
 
 const TypedForm = createForm<UserForm>()
+
+function handleSubmitComplete({ reset }: FormComponentOnSubmitCompleteArguments<UserForm>) {
+  reset('name')
+  reset('email')
+}
 </script>
 
 <template>
@@ -17,10 +23,10 @@ const TypedForm = createForm<UserForm>()
       action="/form-component/types"
       :reset-on-success="['name', 'email']"
       :reset-on-error="['name']"
+      :on-submit-complete="handleSubmitComplete"
     >
       <template #default="{ errors, getData, clearErrors, reset }">
-        {{ errors.name }} {{ errors.email }}
-        {{ getData().name }} {{ getData().email }}
+        {{ errors.name }} {{ errors.email }} {{ getData().name }} {{ getData().email }}
         {{ clearErrors('name', 'email') }}
         {{ reset('name') }}
         {{ reset('email') }}

--- a/packages/vue3/test-app/Pages/FormComponent/TypeScript/Types.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/TypeScript/Types.vue
@@ -1,6 +1,6 @@
 <!-- This component is used for checking the TypeScript implementation; there is no Playwright test depending on it. -->
 <script setup lang="ts">
-import { FormComponentOnSubmitCompleteArguments, FormComponentSlotProps } from '@inertiajs/core'
+import { FormComponentOnSubmitCompleteArguments, FormComponentProps, FormComponentSlotProps } from '@inertiajs/core'
 
 interface UserForm {
   name: string
@@ -34,8 +34,29 @@ function handleSubmitComplete(props: FormComponentOnSubmitCompleteArguments<User
 
   defaults()
 }
+
+function checkResetProps() {
+  const valid: FormComponentProps<UserForm> = {
+    resetOnSuccess: ['name', 'email'],
+    resetOnError: ['name'],
+  }
+
+  const validBoolean: FormComponentProps<UserForm> = {
+    resetOnSuccess: true,
+    resetOnError: false,
+  }
+
+  const invalid: FormComponentProps<UserForm> = {
+    // @ts-expect-error - 'invalid_field' should not be a valid key
+    resetOnSuccess: ['invalid_field'],
+    // @ts-expect-error - 'another_invalid' should not be a valid key
+    resetOnError: ['another_invalid'],
+  }
+
+  return { valid, validBoolean, invalid }
+}
 </script>
 
 <template>
-  <div>{{ renderFormContent.toString() }}{{ handleSubmitComplete.toString() }}</div>
+  <div>{{ renderFormContent.toString() }}{{ handleSubmitComplete.toString() }}{{ checkResetProps.toString() }}</div>
 </template>


### PR DESCRIPTION
The `resetOnSuccess` and `resetOnError` properties on `FormComponentProps` accepted a generic `string[]`. This PR changes both properties to use `FormDataKeys<TForm>[]` so that only valid form keys are accepted when a typed form generic is provided.

Fixes #3036.