### PR TITLE
[3.x] Add `onHttpException`, `onNetworkError`, and response to `onSuccess` in `useHttp`

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -906,8 +906,10 @@ export type UseHttpOptions<TResponse = unknown> = {
   onBefore?: () => boolean | void
   onStart?: () => void
   onProgress?: (progress: HttpProgressEvent) => void
-  onSuccess?: (response: TResponse) => void
+  onSuccess?: (response: TResponse, httpResponse: HttpResponse) => void
   onError?: (errors: Errors) => void
+  onHttpException?: (response: HttpResponse) => boolean | void
+  onNetworkError?: (error: Error) => boolean | void
   onFinish?: () => void
   onCancel?: () => void
   onCancelToken?: (cancelToken: CancelToken) => void

--- a/packages/react/src/useHttp.ts
+++ b/packages/react/src/useHttp.ts
@@ -250,7 +250,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
             setResponse(responseData)
           }
 
-          options.onSuccess?.(responseData)
+          options.onSuccess?.(responseData, httpResponse)
 
           if (isMounted.current && !defaultsCalledInOnSuccessRef.current) {
             baseForm.setData((data: TForm) => {
@@ -282,6 +282,8 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
             }
 
             options.onError?.(processedErrors as Errors)
+          } else {
+            options.onHttpException?.(error.response)
           }
 
           throw error
@@ -291,6 +293,8 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
           options.onCancel?.()
           throw new HttpCancelledError('Request was cancelled', url)
         }
+
+        options.onNetworkError?.(error instanceof Error ? error : new Error('Unknown error'))
 
         throw error
       } finally {

--- a/packages/react/test-app/Pages/UseHttp/Index.tsx
+++ b/packages/react/test-app/Pages/UseHttp/Index.tsx
@@ -47,12 +47,17 @@ export default () => {
   const slowRequest = useHttp<Record<string, never>, { result: string }>({})
 
   const errorHttp = useHttp<Record<string, never>, never>({})
+  const httpExceptionHttp = useHttp<Record<string, never>, never>({})
+  const networkErrorHttp = useHttp<Record<string, never>, never>({})
 
   const [lastGetResponse, setLastGetResponse] = useState<SearchResponse | null>(null)
   const [lastPostResponse, setLastPostResponse] = useState<UserResponse | null>(null)
   const [lastDeleteResponse, setLastDeleteResponse] = useState<DeleteResponse | null>(null)
   const [cancelledMessage, setCancelledMessage] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
+  const [httpExceptionStatus, setHttpExceptionStatus] = useState<number | null>(null)
+  const [httpExceptionBody, setHttpExceptionBody] = useState('')
+  const [networkErrorMessage, setNetworkErrorMessage] = useState('')
 
   const performSearch = async () => {
     try {
@@ -115,6 +120,34 @@ export default () => {
           setErrorMessage('Server returned 500 error')
         }
       }
+    }
+  }
+
+  const triggerHttpException = async () => {
+    setHttpExceptionStatus(null)
+    setHttpExceptionBody('')
+    try {
+      await httpExceptionHttp.post('/api/error', {
+        onHttpException: (response) => {
+          setHttpExceptionStatus(response.status)
+          setHttpExceptionBody(response.data)
+        },
+      })
+    } catch {
+      // Expected
+    }
+  }
+
+  const triggerNetworkError = async () => {
+    setNetworkErrorMessage('')
+    try {
+      await networkErrorHttp.get('/api/network-error-test', {
+        onNetworkError: (error) => {
+          setNetworkErrorMessage(error.message || 'Network error occurred')
+        },
+      })
+    } catch {
+      // Expected
     }
   }
 
@@ -271,6 +304,25 @@ export default () => {
           Trigger Server Error
         </button>
         {errorMessage && <div id="error-message">{errorMessage}</div>}
+      </section>
+
+      {/* HTTP Exception Callback Test */}
+      <section id="http-exception-test">
+        <h2>HTTP Exception Callback</h2>
+        <button onClick={triggerHttpException} id="http-exception-button">
+          Trigger HTTP Exception
+        </button>
+        {httpExceptionStatus && <div id="http-exception-status">Status: {httpExceptionStatus}</div>}
+        {httpExceptionBody && <div id="http-exception-body">Body: {httpExceptionBody}</div>}
+      </section>
+
+      {/* Network Error Callback Test */}
+      <section id="network-error-test">
+        <h2>Network Error Callback</h2>
+        <button onClick={triggerNetworkError} id="network-error-button">
+          Trigger Network Error
+        </button>
+        {networkErrorMessage && <div id="network-error-message">{networkErrorMessage}</div>}
       </section>
 
       {/* Reset Test */}

--- a/packages/svelte/src/useHttp.svelte.ts
+++ b/packages/svelte/src/useHttp.svelte.ts
@@ -229,7 +229,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
         markAsSuccessful()
         setFormState('response', responseData)
 
-        options.onSuccess?.(responseData)
+        options.onSuccess?.(responseData, response)
 
         if (!wasDefaultsCalledInOnSuccess()) {
           setDefaults(cloneDeep(form.data()))
@@ -258,6 +258,8 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
 
           form.clearErrors().setError(processedErrors)
           options.onError?.(processedErrors as Errors)
+        } else {
+          options.onHttpException?.(error.response)
         }
 
         throw error
@@ -267,6 +269,8 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
         options.onCancel?.()
         throw new HttpCancelledError('Request was cancelled', url)
       }
+
+      options.onNetworkError?.(error instanceof Error ? error : new Error('Unknown error'))
 
       throw error
     } finally {

--- a/packages/svelte/test-app/Pages/UseHttp/Index.svelte
+++ b/packages/svelte/test-app/Pages/UseHttp/Index.svelte
@@ -46,12 +46,17 @@
   const slowRequest = useHttp<Record<string, never>, { result: string }>({})
 
   const errorHttp = useHttp<Record<string, never>, never>({})
+  const httpExceptionHttp = useHttp<Record<string, never>, never>({})
+  const networkErrorHttp = useHttp<Record<string, never>, never>({})
 
   let lastGetResponse: SearchResponse | null = $state(null)
   let lastPostResponse: UserResponse | null = $state(null)
   let lastDeleteResponse: DeleteResponse | null = $state(null)
   let cancelledMessage = $state('')
   let errorMessage = $state('')
+  let httpExceptionStatus: number | null = $state(null)
+  let httpExceptionBody = $state('')
+  let networkErrorMessage = $state('')
 
   const performSearch = async () => {
     try {
@@ -114,6 +119,34 @@
           errorMessage = 'Server returned 500 error'
         }
       }
+    }
+  }
+
+  const triggerHttpException = async () => {
+    httpExceptionStatus = null
+    httpExceptionBody = ''
+    try {
+      await httpExceptionHttp.post('/api/error', {
+        onHttpException: (response) => {
+          httpExceptionStatus = response.status
+          httpExceptionBody = response.data
+        },
+      })
+    } catch {
+      // Expected
+    }
+  }
+
+  const triggerNetworkError = async () => {
+    networkErrorMessage = ''
+    try {
+      await networkErrorHttp.get('/api/network-error-test', {
+        onNetworkError: (error) => {
+          networkErrorMessage = error.message || 'Network error occurred'
+        },
+      })
+    } catch {
+      // Expected
     }
   }
 </script>
@@ -245,6 +278,27 @@
     <button onclick={triggerServerError} id="error-button">Trigger Server Error</button>
     {#if errorMessage}
       <div id="error-message">{errorMessage}</div>
+    {/if}
+  </section>
+
+  <!-- HTTP Exception Callback Test -->
+  <section id="http-exception-test">
+    <h2>HTTP Exception Callback</h2>
+    <button onclick={triggerHttpException} id="http-exception-button">Trigger HTTP Exception</button>
+    {#if httpExceptionStatus}
+      <div id="http-exception-status">Status: {httpExceptionStatus}</div>
+    {/if}
+    {#if httpExceptionBody}
+      <div id="http-exception-body">Body: {httpExceptionBody}</div>
+    {/if}
+  </section>
+
+  <!-- Network Error Callback Test -->
+  <section id="network-error-test">
+    <h2>Network Error Callback</h2>
+    <button onclick={triggerNetworkError} id="network-error-button">Trigger Network Error</button>
+    {#if networkErrorMessage}
+      <div id="network-error-message">{networkErrorMessage}</div>
     {/if}
   </section>
 

--- a/packages/vue3/src/useHttp.ts
+++ b/packages/vue3/src/useHttp.ts
@@ -230,7 +230,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
         markAsSuccessful()
         ;(form as any).response = responseData
 
-        options.onSuccess?.(responseData)
+        options.onSuccess?.(responseData, response)
 
         if (!wasDefaultsCalledInOnSuccess()) {
           setDefaults(cloneDeep(form.data()))
@@ -259,6 +259,8 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
 
           form.clearErrors().setError(processedErrors)
           options.onError?.(processedErrors as Errors)
+        } else {
+          options.onHttpException?.(error.response)
         }
 
         throw error
@@ -268,6 +270,8 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
         options.onCancel?.()
         throw new HttpCancelledError('Request was cancelled', url)
       }
+
+      options.onNetworkError?.(error instanceof Error ? error : new Error('Unknown error'))
 
       throw error
     } finally {

--- a/packages/vue3/test-app/Pages/UseHttp/Index.vue
+++ b/packages/vue3/test-app/Pages/UseHttp/Index.vue
@@ -47,12 +47,17 @@ const deleteUser = useHttp<{ userId: number }, DeleteResponse>({
 const slowRequest = useHttp<Record<string, never>, { result: string }>({})
 
 const errorHttp = useHttp<Record<string, never>, never>({})
+const httpExceptionHttp = useHttp<Record<string, never>, never>({})
+const networkErrorHttp = useHttp<Record<string, never>, never>({})
 
 const lastGetResponse = ref<SearchResponse | null>(null)
 const lastPostResponse = ref<UserResponse | null>(null)
 const lastDeleteResponse = ref<DeleteResponse | null>(null)
 const cancelledMessage = ref('')
 const errorMessage = ref('')
+const httpExceptionStatus = ref<number | null>(null)
+const httpExceptionBody = ref('')
+const networkErrorMessage = ref('')
 
 const performSearch = async () => {
   try {
@@ -115,6 +120,34 @@ const triggerServerError = async () => {
         errorMessage.value = 'Server returned 500 error'
       }
     }
+  }
+}
+
+const triggerHttpException = async () => {
+  httpExceptionStatus.value = null
+  httpExceptionBody.value = ''
+  try {
+    await httpExceptionHttp.post('/api/error', {
+      onHttpException: (response) => {
+        httpExceptionStatus.value = response.status
+        httpExceptionBody.value = response.data
+      },
+    })
+  } catch {
+    // Expected
+  }
+}
+
+const triggerNetworkError = async () => {
+  networkErrorMessage.value = ''
+  try {
+    await networkErrorHttp.get('/api/network-error-test', {
+      onNetworkError: (error) => {
+        networkErrorMessage.value = error.message || 'Network error occurred'
+      },
+    })
+  } catch {
+    // Expected
   }
 }
 </script>
@@ -220,6 +253,21 @@ const triggerServerError = async () => {
       <h2>Server Error (500)</h2>
       <button @click="triggerServerError" id="error-button">Trigger Server Error</button>
       <div v-if="errorMessage" id="error-message">{{ errorMessage }}</div>
+    </section>
+
+    <!-- HTTP Exception Callback Test -->
+    <section id="http-exception-test">
+      <h2>HTTP Exception Callback</h2>
+      <button @click="triggerHttpException" id="http-exception-button">Trigger HTTP Exception</button>
+      <div v-if="httpExceptionStatus" id="http-exception-status">Status: {{ httpExceptionStatus }}</div>
+      <div v-if="httpExceptionBody" id="http-exception-body">Body: {{ httpExceptionBody }}</div>
+    </section>
+
+    <!-- Network Error Callback Test -->
+    <section id="network-error-test">
+      <h2>Network Error Callback</h2>
+      <button @click="triggerNetworkError" id="network-error-button">Trigger Network Error</button>
+      <div v-if="networkErrorMessage" id="network-error-message">{{ networkErrorMessage }}</div>
     </section>
 
     <!-- Reset Test -->

--- a/tests/use-http.spec.ts
+++ b/tests/use-http.spec.ts
@@ -130,6 +130,25 @@ test.describe('useHttp', () => {
     await expect(page.locator('#error-message')).toContainText('Server returned 500 error')
   })
 
+  test('it fires the onHttpException callback for non-422 errors', async ({ page }) => {
+    await page.goto('/use-http')
+
+    await page.click('#http-exception-button')
+
+    await expect(page.locator('#http-exception-status')).toContainText('Status: 500')
+    await expect(page.locator('#http-exception-body')).toContainText('Internal server error')
+  })
+
+  test('it fires the onNetworkError callback on network failure', async ({ page }) => {
+    await page.goto('/use-http')
+
+    await page.route('**/api/network-error-test', (route) => route.abort('failed'))
+
+    await page.click('#network-error-button')
+
+    await expect(page.locator('#network-error-message')).toBeVisible()
+  })
+
   test('it resets form to defaults', async ({ page }) => {
     await page.goto('/use-http')
 


### PR DESCRIPTION
The `useHttp` hook was missing the `onHttpException` and `onNetworkError` callbacks that are available on regular Inertia visits. Non-422 error responses were thrown as `HttpResponseError` with no callback, forcing users to manually catch and parse errors via try/catch. Network failures were similarly unhandled.

It also passes the raw `HttpResponse` as a second argument to `onSuccess`, so users can inspect the status code to differentiate between 200 and 204 responses.

Fixes #3039.