### PR TITLE
[3.x] Fix arrow function components assigned directly to Page.layout

### DIFF
--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -71,6 +71,43 @@ function containsRef(result: unknown, target: unknown): boolean {
   return false
 }
 
+type LayoutType = 'render-fn' | 'component' | 'resolver'
+
+const layoutTypeCache = new WeakMap<Function, LayoutType>()
+
+export function classifyLayout(component: ReactComponent): void {
+  const fn = component.layout
+
+  if (!fn || !isLayoutResolver(fn as Function) || layoutTypeCache.has(fn as Function)) {
+    return
+  }
+
+  const probe = createElement('div')
+
+  try {
+    const probeResult = (fn as Function)(probe)
+
+    if (isValidElement(probeResult) && containsRef(probeResult, probe)) {
+      layoutTypeCache.set(fn as Function, 'render-fn')
+      return
+    }
+
+    if (isValidElement(probeResult)) {
+      layoutTypeCache.set(fn as Function, 'component')
+      return
+    }
+
+    // Not a React element — could be resolver or zero-arg component returning null.
+    // Call with empty props to distinguish: components return React elements, resolvers return plain objects.
+    const resolverProbeResult = (fn as Function)({})
+    layoutTypeCache.set(fn as Function, isValidElement(resolverProbeResult) ? 'component' : 'resolver')
+  } catch {
+    // Probe threw — layout function uses hooks which are only valid inside a React render.
+    // That means it's an arrow function component, not a render function.
+    layoutTypeCache.set(fn as Function, 'component')
+  }
+}
+
 let currentIsInitialPage = true
 let routerIsInitialized = false
 let swapComponent: PageHandler<ReactComponent> = async () => {
@@ -153,6 +190,8 @@ export default function App<SharedProps extends PageProps = PageProps>({
         return
       }
 
+      classifyLayout(component)
+
       if (!preserveState) {
         resetLayoutProps()
       }
@@ -187,21 +226,25 @@ export default function App<SharedProps extends PageProps = PageProps>({
       const layoutValue = Component.layout
 
       if (isLayoutResolver(layoutValue)) {
-        const renderResult = (layoutValue as LayoutFunction)(child)
+        const layoutType = layoutTypeCache.get(layoutValue as Function)
 
-        if (isValidElement(renderResult) && containsRef(renderResult, child)) {
-          return renderResult
+        if (layoutType === 'render-fn') {
+          return (layoutValue as LayoutFunction)(child)
         }
 
-        const resolverResult = (layoutValue as Function)(props)
-
-        if (isValidElement(resolverResult)) {
+        if (layoutType === 'component') {
           effectiveLayout = [layoutValue]
-        } else if (isPropsObjectOrCallback(resolverResult, isComponent)) {
-          effectiveLayout = defaultLayout?.(current.page.component, current.page)
-          callbackProps = resolverResult as Record<string, unknown>
         } else {
-          effectiveLayout = resolverResult
+          const resolverResult = (layoutValue as Function)(props)
+
+          if (isValidElement(resolverResult)) {
+            effectiveLayout = [layoutValue]
+          } else if (isPropsObjectOrCallback(resolverResult, isComponent)) {
+            effectiveLayout = defaultLayout?.(current.page.component, current.page)
+            callbackProps = resolverResult as Record<string, unknown>
+          } else {
+            effectiveLayout = resolverResult
+          }
         }
       } else if (isPropsObject(layoutValue, isComponent)) {
         effectiveLayout = defaultLayout?.(current.page.component, current.page)

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -47,6 +47,30 @@ function isLayoutResolver(value: unknown): boolean {
   )
 }
 
+function containsRef(result: unknown, target: unknown): boolean {
+  if (result === target) {
+    return true
+  }
+
+  let node: unknown = result
+
+  while (isValidElement(node)) {
+    const { children } = (node as any).props ?? {}
+
+    if (children === target) {
+      return true
+    }
+
+    if (Array.isArray(children)) {
+      return children.includes(target)
+    }
+
+    node = children
+  }
+
+  return false
+}
+
 let currentIsInitialPage = true
 let routerIsInitialized = false
 let swapComponent: PageHandler<ReactComponent> = async () => {
@@ -163,17 +187,21 @@ export default function App<SharedProps extends PageProps = PageProps>({
       const layoutValue = Component.layout
 
       if (isLayoutResolver(layoutValue)) {
-        const result = (layoutValue as Function)(props)
+        const renderResult = (layoutValue as LayoutFunction)(child)
 
-        if (isValidElement(result)) {
-          return (layoutValue as LayoutFunction)(child)
+        if (isValidElement(renderResult) && containsRef(renderResult, child)) {
+          return renderResult
         }
 
-        if (isPropsObjectOrCallback(result, isComponent)) {
+        const resolverResult = (layoutValue as Function)(props)
+
+        if (isValidElement(resolverResult)) {
+          effectiveLayout = [layoutValue]
+        } else if (isPropsObjectOrCallback(resolverResult, isComponent)) {
           effectiveLayout = defaultLayout?.(current.page.component, current.page)
-          callbackProps = result as Record<string, unknown>
+          callbackProps = resolverResult as Record<string, unknown>
         } else {
-          effectiveLayout = result
+          effectiveLayout = resolverResult
         }
       } else if (isPropsObject(layoutValue, isComponent)) {
         effectiveLayout = defaultLayout?.(current.page.component, current.page)

--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -15,7 +15,7 @@ import {
 import { createElement, ReactElement, StrictMode } from 'react'
 import { createRoot, hydrateRoot } from 'react-dom/client'
 import { renderToString } from 'react-dom/server'
-import App, { InertiaAppProps, type InertiaApp } from './App'
+import App, { classifyLayout, InertiaAppProps, type InertiaApp } from './App'
 import { config } from './index'
 import { ReactComponent, ReactInertiaAppConfig } from './types'
 
@@ -132,6 +132,8 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
       const initialComponent = await resolveComponent(page.component, page)
 
+      classifyLayout(initialComponent)
+
       const props: InertiaAppProps<SharedProps> = {
         initialPage: page,
         initialComponent,
@@ -172,6 +174,8 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     resolveComponent(initialPage.component, initialPage),
     router.decryptHistory().catch(() => {}),
   ]).then(([initialComponent]) => {
+    classifyLayout(initialComponent)
+
     const props: InertiaAppProps<SharedProps> = {
       initialPage,
       initialComponent,

--- a/packages/react/test-app/Pages/DefaultLayout/WithArrowFunctionLayout.tsx
+++ b/packages/react/test-app/Pages/DefaultLayout/WithArrowFunctionLayout.tsx
@@ -1,0 +1,15 @@
+import PageLayout from '@/Layouts/PageLayout'
+import { Link } from '@inertiajs/react'
+
+const WithArrowFunctionLayout = () => {
+  return (
+    <div>
+      <span id="text">DefaultLayout/WithArrowFunctionLayout</span>
+      <Link href="/default-layout">Back to Index</Link>
+    </div>
+  )
+}
+
+WithArrowFunctionLayout.layout = PageLayout
+
+export default WithArrowFunctionLayout

--- a/packages/react/test-app/Pages/DefaultLayout/WithHookLayout.tsx
+++ b/packages/react/test-app/Pages/DefaultLayout/WithHookLayout.tsx
@@ -1,0 +1,24 @@
+import { Link } from '@inertiajs/react'
+import { useId } from 'react'
+
+const HookLayout = ({ children }: { children: React.ReactNode }) => {
+  const id = useId()
+
+  return (
+    <div id="hook-layout" data-layout-id={id}>
+      <span>Hook Layout</span>
+      {children}
+    </div>
+  )
+}
+
+const WithHookLayout = () => (
+  <div>
+    <span id="text">DefaultLayout/WithHookLayout</span>
+    <Link href="/default-layout">Navigate Away</Link>
+  </div>
+)
+
+WithHookLayout.layout = HookLayout
+
+export default WithHookLayout

--- a/packages/react/test-app/Pages/DefaultLayout/WithNestedSiblingRenderFunction.tsx
+++ b/packages/react/test-app/Pages/DefaultLayout/WithNestedSiblingRenderFunction.tsx
@@ -1,0 +1,19 @@
+import { Link } from '@inertiajs/react'
+
+const WithNestedSiblingRenderFunction = () => (
+  <div>
+    <span id="text">DefaultLayout/WithNestedSiblingRenderFunction</span>
+    <Link href="/default-layout">Back to Index</Link>
+  </div>
+)
+
+WithNestedSiblingRenderFunction.layout = (page: React.ReactNode) => (
+  <div id="outer-layout">
+    <div id="inner-layout">
+      <span id="layout-sibling">Sibling</span>
+      {page}
+    </div>
+  </div>
+)
+
+export default WithNestedSiblingRenderFunction

--- a/packages/react/test-app/Pages/DefaultLayout/WithPassthroughRenderFunction.tsx
+++ b/packages/react/test-app/Pages/DefaultLayout/WithPassthroughRenderFunction.tsx
@@ -1,0 +1,12 @@
+import { Link } from '@inertiajs/react'
+
+const WithPassthroughRenderFunction = () => (
+  <div>
+    <span id="text">DefaultLayout/WithPassthroughRenderFunction</span>
+    <Link href="/default-layout">Back to Index</Link>
+  </div>
+)
+
+WithPassthroughRenderFunction.layout = (page: React.ReactNode) => page
+
+export default WithPassthroughRenderFunction

--- a/packages/react/test-app/Pages/DefaultLayout/WithSiblingRenderFunction.tsx
+++ b/packages/react/test-app/Pages/DefaultLayout/WithSiblingRenderFunction.tsx
@@ -1,0 +1,17 @@
+import { Link } from '@inertiajs/react'
+
+const WithSiblingRenderFunction = () => (
+  <div>
+    <span id="text">DefaultLayout/WithSiblingRenderFunction</span>
+    <Link href="/default-layout">Back to Index</Link>
+  </div>
+)
+
+WithSiblingRenderFunction.layout = (page: React.ReactNode) => (
+  <div id="render-layout">
+    <span id="layout-sibling">Sibling</span>
+    {page}
+  </div>
+)
+
+export default WithSiblingRenderFunction

--- a/tests/default-layout.spec.ts
+++ b/tests/default-layout.spec.ts
@@ -36,16 +36,6 @@ test('it applies the default layout after navigating to a page without its own l
   await expect(page.locator('#page-layout')).not.toBeVisible()
 })
 
-test('it supports anonymous arrow functions as layout components', async ({ page }) => {
-  test.skip(process.env.PACKAGE !== 'react', 'React-only test')
-
-  await page.goto('/default-layout?withAnonymousDefaultLayout')
-
-  await expect(page.locator('#default-layout')).toBeVisible()
-  await expect(page.getByText('Default Layout')).toBeVisible()
-  await expect(page.locator('#text')).toHaveText('DefaultLayout/Index')
-})
-
 test('it supports a callback that conditionally returns a layout', async ({ page }) => {
   await page.goto('/default-layout?withDefaultLayoutCallback')
 
@@ -56,4 +46,47 @@ test('it supports a callback that conditionally returns a layout', async ({ page
   await expect(page.locator('#text')).toHaveText('DefaultLayout/CallbackExcluded')
 
   await expect(page.locator('#default-layout')).not.toBeVisible()
+})
+
+test.describe('react layouts', () => {
+  test.skip(process.env.PACKAGE !== 'react', 'React-only test')
+
+  test('it supports anonymous arrow functions as layout components', async ({ page }) => {
+    await page.goto('/default-layout?withAnonymousDefaultLayout')
+
+    await expect(page.locator('#default-layout')).toBeVisible()
+    await expect(page.getByText('Default Layout')).toBeVisible()
+    await expect(page.locator('#text')).toHaveText('DefaultLayout/Index')
+  })
+
+  test('it renders arrow function components assigned directly to Page.layout', async ({ page }) => {
+    await page.goto('/default-layout/with-arrow-function-layout')
+
+    await expect(page.locator('#page-layout')).toBeVisible()
+    await expect(page.getByText('Page Layout')).toBeVisible()
+    await expect(page.locator('#text')).toHaveText('DefaultLayout/WithArrowFunctionLayout')
+  })
+
+  test('it supports render functions with sibling elements at depth 1', async ({ page }) => {
+    await page.goto('/default-layout/with-sibling-render-function')
+
+    await expect(page.locator('#render-layout')).toBeVisible()
+    await expect(page.locator('#layout-sibling')).toBeVisible()
+    await expect(page.locator('#text')).toHaveText('DefaultLayout/WithSiblingRenderFunction')
+  })
+
+  test('it supports render functions with sibling elements nested at depth 2', async ({ page }) => {
+    await page.goto('/default-layout/with-nested-sibling-render-function')
+
+    await expect(page.locator('#outer-layout')).toBeVisible()
+    await expect(page.locator('#inner-layout')).toBeVisible()
+    await expect(page.locator('#layout-sibling')).toBeVisible()
+    await expect(page.locator('#text')).toHaveText('DefaultLayout/WithNestedSiblingRenderFunction')
+  })
+
+  test('it supports render functions that return the page directly', async ({ page }) => {
+    await page.goto('/default-layout/with-passthrough-render-function')
+
+    await expect(page.locator('#text')).toHaveText('DefaultLayout/WithPassthroughRenderFunction')
+  })
 })

--- a/tests/default-layout.spec.ts
+++ b/tests/default-layout.spec.ts
@@ -51,6 +51,22 @@ test('it supports a callback that conditionally returns a layout', async ({ page
 test.describe('react layouts', () => {
   test.skip(process.env.PACKAGE !== 'react', 'React-only test')
 
+  test('it renders arrow function components with hooks and survives navigation away', async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (err) => errors.push(err.message))
+
+    await page.goto('/default-layout/with-hook-layout')
+
+    await expect(page.locator('#hook-layout')).toBeVisible()
+    await expect(page.getByText('Hook Layout')).toBeVisible()
+    await expect(page.locator('#text')).toHaveText('DefaultLayout/WithHookLayout')
+
+    await page.getByRole('link', { name: 'Navigate Away' }).click()
+    await expect(page.locator('#text')).toHaveText('DefaultLayout/Index')
+
+    expect(errors).toHaveLength(0)
+  })
+
   test('it supports anonymous arrow functions as layout components', async ({ page }) => {
     await page.goto('/default-layout?withAnonymousDefaultLayout')
 


### PR DESCRIPTION
In the React adapter, assigning an arrow function component directly to `Page.layout` caused the layout to render as an empty shell. This was a regression for users upgrading from Inertia v2, where the render function pattern `page => <Layout>{page}</Layout>` is common. This PR fixes the detection logic in `App.ts`.

Fixes #3056.