### PR TITLE
[3.x] Add `renderLayout()` for React render function layouts 

### DIFF
--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -79,6 +79,18 @@ const emptySnapshot = {
   named: {} as Record<string, Record<string, unknown>>,
 }
 
+const RENDER_FN_MARKER = Symbol('inertia.renderFn')
+
+type RenderLayoutResult = { readonly fn: LayoutFunction; readonly [RENDER_FN_MARKER]: true }
+
+export function renderLayout(fn: LayoutFunction): RenderLayoutResult {
+  return { fn, [RENDER_FN_MARKER]: true }
+}
+
+function isRenderLayoutResult(value: unknown): value is RenderLayoutResult {
+  return typeof value === 'object' && value !== null && (value as any)[RENDER_FN_MARKER] === true
+}
+
 export default function App<SharedProps extends PageProps = PageProps>({
   children,
   initialPage,
@@ -162,7 +174,9 @@ export default function App<SharedProps extends PageProps = PageProps>({
       let callbackProps: Record<string, unknown> | null = null
       const layoutValue = Component.layout
 
-      if (isLayoutResolver(layoutValue)) {
+      if (isRenderLayoutResult(layoutValue)) {
+        return layoutValue.fn(child)
+      } else if (isLayoutResolver(layoutValue)) {
         const result = (layoutValue as Function)(props)
 
         if (isValidElement(result)) {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,7 +2,7 @@ import { config as coreConfig } from '@inertiajs/core'
 import type { ReactInertiaAppConfig } from './types'
 
 export { http, progress, router } from '@inertiajs/core'
-export { default as App } from './App'
+export { default as App, renderLayout } from './App'
 export { default as createInertiaApp } from './createInertiaApp'
 export { default as Deferred } from './Deferred'
 export { default as Form, useFormContext } from './Form'

--- a/packages/react/test-app/Pages/DefaultLayout/WithArrowComponentLayout.tsx
+++ b/packages/react/test-app/Pages/DefaultLayout/WithArrowComponentLayout.tsx
@@ -1,0 +1,19 @@
+import { Link, renderLayout } from '@inertiajs/react'
+
+const ArrowLayout = ({ children }: { children: React.ReactNode }) => (
+  <div id="arrow-layout">
+    <span>Arrow Layout</span>
+    {children}
+  </div>
+)
+
+const WithArrowComponentLayout = () => (
+  <div>
+    <span id="text">DefaultLayout/WithArrowComponentLayout</span>
+    <Link href="/default-layout">Back to Index</Link>
+  </div>
+)
+
+WithArrowComponentLayout.layout = renderLayout((page) => <ArrowLayout>{page}</ArrowLayout>)
+
+export default WithArrowComponentLayout

--- a/packages/react/test-app/Pages/DefaultLayout/WithRenderLayout.tsx
+++ b/packages/react/test-app/Pages/DefaultLayout/WithRenderLayout.tsx
@@ -1,0 +1,13 @@
+import { Link, renderLayout } from '@inertiajs/react'
+import PageLayout from '@/Layouts/PageLayout'
+
+const WithRenderLayout = () => (
+  <div>
+    <span id="text">DefaultLayout/WithRenderLayout</span>
+    <Link href="/default-layout">Back to Index</Link>
+  </div>
+)
+
+WithRenderLayout.layout = renderLayout((page) => <PageLayout>{page}</PageLayout>)
+
+export default WithRenderLayout

--- a/packages/react/test-app/Pages/DefaultLayout/WithRenderLayout.tsx
+++ b/packages/react/test-app/Pages/DefaultLayout/WithRenderLayout.tsx
@@ -1,5 +1,5 @@
-import { Link, renderLayout } from '@inertiajs/react'
 import PageLayout from '@/Layouts/PageLayout'
+import { Link, renderLayout } from '@inertiajs/react'
 
 const WithRenderLayout = () => (
   <div>

--- a/packages/react/test-app/Pages/DefaultLayout/WithRenderLayoutPageProps.tsx
+++ b/packages/react/test-app/Pages/DefaultLayout/WithRenderLayoutPageProps.tsx
@@ -7,11 +7,15 @@ const WithRenderLayoutPageProps = ({ title }: { title: string }) => (
   </div>
 )
 
-WithRenderLayoutPageProps.layout = renderLayout((page: React.ReactElement<{ title: string }>) => (
-  <div id="props-layout" data-title={page.props.title}>
-    <span id="layout-title">{page.props.title}</span>
-    {page}
-  </div>
-))
+WithRenderLayoutPageProps.layout = renderLayout((page) => {
+  const { title } = (page as React.ReactElement<{ title: string }>).props
+
+  return (
+    <div id="props-layout" data-title={title}>
+      <span id="layout-title">{title}</span>
+      {page}
+    </div>
+  )
+})
 
 export default WithRenderLayoutPageProps

--- a/packages/react/test-app/Pages/DefaultLayout/WithRenderLayoutPageProps.tsx
+++ b/packages/react/test-app/Pages/DefaultLayout/WithRenderLayoutPageProps.tsx
@@ -1,0 +1,17 @@
+import { Link, renderLayout } from '@inertiajs/react'
+
+const WithRenderLayoutPageProps = ({ title }: { title: string }) => (
+  <div>
+    <span id="text">DefaultLayout/WithRenderLayoutPageProps</span>
+    <Link href="/default-layout">Back to Index</Link>
+  </div>
+)
+
+WithRenderLayoutPageProps.layout = renderLayout((page: React.ReactElement<{ title: string }>) => (
+  <div id="props-layout" data-title={page.props.title}>
+    <span id="layout-title">{page.props.title}</span>
+    {page}
+  </div>
+))
+
+export default WithRenderLayoutPageProps

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -889,7 +889,10 @@ app.get('/persistent-layouts/shorthand/nested/page-a', (req, res) =>
 
 app.get('/default-layout', (req, res) => inertia.render(req, res, { component: 'DefaultLayout/Index' }))
 app.get('/default-layout/with-render-layout-page-props', (req, res) =>
-  inertia.render(req, res, { component: 'DefaultLayout/WithRenderLayoutPageProps', props: { title: 'Hello from Props' } }),
+  inertia.render(req, res, {
+    component: 'DefaultLayout/WithRenderLayoutPageProps',
+    props: { title: 'Hello from Props' },
+  }),
 )
 app.get('/layout-props/callback', (req, res) => inertia.render(req, res, { props: { userName: 'Jane' } }))
 app.get('/layout-props/callback-default', (req, res) => inertia.render(req, res, { props: { userName: 'Jane' } }))

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -888,6 +888,9 @@ app.get('/persistent-layouts/shorthand/nested/page-a', (req, res) =>
 )
 
 app.get('/default-layout', (req, res) => inertia.render(req, res, { component: 'DefaultLayout/Index' }))
+app.get('/default-layout/with-render-layout-page-props', (req, res) =>
+  inertia.render(req, res, { component: 'DefaultLayout/WithRenderLayoutPageProps', props: { title: 'Hello from Props' } }),
+)
 app.get('/layout-props/callback', (req, res) => inertia.render(req, res, { props: { userName: 'Jane' } }))
 app.get('/layout-props/callback-default', (req, res) => inertia.render(req, res, { props: { userName: 'Jane' } }))
 app.get('/layout-props/callback-static', (req, res) => inertia.render(req, res))

--- a/tests/default-layout.spec.ts
+++ b/tests/default-layout.spec.ts
@@ -46,6 +46,35 @@ test('it supports anonymous arrow functions as layout components', async ({ page
   await expect(page.locator('#text')).toHaveText('DefaultLayout/Index')
 })
 
+test.describe('react layouts', () => {
+  test.skip(process.env.PACKAGE !== 'react', 'React-only')
+
+  test('it renders arrow function components assigned directly to Page.layout', async ({ page }) => {
+    await page.goto('/default-layout/with-arrow-component-layout')
+
+    await expect(page.locator('#arrow-layout')).toBeVisible()
+    await expect(page.getByText('Arrow Layout')).toBeVisible()
+    await expect(page.locator('#text')).toHaveText('DefaultLayout/WithArrowComponentLayout')
+  })
+
+  test('it supports renderLayout() for arrow function render functions', async ({ page }) => {
+    await page.goto('/default-layout/with-render-layout')
+
+    await expect(page.locator('#page-layout')).toBeVisible()
+    await expect(page.getByText('Page Layout')).toBeVisible()
+    await expect(page.locator('#text')).toHaveText('DefaultLayout/WithRenderLayout')
+  })
+
+  test('it supports renderLayout() with page.props access', async ({ page }) => {
+    await page.goto('/default-layout/with-render-layout-page-props')
+
+    await expect(page.locator('#props-layout')).toBeVisible()
+    await expect(page.locator('#props-layout')).toHaveAttribute('data-title', 'Hello from Props')
+    await expect(page.locator('#layout-title')).toHaveText('Hello from Props')
+    await expect(page.locator('#text')).toHaveText('DefaultLayout/WithRenderLayoutPageProps')
+  })
+})
+
 test('it supports a callback that conditionally returns a layout', async ({ page }) => {
   await page.goto('/default-layout?withDefaultLayoutCallback')
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
