### PR TITLE
[3.x] Add `rescue` slot to `<Deferred>` for failed deferred props

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,7 @@ export {
   type LayoutPropsStore,
 } from './layout'
 export { shouldIntercept, shouldNavigate } from './navigationEvents'
-export { isPathOrSubPath, visitReloadsProp, visitReloadsProps } from './partialReload'
+export { isPathOrSubPath, partialReloadRequestsProp, partialReloadRequestsSomeProps } from './partialReload'
 export { progress, default as setupProgress } from './progress'
 export { FormComponentResetSymbol, resetFormFields } from './resetFormFields'
 export { buildSSRBody } from './ssrUtils'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,7 @@ export {
   type LayoutPropsStore,
 } from './layout'
 export { shouldIntercept, shouldNavigate } from './navigationEvents'
-export { anyPathIsReloaded, isSameOrSubPath, pathIsReloaded } from './partialReload'
+export { isPathOrSubPath, visitReloadsProp, visitReloadsProps } from './partialReload'
 export { progress, default as setupProgress } from './progress'
 export { FormComponentResetSymbol, resetFormFields } from './resetFormFields'
 export { buildSSRBody } from './ssrUtils'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export {
   type LayoutPropsStore,
 } from './layout'
 export { shouldIntercept, shouldNavigate } from './navigationEvents'
+export { anyPathIsReloaded, isSameOrSubPath, pathIsReloaded } from './partialReload'
 export { progress, default as setupProgress } from './progress'
 export { FormComponentResetSymbol, resetFormFields } from './resetFormFields'
 export { buildSSRBody } from './ssrUtils'

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -32,7 +32,7 @@ class CurrentPage {
     resolveComponent,
     onFlash,
   }: RouterInitParams<ComponentType>) {
-    this.page = { ...initialPage, flash: initialPage.flash ?? {} }
+    this.page = { ...initialPage, flash: initialPage.flash ?? {}, rescuedProps: initialPage.rescuedProps ?? [] }
     this.swapComponent = swapComponent
     this.resolveComponent = resolveComponent
     this.onFlashCallback = onFlash

--- a/packages/core/src/partialReload.ts
+++ b/packages/core/src/partialReload.ts
@@ -1,23 +1,35 @@
-export const isSameOrSubPath = (path: string, candidate: string): boolean => {
+import { ActiveVisit } from './types'
+
+type VisitFilter = Pick<ActiveVisit, 'only' | 'except'>
+
+export const isPathOrSubPath = (path: string, candidate: string): boolean => {
   return path === candidate || path.startsWith(`${candidate}.`)
 }
 
-export const pathIsReloaded = (path: string, only: string[], except: string[]): boolean => {
-  if (only.length > 0) {
-    return only.some((candidate) => isSameOrSubPath(path, candidate))
+export const visitReloadsProp = (visit: VisitFilter, prop: string): boolean => {
+  const { only, except } = visit
+
+  if (only.length === 0 && except.length === 0) {
+    return false
   }
 
-  if (except.length > 0) {
-    return !except.some((candidate) => isSameOrSubPath(path, candidate))
+  if (only.length > 0 && !only.some((candidate) => isPathOrSubPath(prop, candidate))) {
+    return false
   }
 
-  return false
+  if (except.length > 0 && except.some((candidate) => isPathOrSubPath(prop, candidate))) {
+    return false
+  }
+
+  return true
 }
 
-export const anyPathIsReloaded = (paths: string[], only: string[], except: string[]): boolean => {
+export const visitReloadsProps = (visit: VisitFilter, props: string[]): boolean => {
+  const { only, except } = visit
+
   if (only.length === 0 && except.length === 0) {
     return true
   }
 
-  return paths.some((path) => pathIsReloaded(path, only, except))
+  return props.some((prop) => visitReloadsProp(visit, prop))
 }

--- a/packages/core/src/partialReload.ts
+++ b/packages/core/src/partialReload.ts
@@ -1,0 +1,23 @@
+export const isSameOrSubPath = (path: string, candidate: string): boolean => {
+  return path === candidate || path.startsWith(`${candidate}.`)
+}
+
+export const pathIsReloaded = (path: string, only: string[], except: string[]): boolean => {
+  if (only.length > 0) {
+    return only.some((candidate) => isSameOrSubPath(path, candidate))
+  }
+
+  if (except.length > 0) {
+    return !except.some((candidate) => isSameOrSubPath(path, candidate))
+  }
+
+  return false
+}
+
+export const anyPathIsReloaded = (paths: string[], only: string[], except: string[]): boolean => {
+  if (only.length === 0 && except.length === 0) {
+    return true
+  }
+
+  return paths.some((path) => pathIsReloaded(path, only, except))
+}

--- a/packages/core/src/partialReload.ts
+++ b/packages/core/src/partialReload.ts
@@ -6,7 +6,7 @@ export const isPathOrSubPath = (path: string, candidate: string): boolean => {
   return path === candidate || path.startsWith(`${candidate}.`)
 }
 
-export const visitReloadsProp = (visit: VisitFilter, prop: string): boolean => {
+export const partialReloadRequestsProp = (visit: VisitFilter, prop: string): boolean => {
   const { only, except } = visit
 
   if (only.length === 0 && except.length === 0) {
@@ -24,12 +24,6 @@ export const visitReloadsProp = (visit: VisitFilter, prop: string): boolean => {
   return true
 }
 
-export const visitReloadsProps = (visit: VisitFilter, props: string[]): boolean => {
-  const { only, except } = visit
-
-  if (only.length === 0 && except.length === 0) {
-    return true
-  }
-
-  return props.some((prop) => visitReloadsProp(visit, prop))
+export const partialReloadRequestsSomeProps = (visit: VisitFilter, props: string[]): boolean => {
+  return props.some((prop) => partialReloadRequestsProp(visit, prop))
 }

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -396,7 +396,6 @@ export class Response {
         .filter((prop) => prop.includes('.'))
         .map((prop) => prop.split('.')[0]),
     )
-
     for (const key of nestedTopKeys) {
       const currentValue = currentPage.get().props[key]
 
@@ -439,7 +438,13 @@ export class Response {
       pageResponse.initialDeferredProps = currentOriginalDeferred
     }
 
-    pageResponse.rescuedProps = this.mergeRescuedProps(pageResponse)
+    const rescuedProps = this.mergeRescuedProps(pageResponse)
+
+    if (rescuedProps !== undefined) {
+      pageResponse.rescuedProps = rescuedProps
+    } else {
+      delete pageResponse.rescuedProps
+    }
   }
 
   protected mergeRescuedProps(pageResponse: Page): string[] | undefined {

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -12,7 +12,7 @@ import {
 } from './events'
 import { history } from './history'
 import { page as currentPage } from './page'
-import { visitReloadsProp } from './partialReload'
+import { partialReloadRequestsProp } from './partialReload'
 import Queue from './queue'
 import { RequestParams } from './requestParams'
 import { SessionStorage } from './sessionStorage'
@@ -445,7 +445,9 @@ export class Response {
     const currentRescued = currentPage.get().rescuedProps ?? []
     const incomingRescued = pageResponse.rescuedProps ?? []
 
-    const newRescued = new Set(currentRescued.filter((prop) => !visitReloadsProp(this.requestParams.all(), prop)))
+    const newRescued = new Set(
+      currentRescued.filter((prop) => !partialReloadRequestsProp(this.requestParams.all(), prop)),
+    )
 
     incomingRescued.forEach((prop) => newRescued.add(prop))
 

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -445,15 +445,11 @@ export class Response {
     const currentRescued = currentPage.get().rescuedProps ?? []
     const incomingRescued = pageResponse.rescuedProps ?? []
 
-    const merged = new Set(currentRescued.filter((prop) => !this.wasPropReloaded(prop)))
+    const newRescued = new Set(currentRescued.filter((prop) => !visitReloadsProp(this.requestParams.all(), prop)))
 
-    incomingRescued.forEach((prop) => merged.add(prop))
+    incomingRescued.forEach((prop) => newRescued.add(prop))
 
-    return Array.from(merged)
-  }
-
-  protected wasPropReloaded(prop: string): boolean {
-    return visitReloadsProp(this.requestParams.all(), prop)
+    return Array.from(newRescued)
   }
 
   /**

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -17,7 +17,7 @@ import { RequestParams } from './requestParams'
 import { SessionStorage } from './sessionStorage'
 import { ActiveVisit, ErrorBag, Errors, HttpResponse, Page, PageProps } from './types'
 import { hrefToUrl, isSameUrlWithoutHash, setHashIfSameUrl } from './url'
-import { pathIsReloaded } from './partialReload'
+import { visitReloadsProp } from './partialReload'
 
 const queue = new Queue<Promise<boolean | void>>()
 
@@ -458,8 +458,7 @@ export class Response {
   }
 
   protected wasPropReloaded(prop: string): boolean {
-    const { only, except } = this.requestParams.all()
-    return pathIsReloaded(prop, only, except)
+    return visitReloadsProp(this.requestParams.all(), prop)
   }
 
   /**

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -17,6 +17,7 @@ import { RequestParams } from './requestParams'
 import { SessionStorage } from './sessionStorage'
 import { ActiveVisit, ErrorBag, Errors, HttpResponse, Page, PageProps } from './types'
 import { hrefToUrl, isSameUrlWithoutHash, setHashIfSameUrl } from './url'
+import { pathIsReloaded } from './partialReload'
 
 const queue = new Queue<Promise<boolean | void>>()
 
@@ -437,6 +438,28 @@ export class Response {
     if (currentOriginalDeferred && Object.keys(currentOriginalDeferred).length > 0) {
       pageResponse.initialDeferredProps = currentOriginalDeferred
     }
+
+    pageResponse.rescuedProps = this.mergeRescuedProps(pageResponse)
+  }
+
+  protected mergeRescuedProps(pageResponse: Page): string[] | undefined {
+    const currentRescued = currentPage.get().rescuedProps || []
+    const incomingRescued = pageResponse.rescuedProps || []
+
+    if (currentRescued.length === 0 && incomingRescued.length === 0) {
+      return undefined
+    }
+
+    const merged = new Set(currentRescued.filter((prop) => !this.wasPropReloaded(prop)))
+
+    incomingRescued.forEach((prop) => merged.add(prop))
+
+    return merged.size > 0 ? Array.from(merged) : undefined
+  }
+
+  protected wasPropReloaded(prop: string): boolean {
+    const { only, except } = this.requestParams.all()
+    return pathIsReloaded(prop, only, except)
   }
 
   /**

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -12,12 +12,12 @@ import {
 } from './events'
 import { history } from './history'
 import { page as currentPage } from './page'
+import { visitReloadsProp } from './partialReload'
 import Queue from './queue'
 import { RequestParams } from './requestParams'
 import { SessionStorage } from './sessionStorage'
 import { ActiveVisit, ErrorBag, Errors, HttpResponse, Page, PageProps } from './types'
 import { hrefToUrl, isSameUrlWithoutHash, setHashIfSameUrl } from './url'
-import { visitReloadsProp } from './partialReload'
 
 const queue = new Queue<Promise<boolean | void>>()
 
@@ -129,7 +129,7 @@ export class Response {
 
     // Only spread if data is an object (not a string like HTML error pages)
     if (typeof data === 'object') {
-      return (this.response.data = { ...data, flash: data.flash ?? {} })
+      return (this.response.data = { ...data, flash: data.flash ?? {}, rescuedProps: data.rescuedProps ?? [] })
     }
 
     return (this.response.data = data)
@@ -438,28 +438,18 @@ export class Response {
       pageResponse.initialDeferredProps = currentOriginalDeferred
     }
 
-    const rescuedProps = this.mergeRescuedProps(pageResponse)
-
-    if (rescuedProps !== undefined) {
-      pageResponse.rescuedProps = rescuedProps
-    } else {
-      delete pageResponse.rescuedProps
-    }
+    pageResponse.rescuedProps = this.mergeRescuedProps(pageResponse)
   }
 
-  protected mergeRescuedProps(pageResponse: Page): string[] | undefined {
-    const currentRescued = currentPage.get().rescuedProps || []
-    const incomingRescued = pageResponse.rescuedProps || []
-
-    if (currentRescued.length === 0 && incomingRescued.length === 0) {
-      return undefined
-    }
+  protected mergeRescuedProps(pageResponse: Page): string[] {
+    const currentRescued = currentPage.get().rescuedProps ?? []
+    const incomingRescued = pageResponse.rescuedProps ?? []
 
     const merged = new Set(currentRescued.filter((prop) => !this.wasPropReloaded(prop)))
 
     incomingRescued.forEach((prop) => merged.add(prop))
 
-    return merged.size > 0 ? Array.from(merged) : undefined
+    return Array.from(merged)
   }
 
   protected wasPropReloaded(prop: string): boolean {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -591,6 +591,7 @@ export class Router {
         errors: {},
       },
       flash: {},
+      rescuedProps: [],
       clearHistory: false,
       encryptHistory: current.encryptHistory,
       sharedProps: current.sharedProps,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -232,6 +232,7 @@ export interface Page<SharedProps extends PageProps = PageProps> {
   encryptHistory?: boolean
   deferredProps?: Record<string, NonNullable<VisitOptions['only']>>
   initialDeferredProps?: Record<string, NonNullable<VisitOptions['only']>>
+  rescuedProps?: string[]
   mergeProps?: string[]
   prependProps?: string[]
   deepMergeProps?: string[]

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -232,7 +232,7 @@ export interface Page<SharedProps extends PageProps = PageProps> {
   encryptHistory?: boolean
   deferredProps?: Record<string, NonNullable<VisitOptions['only']>>
   initialDeferredProps?: Record<string, NonNullable<VisitOptions['only']>>
-  rescuedProps?: string[]
+  rescuedProps: string[]
   mergeProps?: string[]
   prependProps?: string[]
   deepMergeProps?: string[]

--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -10,7 +10,7 @@ interface DeferredSlotProps {
 
 interface DeferredProps {
   children: ReactNode | ((props: DeferredSlotProps) => ReactNode)
-  rescue?: ReactNode | (() => ReactNode)
+  rescue?: ReactNode | ((props: DeferredSlotProps) => ReactNode)
   fallback: ReactNode | (() => ReactNode)
   data: string | string[]
 }
@@ -73,7 +73,7 @@ const Deferred = ({ children, data, rescue, fallback }: DeferredProps) => {
   }
 
   if (hasRescuedProps && rescue) {
-    return typeof rescue === 'function' ? rescue() : rescue
+    return typeof rescue === 'function' ? rescue({ reloading }) : rescue
   }
 
   return typeof fallback === 'function' ? fallback() : fallback

--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -29,7 +29,7 @@ const Deferred = ({ children, data, error, fallback }: DeferredProps) => {
   const page = usePage()
   const pageProps = page.props
   const keys = useMemo(() => (Array.isArray(data) ? data : [data]), [data])
-  const rescuedKeys = useMemo(() => new Set(page.rescuedProps || []), [page.rescuedProps])
+  const rescuedKeys = useMemo(() => new Set(page.rescuedProps), [page.rescuedProps])
 
   useEffect(() => {
     const removeStartListener = router.on('start', (e) => {

--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -1,4 +1,4 @@
-import { isSameUrlWithoutQueryOrHash, visitReloadsProps } from '@inertiajs/core'
+import { isSameUrlWithoutQueryOrHash, partialReloadRequestsSomeProps } from '@inertiajs/core'
 import { get } from 'es-toolkit/compat'
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { router } from '.'
@@ -38,7 +38,7 @@ const Deferred = ({ children, data, rescue, fallback }: DeferredProps) => {
       if (
         visit.preserveState === true &&
         isSameUrlWithoutQueryOrHash(visit.url, window.location) &&
-        visitReloadsProps(visit, keys)
+        partialReloadRequestsSomeProps(visit, keys)
       ) {
         activeReloads.current.add(visit)
         setReloading(true)

--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -1,4 +1,4 @@
-import { anyPathIsReloaded, isSameUrlWithoutQueryOrHash } from '@inertiajs/core'
+import { isSameUrlWithoutQueryOrHash, visitReloadsProps } from '@inertiajs/core'
 import { get } from 'es-toolkit/compat'
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { router } from '.'
@@ -20,7 +20,10 @@ const Deferred = ({ children, data, error, fallback }: DeferredProps) => {
     throw new Error('`<Deferred>` requires a `data` prop to be a string or array of strings')
   }
 
-  const [loaded, setLoaded] = useState(false)
+  if (!fallback) {
+    throw new Error('`<Deferred>` requires a `fallback` prop')
+  }
+
   const [reloading, setReloading] = useState(false)
   const activeReloads = useRef(new Set<object>())
   const page = usePage()
@@ -35,7 +38,7 @@ const Deferred = ({ children, data, error, fallback }: DeferredProps) => {
       if (
         visit.preserveState === true &&
         isSameUrlWithoutQueryOrHash(visit.url, window.location) &&
-        anyPathIsReloaded(keys, visit.only, visit.except)
+        visitReloadsProps(visit, keys)
       ) {
         activeReloads.current.add(visit)
         setReloading(true)
@@ -58,10 +61,6 @@ const Deferred = ({ children, data, error, fallback }: DeferredProps) => {
     }
   }, [keys])
 
-  useEffect(() => {
-    setLoaded(keys.every((key) => get(pageProps, key) !== undefined || rescuedKeys.has(key)))
-  }, [pageProps, keys, rescuedKeys])
-
   const propsAreDefined = useMemo(() => keys.every((key) => get(pageProps, key) !== undefined), [keys, pageProps])
   const propsAreSettled = useMemo(
     () => keys.every((key) => get(pageProps, key) !== undefined || rescuedKeys.has(key)),
@@ -69,7 +68,7 @@ const Deferred = ({ children, data, error, fallback }: DeferredProps) => {
   )
   const hasRescuedProps = useMemo(() => keys.some((key) => rescuedKeys.has(key)), [keys, rescuedKeys])
 
-  if (loaded && propsAreDefined && !hasRescuedProps) {
+  if (propsAreDefined && !hasRescuedProps) {
     if (typeof children === 'function') {
       return children({ reloading })
     }

--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -1,20 +1,8 @@
-import { isSameUrlWithoutQueryOrHash } from '@inertiajs/core'
+import { anyPathIsReloaded, isSameUrlWithoutQueryOrHash } from '@inertiajs/core'
 import { get } from 'es-toolkit/compat'
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { router } from '.'
 import usePage from './usePage'
-
-const keysAreBeingReloaded = (only: string[], except: string[], keys: string[]): boolean => {
-  if (only.length === 0 && except.length === 0) {
-    return true
-  }
-
-  if (only.length > 0) {
-    return keys.some((key) => only.includes(key))
-  }
-
-  return keys.some((key) => !except.includes(key))
-}
 
 interface DeferredSlotProps {
   reloading: boolean
@@ -22,11 +10,12 @@ interface DeferredSlotProps {
 
 interface DeferredProps {
   children: ReactNode | ((props: DeferredSlotProps) => ReactNode)
+  error?: ReactNode | (() => ReactNode)
   fallback: ReactNode | (() => ReactNode)
   data: string | string[]
 }
 
-const Deferred = ({ children, data, fallback }: DeferredProps) => {
+const Deferred = ({ children, data, error, fallback }: DeferredProps) => {
   if (!data) {
     throw new Error('`<Deferred>` requires a `data` prop to be a string or array of strings')
   }
@@ -34,8 +23,10 @@ const Deferred = ({ children, data, fallback }: DeferredProps) => {
   const [loaded, setLoaded] = useState(false)
   const [reloading, setReloading] = useState(false)
   const activeReloads = useRef(new Set<object>())
-  const pageProps = usePage().props
+  const page = usePage()
+  const pageProps = page.props
   const keys = useMemo(() => (Array.isArray(data) ? data : [data]), [data])
+  const rescuedKeys = useMemo(() => new Set(page.rescuedProps || []), [page.rescuedProps])
 
   useEffect(() => {
     const removeStartListener = router.on('start', (e) => {
@@ -44,7 +35,7 @@ const Deferred = ({ children, data, fallback }: DeferredProps) => {
       if (
         visit.preserveState === true &&
         isSameUrlWithoutQueryOrHash(visit.url, window.location) &&
-        keysAreBeingReloaded(visit.only, visit.except, keys)
+        anyPathIsReloaded(keys, visit.only, visit.except)
       ) {
         activeReloads.current.add(visit)
         setReloading(true)
@@ -68,17 +59,26 @@ const Deferred = ({ children, data, fallback }: DeferredProps) => {
   }, [keys])
 
   useEffect(() => {
-    setLoaded(keys.every((key) => get(pageProps, key) !== undefined))
-  }, [pageProps, keys])
+    setLoaded(keys.every((key) => get(pageProps, key) !== undefined || rescuedKeys.has(key)))
+  }, [pageProps, keys, rescuedKeys])
 
   const propsAreDefined = useMemo(() => keys.every((key) => get(pageProps, key) !== undefined), [keys, pageProps])
+  const propsAreSettled = useMemo(
+    () => keys.every((key) => get(pageProps, key) !== undefined || rescuedKeys.has(key)),
+    [keys, pageProps, rescuedKeys],
+  )
+  const hasRescuedProps = useMemo(() => keys.some((key) => rescuedKeys.has(key)), [keys, rescuedKeys])
 
-  if (loaded && propsAreDefined) {
+  if (loaded && propsAreDefined && !hasRescuedProps) {
     if (typeof children === 'function') {
       return children({ reloading })
     }
 
     return children
+  }
+
+  if (propsAreSettled && hasRescuedProps && error) {
+    return typeof error === 'function' ? error() : error
   }
 
   return typeof fallback === 'function' ? fallback() : fallback

--- a/packages/react/src/Deferred.ts
+++ b/packages/react/src/Deferred.ts
@@ -10,12 +10,12 @@ interface DeferredSlotProps {
 
 interface DeferredProps {
   children: ReactNode | ((props: DeferredSlotProps) => ReactNode)
-  error?: ReactNode | (() => ReactNode)
+  rescue?: ReactNode | (() => ReactNode)
   fallback: ReactNode | (() => ReactNode)
   data: string | string[]
 }
 
-const Deferred = ({ children, data, error, fallback }: DeferredProps) => {
+const Deferred = ({ children, data, rescue, fallback }: DeferredProps) => {
   if (!data) {
     throw new Error('`<Deferred>` requires a `data` prop to be a string or array of strings')
   }
@@ -62,10 +62,6 @@ const Deferred = ({ children, data, error, fallback }: DeferredProps) => {
   }, [keys])
 
   const propsAreDefined = useMemo(() => keys.every((key) => get(pageProps, key) !== undefined), [keys, pageProps])
-  const propsAreSettled = useMemo(
-    () => keys.every((key) => get(pageProps, key) !== undefined || rescuedKeys.has(key)),
-    [keys, pageProps, rescuedKeys],
-  )
   const hasRescuedProps = useMemo(() => keys.some((key) => rescuedKeys.has(key)), [keys, rescuedKeys])
 
   if (propsAreDefined && !hasRescuedProps) {
@@ -76,8 +72,8 @@ const Deferred = ({ children, data, error, fallback }: DeferredProps) => {
     return children
   }
 
-  if (propsAreSettled && hasRescuedProps && error) {
-    return typeof error === 'function' ? error() : error
+  if (hasRescuedProps && rescue) {
+    return typeof rescue === 'function' ? rescue() : rescue
   }
 
   return typeof fallback === 'function' ? fallback() : fallback

--- a/packages/react/test-app/Pages/DeferredProps/WithRescuedErrors.tsx
+++ b/packages/react/test-app/Pages/DeferredProps/WithRescuedErrors.tsx
@@ -8,12 +8,21 @@ const Foo = () => {
 
 export default () => {
   const retry = () => {
-    router.reload({ only: ['foo'] })
+    router.reload({ only: ['foo'], headers: { 'X-Test-Retry': 'true' } })
   }
 
   return (
     <>
-      <Deferred data="foo" fallback={<div>Loading foo...</div>} rescue={<div id="foo-error">Unable to load foo.</div>}>
+      <Deferred
+        data="foo"
+        fallback={<div>Loading foo...</div>}
+        rescue={({ reloading }) => (
+          <>
+            <div id="foo-error">Unable to load foo.</div>
+            <span id="reloading">{String(reloading)}</span>
+          </>
+        )}
+      >
         <Foo />
       </Deferred>
 

--- a/packages/react/test-app/Pages/DeferredProps/WithRescuedErrors.tsx
+++ b/packages/react/test-app/Pages/DeferredProps/WithRescuedErrors.tsx
@@ -13,7 +13,7 @@ export default () => {
 
   return (
     <>
-      <Deferred data="foo" fallback={<div>Loading foo...</div>} error={<div id="foo-error">Unable to load foo.</div>}>
+      <Deferred data="foo" fallback={<div>Loading foo...</div>} rescue={<div id="foo-error">Unable to load foo.</div>}>
         <Foo />
       </Deferred>
 

--- a/packages/react/test-app/Pages/DeferredProps/WithRescuedErrors.tsx
+++ b/packages/react/test-app/Pages/DeferredProps/WithRescuedErrors.tsx
@@ -1,0 +1,25 @@
+import { Deferred, router, usePage } from '@inertiajs/react'
+
+const Foo = () => {
+  const { foo } = usePage<{ foo?: { text: string } | null }>().props
+
+  return <div id="foo">{foo?.text}</div>
+}
+
+export default () => {
+  const retry = () => {
+    router.reload({ only: ['foo'] })
+  }
+
+  return (
+    <>
+      <Deferred data="foo" fallback={<div>Loading foo...</div>} error={<div id="foo-error">Unable to load foo.</div>}>
+        <Foo />
+      </Deferred>
+
+      <button type="button" onClick={retry}>
+        Retry
+      </button>
+    </>
+  )
+}

--- a/packages/react/test-app/Pages/NestedProps/RescuedDeferred.tsx
+++ b/packages/react/test-app/Pages/NestedProps/RescuedDeferred.tsx
@@ -16,7 +16,7 @@ export default () => {
       <Deferred
         data="auth.notifications"
         fallback={<div id="loading">Loading notifications...</div>}
-        error={
+        rescue={
           <button id="retry" onClick={() => router.reload({ only: ['auth'] })}>
             Retry auth
           </button>

--- a/packages/react/test-app/Pages/NestedProps/RescuedDeferred.tsx
+++ b/packages/react/test-app/Pages/NestedProps/RescuedDeferred.tsx
@@ -17,7 +17,7 @@ export default () => {
         data="auth.notifications"
         fallback={<div id="loading">Loading notifications...</div>}
         rescue={
-          <button id="retry" onClick={() => router.reload({ only: ['auth'] })}>
+          <button id="retry" onClick={() => router.reload({ only: ['auth'], headers: { 'X-Test-Retry': 'true' } })}>
             Retry auth
           </button>
         }

--- a/packages/react/test-app/Pages/NestedProps/RescuedDeferred.tsx
+++ b/packages/react/test-app/Pages/NestedProps/RescuedDeferred.tsx
@@ -1,0 +1,29 @@
+import { Deferred, router, usePage } from '@inertiajs/react'
+
+const Notifications = () => {
+  const { auth } = usePage<{ auth: { notifications?: string[] } }>().props
+
+  return <p id="notifications">Notifications: {auth.notifications?.join(', ')}</p>
+}
+
+export default () => {
+  const { auth } = usePage<{ auth: { user?: string; notifications?: string[] } }>().props
+
+  return (
+    <>
+      <p id="user">User: {auth.user}</p>
+
+      <Deferred
+        data="auth.notifications"
+        fallback={<div id="loading">Loading notifications...</div>}
+        error={
+          <button id="retry" onClick={() => router.reload({ only: ['auth'] })}>
+            Retry auth
+          </button>
+        }
+      >
+        <Notifications />
+      </Deferred>
+    </>
+  )
+}

--- a/packages/react/test-app/Pages/NestedProps/RescuedDeferredExcept.tsx
+++ b/packages/react/test-app/Pages/NestedProps/RescuedDeferredExcept.tsx
@@ -1,0 +1,21 @@
+import { Deferred, router, usePage } from '@inertiajs/react'
+
+export default () => {
+  const { auth, status } = usePage<{ auth: { user?: string; token?: string; notifications?: string[] }; status: string }>().props
+
+  return (
+    <>
+      <p id="user">User: {auth.user}</p>
+      <p id="token">Token: {auth.token}</p>
+      <p id="status">Status: {status}</p>
+
+      <Deferred
+        data="auth.notifications"
+        fallback={<div id="loading">Loading notifications...</div>}
+        error={<button id="reload-except" onClick={() => router.reload({ except: ['auth.notifications'] })}>Reload without notifications</button>}
+      >
+        <p id="notifications">Notifications: {auth.notifications?.join(', ')}</p>
+      </Deferred>
+    </>
+  )
+}

--- a/packages/react/test-app/Pages/NestedProps/RescuedDeferredExcept.tsx
+++ b/packages/react/test-app/Pages/NestedProps/RescuedDeferredExcept.tsx
@@ -1,7 +1,10 @@
 import { Deferred, router, usePage } from '@inertiajs/react'
 
 export default () => {
-  const { auth, status } = usePage<{ auth: { user?: string; token?: string; notifications?: string[] }; status: string }>().props
+  const { auth, status } = usePage<{
+    auth: { user?: string; token?: string; notifications?: string[] }
+    status: string
+  }>().props
 
   return (
     <>
@@ -12,7 +15,11 @@ export default () => {
       <Deferred
         data="auth.notifications"
         fallback={<div id="loading">Loading notifications...</div>}
-        error={<button id="reload-except" onClick={() => router.reload({ except: ['auth.notifications'] })}>Reload without notifications</button>}
+        error={
+          <button id="reload-except" onClick={() => router.reload({ except: ['auth.notifications'] })}>
+            Reload without notifications
+          </button>
+        }
       >
         <p id="notifications">Notifications: {auth.notifications?.join(', ')}</p>
       </Deferred>

--- a/packages/react/test-app/Pages/NestedProps/RescuedDeferredExcept.tsx
+++ b/packages/react/test-app/Pages/NestedProps/RescuedDeferredExcept.tsx
@@ -15,7 +15,7 @@ export default () => {
       <Deferred
         data="auth.notifications"
         fallback={<div id="loading">Loading notifications...</div>}
-        error={
+        rescue={
           <button id="reload-except" onClick={() => router.reload({ except: ['auth.notifications'] })}>
             Reload without notifications
           </button>

--- a/packages/react/test-app/Pages/NestedProps/RescuedDeferredExcept.tsx
+++ b/packages/react/test-app/Pages/NestedProps/RescuedDeferredExcept.tsx
@@ -16,7 +16,7 @@ export default () => {
         data="auth.notifications"
         fallback={<div id="loading">Loading notifications...</div>}
         rescue={
-          <button id="reload-except" onClick={() => router.reload({ except: ['auth.notifications'] })}>
+          <button id="reload-except" onClick={() => router.reload({ except: ['auth.notifications'], headers: { 'X-Test-Retry': 'true' } })}>
             Reload without notifications
           </button>
         }

--- a/packages/react/test-app/Pages/NestedProps/RescuedDeferredExcept.tsx
+++ b/packages/react/test-app/Pages/NestedProps/RescuedDeferredExcept.tsx
@@ -16,7 +16,10 @@ export default () => {
         data="auth.notifications"
         fallback={<div id="loading">Loading notifications...</div>}
         rescue={
-          <button id="reload-except" onClick={() => router.reload({ except: ['auth.notifications'], headers: { 'X-Test-Retry': 'true' } })}>
+          <button
+            id="reload-except"
+            onClick={() => router.reload({ except: ['auth.notifications'], headers: { 'X-Test-Retry': 'true' } })}
+          >
             Reload without notifications
           </button>
         }

--- a/packages/svelte/src/components/Deferred.svelte
+++ b/packages/svelte/src/components/Deferred.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { anyPathIsReloaded, isSameUrlWithoutQueryOrHash, router } from '@inertiajs/core'
+  import { isSameUrlWithoutQueryOrHash, router, visitReloadsProps } from '@inertiajs/core'
   import { get } from 'es-toolkit/compat'
   import { page } from '../index'
 
@@ -28,7 +28,7 @@
       if (
         visit.preserveState === true &&
         isSameUrlWithoutQueryOrHash(visit.url, window.location) &&
-        anyPathIsReloaded(keys, visit.only, visit.except)
+        visitReloadsProps(visit, keys)
       ) {
         activeReloads.add(visit)
         reloading = true

--- a/packages/svelte/src/components/Deferred.svelte
+++ b/packages/svelte/src/components/Deferred.svelte
@@ -5,7 +5,7 @@
 
   interface Props {
     data: string | string[]
-    rescue?: import('svelte').Snippet
+    rescue?: import('svelte').Snippet<[{ reloading: boolean }]>
     fallback?: import('svelte').Snippet
     children?: import('svelte').Snippet<[{ reloading: boolean }]>
   }
@@ -60,7 +60,7 @@
 {#if loaded && !failed}
   {@render children?.({ reloading })}
 {:else if failed && rescue}
-  {@render rescue?.()}
+  {@render rescue?.({ reloading })}
 {:else}
   {@render fallback?.()}
 {/if}

--- a/packages/svelte/src/components/Deferred.svelte
+++ b/packages/svelte/src/components/Deferred.svelte
@@ -5,18 +5,17 @@
 
   interface Props {
     data: string | string[]
-    error?: import('svelte').Snippet
+    rescue?: import('svelte').Snippet
     fallback?: import('svelte').Snippet
     children?: import('svelte').Snippet<[{ reloading: boolean }]>
   }
 
-  let { data, error, fallback, children }: Props = $props()
+  let { data, rescue, fallback, children }: Props = $props()
 
   const keys = $derived(Array.isArray(data) ? data : [data])
   const rescuedKeys = $derived(new Set(page.rescuedProps))
   const loaded = $derived(keys.every((key) => typeof get(page.props, key) !== 'undefined'))
-  const settled = $derived(keys.every((key) => typeof get(page.props, key) !== 'undefined' || rescuedKeys.has(key)))
-  const failed = $derived(settled && keys.some((key) => rescuedKeys.has(key)))
+  const failed = $derived(keys.some((key) => rescuedKeys.has(key)))
 
   let reloading = $state(false)
   const activeReloads = new Set<object>()
@@ -60,8 +59,8 @@
 
 {#if loaded && !failed}
   {@render children?.({ reloading })}
-{:else if failed && error}
-  {@render error?.()}
+{:else if failed && rescue}
+  {@render rescue?.()}
 {:else}
   {@render fallback?.()}
 {/if}

--- a/packages/svelte/src/components/Deferred.svelte
+++ b/packages/svelte/src/components/Deferred.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { isSameUrlWithoutQueryOrHash, router, visitReloadsProps } from '@inertiajs/core'
+  import { isSameUrlWithoutQueryOrHash, router, partialReloadRequestsSomeProps } from '@inertiajs/core'
   import { get } from 'es-toolkit/compat'
   import { page } from '../index'
 
@@ -27,7 +27,7 @@
       if (
         visit.preserveState === true &&
         isSameUrlWithoutQueryOrHash(visit.url, window.location) &&
-        visitReloadsProps(visit, keys)
+        partialReloadRequestsSomeProps(visit, keys)
       ) {
         activeReloads.add(visit)
         reloading = true

--- a/packages/svelte/src/components/Deferred.svelte
+++ b/packages/svelte/src/components/Deferred.svelte
@@ -1,33 +1,25 @@
 <script lang="ts">
-  import { isSameUrlWithoutQueryOrHash, router } from '@inertiajs/core'
+  import { anyPathIsReloaded, isSameUrlWithoutQueryOrHash, router } from '@inertiajs/core'
   import { get } from 'es-toolkit/compat'
   import { page } from '../index'
 
   interface Props {
     data: string | string[]
+    error?: import('svelte').Snippet
     fallback?: import('svelte').Snippet
     children?: import('svelte').Snippet<[{ reloading: boolean }]>
   }
 
-  let { data, fallback, children }: Props = $props()
+  let { data, error, fallback, children }: Props = $props()
 
   const keys = $derived(Array.isArray(data) ? data : [data])
+  const rescuedKeys = $derived(new Set(page.rescuedProps || []))
   const loaded = $derived(keys.every((key) => typeof get(page.props, key) !== 'undefined'))
+  const settled = $derived(keys.every((key) => typeof get(page.props, key) !== 'undefined' || rescuedKeys.has(key)))
+  const failed = $derived(settled && keys.some((key) => rescuedKeys.has(key)))
 
   let reloading = $state(false)
   const activeReloads = new Set<object>()
-
-  const keysAreBeingReloaded = (only: string[], except: string[], keys: string[]): boolean => {
-    if (only.length === 0 && except.length === 0) {
-      return true
-    }
-
-    if (only.length > 0) {
-      return keys.some((key) => only.includes(key))
-    }
-
-    return keys.some((key) => !except.includes(key))
-  }
 
   $effect(() => {
     const removeStartListener = router.on('start', (e) => {
@@ -36,7 +28,7 @@
       if (
         visit.preserveState === true &&
         isSameUrlWithoutQueryOrHash(visit.url, window.location) &&
-        keysAreBeingReloaded(visit.only, visit.except, keys)
+        anyPathIsReloaded(keys, visit.only, visit.except)
       ) {
         activeReloads.add(visit)
         reloading = true
@@ -66,8 +58,10 @@
   })
 </script>
 
-{#if loaded}
+{#if loaded && !failed}
   {@render children?.({ reloading })}
+{:else if failed && error}
+  {@render error?.()}
 {:else}
   {@render fallback?.()}
 {/if}

--- a/packages/svelte/src/components/Deferred.svelte
+++ b/packages/svelte/src/components/Deferred.svelte
@@ -13,7 +13,7 @@
   let { data, error, fallback, children }: Props = $props()
 
   const keys = $derived(Array.isArray(data) ? data : [data])
-  const rescuedKeys = $derived(new Set(page.rescuedProps || []))
+  const rescuedKeys = $derived(new Set(page.rescuedProps))
   const loaded = $derived(keys.every((key) => typeof get(page.props, key) !== 'undefined'))
   const settled = $derived(keys.every((key) => typeof get(page.props, key) !== 'undefined' || rescuedKeys.has(key)))
   const failed = $derived(settled && keys.some((key) => rescuedKeys.has(key)))

--- a/packages/svelte/test-app/Pages/DeferredProps/WithRescuedErrors.svelte
+++ b/packages/svelte/test-app/Pages/DeferredProps/WithRescuedErrors.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { Deferred, router } from '@inertiajs/svelte'
+
+  interface Props {
+    foo?: { text: string } | null
+  }
+
+  let { foo }: Props = $props()
+
+  const retry = () => {
+    router.reload({ only: ['foo'] })
+  }
+</script>
+
+<Deferred data="foo">
+  {#snippet fallback()}
+    <div>Loading foo...</div>
+  {/snippet}
+
+  {#snippet error()}
+    <div id="foo-error">Unable to load foo.</div>
+  {/snippet}
+
+  <div id="foo">{foo?.text}</div>
+</Deferred>
+
+<button type="button" onclick={retry}>Retry</button>

--- a/packages/svelte/test-app/Pages/DeferredProps/WithRescuedErrors.svelte
+++ b/packages/svelte/test-app/Pages/DeferredProps/WithRescuedErrors.svelte
@@ -8,7 +8,7 @@
   let { foo }: Props = $props()
 
   const retry = () => {
-    router.reload({ only: ['foo'] })
+    router.reload({ only: ['foo'], headers: { 'X-Test-Retry': 'true' } })
   }
 </script>
 
@@ -17,8 +17,9 @@
     <div>Loading foo...</div>
   {/snippet}
 
-  {#snippet rescue()}
+  {#snippet rescue({ reloading })}
     <div id="foo-error">Unable to load foo.</div>
+    <span id="reloading">{reloading}</span>
   {/snippet}
 
   <div id="foo">{foo?.text}</div>

--- a/packages/svelte/test-app/Pages/DeferredProps/WithRescuedErrors.svelte
+++ b/packages/svelte/test-app/Pages/DeferredProps/WithRescuedErrors.svelte
@@ -17,7 +17,7 @@
     <div>Loading foo...</div>
   {/snippet}
 
-  {#snippet error()}
+  {#snippet rescue()}
     <div id="foo-error">Unable to load foo.</div>
   {/snippet}
 

--- a/packages/svelte/test-app/Pages/NestedProps/RescuedDeferred.svelte
+++ b/packages/svelte/test-app/Pages/NestedProps/RescuedDeferred.svelte
@@ -18,7 +18,7 @@
     <div id="loading">Loading notifications...</div>
   {/snippet}
 
-  {#snippet error()}
+  {#snippet rescue()}
     <button id="retry" onclick={() => router.reload({ only: ['auth'] })}>Retry auth</button>
   {/snippet}
 

--- a/packages/svelte/test-app/Pages/NestedProps/RescuedDeferred.svelte
+++ b/packages/svelte/test-app/Pages/NestedProps/RescuedDeferred.svelte
@@ -19,7 +19,9 @@
   {/snippet}
 
   {#snippet rescue()}
-    <button id="retry" onclick={() => router.reload({ only: ['auth'], headers: { 'X-Test-Retry': 'true' } })}>Retry auth</button>
+    <button id="retry" onclick={() => router.reload({ only: ['auth'], headers: { 'X-Test-Retry': 'true' } })}
+      >Retry auth</button
+    >
   {/snippet}
 
   <p id="notifications">Notifications: {auth.notifications?.join(', ')}</p>

--- a/packages/svelte/test-app/Pages/NestedProps/RescuedDeferred.svelte
+++ b/packages/svelte/test-app/Pages/NestedProps/RescuedDeferred.svelte
@@ -19,7 +19,7 @@
   {/snippet}
 
   {#snippet rescue()}
-    <button id="retry" onclick={() => router.reload({ only: ['auth'] })}>Retry auth</button>
+    <button id="retry" onclick={() => router.reload({ only: ['auth'], headers: { 'X-Test-Retry': 'true' } })}>Retry auth</button>
   {/snippet}
 
   <p id="notifications">Notifications: {auth.notifications?.join(', ')}</p>

--- a/packages/svelte/test-app/Pages/NestedProps/RescuedDeferred.svelte
+++ b/packages/svelte/test-app/Pages/NestedProps/RescuedDeferred.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { Deferred, router } from '@inertiajs/svelte'
+
+  interface Props {
+    auth: {
+      user?: string
+      notifications?: string[]
+    }
+  }
+
+  let { auth }: Props = $props()
+</script>
+
+<p id="user">User: {auth.user}</p>
+
+<Deferred data="auth.notifications">
+  {#snippet fallback()}
+    <div id="loading">Loading notifications...</div>
+  {/snippet}
+
+  {#snippet error()}
+    <button id="retry" onclick={() => router.reload({ only: ['auth'] })}>Retry auth</button>
+  {/snippet}
+
+  <p id="notifications">Notifications: {auth.notifications?.join(', ')}</p>
+</Deferred>

--- a/packages/svelte/test-app/Pages/NestedProps/RescuedDeferredExcept.svelte
+++ b/packages/svelte/test-app/Pages/NestedProps/RescuedDeferredExcept.svelte
@@ -22,7 +22,7 @@
     <div id="loading">Loading notifications...</div>
   {/snippet}
 
-  {#snippet error()}
+  {#snippet rescue()}
     <button id="reload-except" onclick={() => router.reload({ except: ['auth.notifications'] })}>
       Reload without notifications
     </button>

--- a/packages/svelte/test-app/Pages/NestedProps/RescuedDeferredExcept.svelte
+++ b/packages/svelte/test-app/Pages/NestedProps/RescuedDeferredExcept.svelte
@@ -23,7 +23,7 @@
   {/snippet}
 
   {#snippet rescue()}
-    <button id="reload-except" onclick={() => router.reload({ except: ['auth.notifications'] })}>
+    <button id="reload-except" onclick={() => router.reload({ except: ['auth.notifications'], headers: { 'X-Test-Retry': 'true' } })}>
       Reload without notifications
     </button>
   {/snippet}

--- a/packages/svelte/test-app/Pages/NestedProps/RescuedDeferredExcept.svelte
+++ b/packages/svelte/test-app/Pages/NestedProps/RescuedDeferredExcept.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { Deferred, router } from '@inertiajs/svelte'
+
+  interface Props {
+    auth: {
+      user?: string
+      token?: string
+      notifications?: string[]
+    }
+    status: string
+  }
+
+  let { auth, status }: Props = $props()
+</script>
+
+<p id="user">User: {auth.user}</p>
+<p id="token">Token: {auth.token}</p>
+<p id="status">Status: {status}</p>
+
+<Deferred data="auth.notifications">
+  {#snippet fallback()}
+    <div id="loading">Loading notifications...</div>
+  {/snippet}
+
+  {#snippet error()}
+    <button id="reload-except" onclick={() => router.reload({ except: ['auth.notifications'] })}>
+      Reload without notifications
+    </button>
+  {/snippet}
+
+  <p id="notifications">Notifications: {auth.notifications?.join(', ')}</p>
+</Deferred>

--- a/packages/svelte/test-app/Pages/NestedProps/RescuedDeferredExcept.svelte
+++ b/packages/svelte/test-app/Pages/NestedProps/RescuedDeferredExcept.svelte
@@ -23,7 +23,10 @@
   {/snippet}
 
   {#snippet rescue()}
-    <button id="reload-except" onclick={() => router.reload({ except: ['auth.notifications'], headers: { 'X-Test-Retry': 'true' } })}>
+    <button
+      id="reload-except"
+      onclick={() => router.reload({ except: ['auth.notifications'], headers: { 'X-Test-Retry': 'true' } })}
+    >
       Reload without notifications
     </button>
   {/snippet}

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -250,6 +250,7 @@ export function usePage<TPageProps extends PageProps = PageProps>(): Page<TPageP
       version: computed(() => page.value?.version),
       clearHistory: computed(() => page.value?.clearHistory),
       deferredProps: computed(() => page.value?.deferredProps),
+      rescuedProps: computed(() => page.value?.rescuedProps),
       mergeProps: computed(() => page.value?.mergeProps),
       prependProps: computed(() => page.value?.prependProps),
       deepMergeProps: computed(() => page.value?.deepMergeProps),

--- a/packages/vue3/src/deferred.ts
+++ b/packages/vue3/src/deferred.ts
@@ -1,4 +1,4 @@
-import { isSameUrlWithoutQueryOrHash, router, visitReloadsProps } from '@inertiajs/core'
+import { isSameUrlWithoutQueryOrHash, partialReloadRequestsSomeProps, router } from '@inertiajs/core'
 import { get } from 'es-toolkit/compat'
 import { computed, defineComponent, onMounted, onUnmounted, ref, type SlotsType } from 'vue'
 import { usePage } from './app'
@@ -33,7 +33,7 @@ export default defineComponent({
         if (
           visit.preserveState === true &&
           isSameUrlWithoutQueryOrHash(visit.url, window.location) &&
-          visitReloadsProps(visit, keys.value)
+          partialReloadRequestsSomeProps(visit, keys.value)
         ) {
           activeReloads.add(visit)
           reloading.value = true

--- a/packages/vue3/src/deferred.ts
+++ b/packages/vue3/src/deferred.ts
@@ -21,7 +21,7 @@ export default defineComponent({
     const activeReloads = new Set<object>()
     const page = usePage()
     const keys = computed(() => (Array.isArray(props.data) ? props.data : [props.data]) as string[])
-    const rescuedKeys = computed(() => new Set(page.rescuedProps || []))
+    const rescuedKeys = computed(() => new Set(page.rescuedProps))
 
     let removeStartListener: (() => void) | null = null
     let removeFinishListener: (() => void) | null = null
@@ -62,7 +62,9 @@ export default defineComponent({
       }
 
       const propsAreDefined = keys.value.every((key) => get(page.props, key) !== undefined)
-      const propsAreSettled = keys.value.every((key) => get(page.props, key) !== undefined || rescuedKeys.value.has(key))
+      const propsAreSettled = keys.value.every(
+        (key) => get(page.props, key) !== undefined || rescuedKeys.value.has(key),
+      )
       const hasRescuedProps = keys.value.some((key) => rescuedKeys.value.has(key))
 
       return propsAreDefined && !hasRescuedProps

--- a/packages/vue3/src/deferred.ts
+++ b/packages/vue3/src/deferred.ts
@@ -14,7 +14,7 @@ export default defineComponent({
   slots: Object as SlotsType<{
     default: { reloading: boolean }
     fallback: {}
-    rescue: {}
+    rescue: { reloading: boolean }
   }>,
   setup(props, { slots }) {
     const reloading = ref(false)
@@ -67,7 +67,7 @@ export default defineComponent({
       return propsAreDefined && !hasRescuedProps
         ? slots.default?.({ reloading: reloading.value })
         : hasRescuedProps && slots.rescue
-          ? slots.rescue({})
+          ? slots.rescue({ reloading: reloading.value })
           : slots.fallback({})
     }
   },

--- a/packages/vue3/src/deferred.ts
+++ b/packages/vue3/src/deferred.ts
@@ -14,7 +14,7 @@ export default defineComponent({
   slots: Object as SlotsType<{
     default: { reloading: boolean }
     fallback: {}
-    error: {}
+    rescue: {}
   }>,
   setup(props, { slots }) {
     const reloading = ref(false)
@@ -62,15 +62,12 @@ export default defineComponent({
       }
 
       const propsAreDefined = keys.value.every((key) => get(page.props, key) !== undefined)
-      const propsAreSettled = keys.value.every(
-        (key) => get(page.props, key) !== undefined || rescuedKeys.value.has(key),
-      )
       const hasRescuedProps = keys.value.some((key) => rescuedKeys.value.has(key))
 
       return propsAreDefined && !hasRescuedProps
         ? slots.default?.({ reloading: reloading.value })
-        : propsAreSettled && hasRescuedProps && slots.error
-          ? slots.error({})
+        : hasRescuedProps && slots.rescue
+          ? slots.rescue({})
           : slots.fallback({})
     }
   },

--- a/packages/vue3/src/deferred.ts
+++ b/packages/vue3/src/deferred.ts
@@ -1,6 +1,6 @@
-import { anyPathIsReloaded, isSameUrlWithoutQueryOrHash, router } from '@inertiajs/core'
+import { isSameUrlWithoutQueryOrHash, router, visitReloadsProps } from '@inertiajs/core'
 import { get } from 'es-toolkit/compat'
-import { defineComponent, onMounted, onUnmounted, ref, type SlotsType } from 'vue'
+import { computed, defineComponent, onMounted, onUnmounted, ref, type SlotsType } from 'vue'
 import { usePage } from './app'
 
 export default defineComponent({
@@ -20,20 +20,20 @@ export default defineComponent({
     const reloading = ref(false)
     const activeReloads = new Set<object>()
     const page = usePage()
+    const keys = computed(() => (Array.isArray(props.data) ? props.data : [props.data]) as string[])
+    const rescuedKeys = computed(() => new Set(page.rescuedProps || []))
 
     let removeStartListener: (() => void) | null = null
     let removeFinishListener: (() => void) | null = null
 
     onMounted(() => {
-      const keys = (Array.isArray(props.data) ? props.data : [props.data]) as string[]
-
       removeStartListener = router.on('start', (e) => {
         const visit = e.detail.visit
 
         if (
           visit.preserveState === true &&
           isSameUrlWithoutQueryOrHash(visit.url, window.location) &&
-          anyPathIsReloaded(keys, visit.only, visit.except)
+          visitReloadsProps(visit, keys.value)
         ) {
           activeReloads.add(visit)
           reloading.value = true
@@ -57,22 +57,19 @@ export default defineComponent({
     })
 
     return () => {
-      const keys = (Array.isArray(props.data) ? props.data : [props.data]) as string[]
-      const rescuedKeys = new Set(page.rescuedProps || [])
-
       if (!slots.fallback) {
         throw new Error('`<Deferred>` requires a `<template #fallback>` slot')
       }
 
-      const propsAreDefined = keys.every((key) => get(page.props, key) !== undefined)
-      const propsAreSettled = keys.every((key) => get(page.props, key) !== undefined || rescuedKeys.has(key))
-      const hasRescuedProps = keys.some((key) => rescuedKeys.has(key))
+      const propsAreDefined = keys.value.every((key) => get(page.props, key) !== undefined)
+      const propsAreSettled = keys.value.every((key) => get(page.props, key) !== undefined || rescuedKeys.value.has(key))
+      const hasRescuedProps = keys.value.some((key) => rescuedKeys.value.has(key))
 
       return propsAreDefined && !hasRescuedProps
         ? slots.default?.({ reloading: reloading.value })
         : propsAreSettled && hasRescuedProps && slots.error
           ? slots.error({})
-        : slots.fallback({})
+          : slots.fallback({})
     }
   },
 })

--- a/packages/vue3/src/deferred.ts
+++ b/packages/vue3/src/deferred.ts
@@ -1,19 +1,7 @@
-import { isSameUrlWithoutQueryOrHash, router } from '@inertiajs/core'
+import { anyPathIsReloaded, isSameUrlWithoutQueryOrHash, router } from '@inertiajs/core'
 import { get } from 'es-toolkit/compat'
 import { defineComponent, onMounted, onUnmounted, ref, type SlotsType } from 'vue'
 import { usePage } from './app'
-
-const keysAreBeingReloaded = (only: string[], except: string[], keys: string[]): boolean => {
-  if (only.length === 0 && except.length === 0) {
-    return true
-  }
-
-  if (only.length > 0) {
-    return keys.some((key) => only.includes(key))
-  }
-
-  return keys.some((key) => !except.includes(key))
-}
 
 export default defineComponent({
   name: 'Deferred',
@@ -26,6 +14,7 @@ export default defineComponent({
   slots: Object as SlotsType<{
     default: { reloading: boolean }
     fallback: {}
+    error: {}
   }>,
   setup(props, { slots }) {
     const reloading = ref(false)
@@ -44,7 +33,7 @@ export default defineComponent({
         if (
           visit.preserveState === true &&
           isSameUrlWithoutQueryOrHash(visit.url, window.location) &&
-          keysAreBeingReloaded(visit.only, visit.except, keys)
+          anyPathIsReloaded(keys, visit.only, visit.except)
         ) {
           activeReloads.add(visit)
           reloading.value = true
@@ -69,13 +58,20 @@ export default defineComponent({
 
     return () => {
       const keys = (Array.isArray(props.data) ? props.data : [props.data]) as string[]
+      const rescuedKeys = new Set(page.rescuedProps || [])
 
       if (!slots.fallback) {
         throw new Error('`<Deferred>` requires a `<template #fallback>` slot')
       }
 
-      return keys.every((key) => get(page.props, key) !== undefined)
+      const propsAreDefined = keys.every((key) => get(page.props, key) !== undefined)
+      const propsAreSettled = keys.every((key) => get(page.props, key) !== undefined || rescuedKeys.has(key))
+      const hasRescuedProps = keys.some((key) => rescuedKeys.has(key))
+
+      return propsAreDefined && !hasRescuedProps
         ? slots.default?.({ reloading: reloading.value })
+        : propsAreSettled && hasRescuedProps && slots.error
+          ? slots.error({})
         : slots.fallback({})
     }
   },

--- a/packages/vue3/test-app/Pages/DeferredProps/WithRescuedErrors.vue
+++ b/packages/vue3/test-app/Pages/DeferredProps/WithRescuedErrors.vue
@@ -16,7 +16,7 @@ const retry = () => {
       <div>Loading foo...</div>
     </template>
 
-    <template #error>
+    <template #rescue>
       <div id="foo-error">Unable to load foo.</div>
     </template>
 

--- a/packages/vue3/test-app/Pages/DeferredProps/WithRescuedErrors.vue
+++ b/packages/vue3/test-app/Pages/DeferredProps/WithRescuedErrors.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { Deferred, router } from '@inertiajs/vue3'
+
+defineProps<{
+  foo?: { text: string } | null
+}>()
+
+const retry = () => {
+  router.reload({ only: ['foo'] })
+}
+</script>
+
+<template>
+  <Deferred data="foo">
+    <template #fallback>
+      <div>Loading foo...</div>
+    </template>
+
+    <template #error>
+      <div id="foo-error">Unable to load foo.</div>
+    </template>
+
+    <div id="foo">{{ foo?.text }}</div>
+  </Deferred>
+
+  <button type="button" @click="retry">Retry</button>
+</template>

--- a/packages/vue3/test-app/Pages/DeferredProps/WithRescuedErrors.vue
+++ b/packages/vue3/test-app/Pages/DeferredProps/WithRescuedErrors.vue
@@ -6,7 +6,7 @@ defineProps<{
 }>()
 
 const retry = () => {
-  router.reload({ only: ['foo'] })
+  router.reload({ only: ['foo'], headers: { 'X-Test-Retry': 'true' } })
 }
 </script>
 
@@ -16,8 +16,9 @@ const retry = () => {
       <div>Loading foo...</div>
     </template>
 
-    <template #rescue>
+    <template #rescue="{ reloading }">
       <div id="foo-error">Unable to load foo.</div>
+      <span id="reloading">{{ reloading }}</span>
     </template>
 
     <div id="foo">{{ foo?.text }}</div>

--- a/packages/vue3/test-app/Pages/NestedProps/RescuedDeferred.vue
+++ b/packages/vue3/test-app/Pages/NestedProps/RescuedDeferred.vue
@@ -18,7 +18,9 @@ defineProps<{
     </template>
 
     <template #rescue>
-      <button id="retry" @click="router.reload({ only: ['auth'], headers: { 'X-Test-Retry': 'true' } })">Retry auth</button>
+      <button id="retry" @click="router.reload({ only: ['auth'], headers: { 'X-Test-Retry': 'true' } })">
+        Retry auth
+      </button>
     </template>
 
     <p id="notifications">Notifications: {{ auth.notifications?.join(', ') }}</p>

--- a/packages/vue3/test-app/Pages/NestedProps/RescuedDeferred.vue
+++ b/packages/vue3/test-app/Pages/NestedProps/RescuedDeferred.vue
@@ -18,7 +18,7 @@ defineProps<{
     </template>
 
     <template #rescue>
-      <button id="retry" @click="router.reload({ only: ['auth'] })">Retry auth</button>
+      <button id="retry" @click="router.reload({ only: ['auth'], headers: { 'X-Test-Retry': 'true' } })">Retry auth</button>
     </template>
 
     <p id="notifications">Notifications: {{ auth.notifications?.join(', ') }}</p>

--- a/packages/vue3/test-app/Pages/NestedProps/RescuedDeferred.vue
+++ b/packages/vue3/test-app/Pages/NestedProps/RescuedDeferred.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { Deferred, router } from '@inertiajs/vue3'
+
+defineProps<{
+  auth: {
+    user?: string
+    notifications?: string[]
+  }
+}>()
+</script>
+
+<template>
+  <p id="user">User: {{ auth.user }}</p>
+
+  <Deferred data="auth.notifications">
+    <template #fallback>
+      <div id="loading">Loading notifications...</div>
+    </template>
+
+    <template #error>
+      <button id="retry" @click="router.reload({ only: ['auth'] })">Retry auth</button>
+    </template>
+
+    <p id="notifications">Notifications: {{ auth.notifications?.join(', ') }}</p>
+  </Deferred>
+</template>

--- a/packages/vue3/test-app/Pages/NestedProps/RescuedDeferred.vue
+++ b/packages/vue3/test-app/Pages/NestedProps/RescuedDeferred.vue
@@ -17,7 +17,7 @@ defineProps<{
       <div id="loading">Loading notifications...</div>
     </template>
 
-    <template #error>
+    <template #rescue>
       <button id="retry" @click="router.reload({ only: ['auth'] })">Retry auth</button>
     </template>
 

--- a/packages/vue3/test-app/Pages/NestedProps/RescuedDeferredExcept.vue
+++ b/packages/vue3/test-app/Pages/NestedProps/RescuedDeferredExcept.vue
@@ -22,7 +22,10 @@ defineProps<{
     </template>
 
     <template #rescue>
-      <button id="reload-except" @click="router.reload({ except: ['auth.notifications'], headers: { 'X-Test-Retry': 'true' } })">
+      <button
+        id="reload-except"
+        @click="router.reload({ except: ['auth.notifications'], headers: { 'X-Test-Retry': 'true' } })"
+      >
         Reload without notifications
       </button>
     </template>

--- a/packages/vue3/test-app/Pages/NestedProps/RescuedDeferredExcept.vue
+++ b/packages/vue3/test-app/Pages/NestedProps/RescuedDeferredExcept.vue
@@ -22,7 +22,7 @@ defineProps<{
     </template>
 
     <template #rescue>
-      <button id="reload-except" @click="router.reload({ except: ['auth.notifications'] })">
+      <button id="reload-except" @click="router.reload({ except: ['auth.notifications'], headers: { 'X-Test-Retry': 'true' } })">
         Reload without notifications
       </button>
     </template>

--- a/packages/vue3/test-app/Pages/NestedProps/RescuedDeferredExcept.vue
+++ b/packages/vue3/test-app/Pages/NestedProps/RescuedDeferredExcept.vue
@@ -21,7 +21,7 @@ defineProps<{
       <div id="loading">Loading notifications...</div>
     </template>
 
-    <template #error>
+    <template #rescue>
       <button id="reload-except" @click="router.reload({ except: ['auth.notifications'] })">
         Reload without notifications
       </button>

--- a/packages/vue3/test-app/Pages/NestedProps/RescuedDeferredExcept.vue
+++ b/packages/vue3/test-app/Pages/NestedProps/RescuedDeferredExcept.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { Deferred, router } from '@inertiajs/vue3'
+
+defineProps<{
+  auth: {
+    user?: string
+    token?: string
+    notifications?: string[]
+  }
+  status: string
+}>()
+</script>
+
+<template>
+  <p id="user">User: {{ auth.user }}</p>
+  <p id="token">Token: {{ auth.token }}</p>
+  <p id="status">Status: {{ status }}</p>
+
+  <Deferred data="auth.notifications">
+    <template #fallback>
+      <div id="loading">Loading notifications...</div>
+    </template>
+
+    <template #error>
+      <button id="reload-except" @click="router.reload({ except: ['auth.notifications'] })">
+        Reload without notifications
+      </button>
+    </template>
+
+    <p id="notifications">Notifications: {{ auth.notifications?.join(', ') }}</p>
+  </Deferred>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -3411,12 +3411,13 @@ app.get('/nested-props/rescued-deferred', (req, res) => {
     return inertia.render(req, res, {
       component: 'NestedProps/RescuedDeferred',
       props: {
-        auth: partialData.includes('auth') || partialData.includes('auth.notifications')
-          ? {
-              user: 'John Doe',
-              notifications: ['Notification 1', 'Notification 2', 'Notification 3'],
-            }
-          : undefined,
+        auth:
+          partialData.includes('auth') || partialData.includes('auth.notifications')
+            ? {
+                user: 'John Doe',
+                notifications: ['Notification 1', 'Notification 2', 'Notification 3'],
+              }
+            : undefined,
       },
     })
   }, 300)

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -1666,7 +1666,6 @@ app.get('/deferred-props/partial-reloads', (req, res) => {
 })
 
 let deferredPropsWithErrorsState = {}
-let rescuedPropsState = { failNext: true }
 
 app.get('/deferred-props/with-errors', (req, res) => {
   const errors = { ...deferredPropsWithErrorsState }
@@ -1706,8 +1705,6 @@ app.post('/deferred-props/with-errors', (req, res) => {
 
 app.get('/deferred-props/with-rescued-errors', (req, res) => {
   if (!req.headers['x-inertia-partial-data']) {
-    rescuedPropsState = { failNext: true }
-
     return inertia.render(req, res, {
       component: 'DeferredProps/WithRescuedErrors',
       deferredProps: {
@@ -1718,22 +1715,20 @@ app.get('/deferred-props/with-rescued-errors', (req, res) => {
   }
 
   setTimeout(() => {
-    if (rescuedPropsState.failNext) {
-      rescuedPropsState.failNext = false
-
+    if (req.headers['x-test-retry']) {
       return inertia.render(req, res, {
         component: 'DeferredProps/WithRescuedErrors',
-        rescuedProps: ['foo'],
         props: {
-          foo: null,
+          foo: { text: 'foo value' },
         },
       })
     }
 
     return inertia.render(req, res, {
       component: 'DeferredProps/WithRescuedErrors',
+      rescuedProps: ['foo'],
       props: {
-        foo: { text: 'foo value' },
+        foo: null,
       },
     })
   }, 250)
@@ -3374,14 +3369,10 @@ app.get('/nested-props/deferred', (req, res) => {
   )
 })
 
-let nestedRescuedDeferredFailedOnce = false
-
 app.get('/nested-props/rescued-deferred', (req, res) => {
   const partialData = req.headers['x-inertia-partial-data']?.split(',') ?? []
 
   if (!req.headers['x-inertia-partial-data']) {
-    nestedRescuedDeferredFailedOnce = false
-
     return inertia.render(req, res, {
       component: 'NestedProps/RescuedDeferred',
       deferredProps: {
@@ -3396,42 +3387,36 @@ app.get('/nested-props/rescued-deferred', (req, res) => {
   }
 
   setTimeout(() => {
-    if (!nestedRescuedDeferredFailedOnce && partialData.includes('auth.notifications')) {
-      nestedRescuedDeferredFailedOnce = true
-
+    if (req.headers['x-test-retry']) {
       return inertia.render(req, res, {
         component: 'NestedProps/RescuedDeferred',
-        rescuedProps: ['auth.notifications'],
         props: {
-          auth: {},
+          auth:
+            partialData.includes('auth') || partialData.includes('auth.notifications')
+              ? {
+                  user: 'John Doe',
+                  notifications: ['Notification 1', 'Notification 2', 'Notification 3'],
+                }
+              : undefined,
         },
       })
     }
 
     return inertia.render(req, res, {
       component: 'NestedProps/RescuedDeferred',
+      rescuedProps: ['auth.notifications'],
       props: {
-        auth:
-          partialData.includes('auth') || partialData.includes('auth.notifications')
-            ? {
-                user: 'John Doe',
-                notifications: ['Notification 1', 'Notification 2', 'Notification 3'],
-              }
-            : undefined,
+        auth: {},
       },
     })
   }, 300)
 })
-
-let nestedExceptRescuedDeferredFailedOnce = false
 
 app.get('/nested-props/rescued-deferred-except', (req, res) => {
   const partialData = req.headers['x-inertia-partial-data']?.split(',') ?? []
   const partialExcept = req.headers['x-inertia-partial-except']?.split(',') ?? []
 
   if (!req.headers['x-inertia-partial-data'] && !req.headers['x-inertia-partial-except']) {
-    nestedExceptRescuedDeferredFailedOnce = false
-
     return inertia.render(req, res, {
       component: 'NestedProps/RescuedDeferredExcept',
       deferredProps: {
@@ -3448,36 +3433,34 @@ app.get('/nested-props/rescued-deferred-except', (req, res) => {
   }
 
   setTimeout(() => {
-    if (!nestedExceptRescuedDeferredFailedOnce && partialData.includes('auth.notifications')) {
-      nestedExceptRescuedDeferredFailedOnce = true
-
+    if (req.headers['x-test-retry']) {
       return inertia.render(req, res, {
         component: 'NestedProps/RescuedDeferredExcept',
-        rescuedProps: ['auth.notifications'],
         props: {
-          auth: {
-            user: 'John Doe',
-            token: 'secret-token-123',
-          },
-          status: 'pending',
+          auth: partialExcept.includes('auth.notifications')
+            ? {
+                user: 'John Doe',
+                token: 'rotated-token-456',
+              }
+            : {
+                user: 'John Doe',
+                token: 'rotated-token-456',
+                notifications: ['Notification 1', 'Notification 2', 'Notification 3'],
+              },
+          status: 'refreshed',
         },
       })
     }
 
     return inertia.render(req, res, {
       component: 'NestedProps/RescuedDeferredExcept',
+      rescuedProps: ['auth.notifications'],
       props: {
-        auth: partialExcept.includes('auth.notifications')
-          ? {
-              user: 'John Doe',
-              token: 'rotated-token-456',
-            }
-          : {
-              user: 'John Doe',
-              token: 'rotated-token-456',
-              notifications: ['Notification 1', 'Notification 2', 'Notification 3'],
-            },
-        status: 'refreshed',
+        auth: {
+          user: 'John Doe',
+          token: 'secret-token-123',
+        },
+        status: 'pending',
       },
     })
   }, 300)

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -1666,6 +1666,7 @@ app.get('/deferred-props/partial-reloads', (req, res) => {
 })
 
 let deferredPropsWithErrorsState = {}
+let rescuedPropsState = { failNext: true }
 
 app.get('/deferred-props/with-errors', (req, res) => {
   const errors = { ...deferredPropsWithErrorsState }
@@ -1701,6 +1702,41 @@ app.post('/deferred-props/with-errors', (req, res) => {
   deferredPropsWithErrorsState = { name: 'The name field is required.' }
 
   res.redirect(303, '/deferred-props/with-errors')
+})
+
+app.get('/deferred-props/with-rescued-errors', (req, res) => {
+  if (!req.headers['x-inertia-partial-data']) {
+    rescuedPropsState = { failNext: true }
+
+    return inertia.render(req, res, {
+      component: 'DeferredProps/WithRescuedErrors',
+      deferredProps: {
+        default: ['foo'],
+      },
+      props: {},
+    })
+  }
+
+  setTimeout(() => {
+    if (rescuedPropsState.failNext) {
+      rescuedPropsState.failNext = false
+
+      return inertia.render(req, res, {
+        component: 'DeferredProps/WithRescuedErrors',
+        rescuedProps: ['foo'],
+        props: {
+          foo: null,
+        },
+      })
+    }
+
+    return inertia.render(req, res, {
+      component: 'DeferredProps/WithRescuedErrors',
+      props: {
+        foo: { text: 'foo value' },
+      },
+    })
+  }, 250)
 })
 
 app.get('/deferred-props/with-reload', (req, res) => {
@@ -3336,6 +3372,114 @@ app.get('/nested-props/deferred', (req, res) => {
       }),
     300,
   )
+})
+
+let nestedRescuedDeferredFailedOnce = false
+
+app.get('/nested-props/rescued-deferred', (req, res) => {
+  const partialData = req.headers['x-inertia-partial-data']?.split(',') ?? []
+
+  if (!req.headers['x-inertia-partial-data']) {
+    nestedRescuedDeferredFailedOnce = false
+
+    return inertia.render(req, res, {
+      component: 'NestedProps/RescuedDeferred',
+      deferredProps: {
+        default: ['auth.notifications'],
+      },
+      props: {
+        auth: {
+          user: 'John Doe',
+        },
+      },
+    })
+  }
+
+  setTimeout(() => {
+    if (!nestedRescuedDeferredFailedOnce && partialData.includes('auth.notifications')) {
+      nestedRescuedDeferredFailedOnce = true
+
+      return inertia.render(req, res, {
+        component: 'NestedProps/RescuedDeferred',
+        rescuedProps: ['auth.notifications'],
+        props: {
+          auth: {},
+        },
+      })
+    }
+
+    return inertia.render(req, res, {
+      component: 'NestedProps/RescuedDeferred',
+      props: {
+        auth: partialData.includes('auth') || partialData.includes('auth.notifications')
+          ? {
+              user: 'John Doe',
+              notifications: ['Notification 1', 'Notification 2', 'Notification 3'],
+            }
+          : undefined,
+      },
+    })
+  }, 300)
+})
+
+let nestedExceptRescuedDeferredFailedOnce = false
+
+app.get('/nested-props/rescued-deferred-except', (req, res) => {
+  const partialData = req.headers['x-inertia-partial-data']?.split(',') ?? []
+  const partialExcept = req.headers['x-inertia-partial-except']?.split(',') ?? []
+
+  if (!req.headers['x-inertia-partial-data'] && !req.headers['x-inertia-partial-except']) {
+    nestedExceptRescuedDeferredFailedOnce = false
+
+    return inertia.render(req, res, {
+      component: 'NestedProps/RescuedDeferredExcept',
+      deferredProps: {
+        default: ['auth.notifications'],
+      },
+      props: {
+        auth: {
+          user: 'John Doe',
+          token: 'secret-token-123',
+        },
+        status: 'pending',
+      },
+    })
+  }
+
+  setTimeout(() => {
+    if (!nestedExceptRescuedDeferredFailedOnce && partialData.includes('auth.notifications')) {
+      nestedExceptRescuedDeferredFailedOnce = true
+
+      return inertia.render(req, res, {
+        component: 'NestedProps/RescuedDeferredExcept',
+        rescuedProps: ['auth.notifications'],
+        props: {
+          auth: {
+            user: 'John Doe',
+            token: 'secret-token-123',
+          },
+          status: 'pending',
+        },
+      })
+    }
+
+    return inertia.render(req, res, {
+      component: 'NestedProps/RescuedDeferredExcept',
+      props: {
+        auth: partialExcept.includes('auth.notifications')
+          ? {
+              user: 'John Doe',
+              token: 'rotated-token-456',
+            }
+          : {
+              user: 'John Doe',
+              token: 'rotated-token-456',
+              notifications: ['Notification 1', 'Notification 2', 'Notification 3'],
+            },
+        status: 'refreshed',
+      },
+    })
+  }, 300)
 })
 
 let nestedMergeRequestCount = 0

--- a/tests/deferred-props.spec.ts
+++ b/tests/deferred-props.spec.ts
@@ -43,6 +43,30 @@ test('can load deferred props', async ({ page }) => {
   await expect(page.getByText('both baz value and qux value')).toBeVisible()
 })
 
+test('can render rescued deferred props with error UI and recover on retry', async ({ page }) => {
+  await gotoPageAndWaitForContent(page, '/deferred-props/with-rescued-errors')
+
+  await expect(page.getByText('Loading foo...')).toBeVisible()
+
+  await page.waitForResponse(
+    (response) => response.request().headers()['x-inertia-partial-data'] === 'foo' && response.status() === 200,
+  )
+
+  await expect(page.getByText('Loading foo...')).not.toBeVisible()
+  await expect(page.locator('#foo-error')).toContainText('Unable to load foo.')
+  await expect(page.locator('#foo')).toHaveCount(0)
+
+  const retryResponse = page.waitForResponse(
+    (response) => response.request().headers()['x-inertia-partial-data'] === 'foo' && response.status() === 200,
+  )
+
+  await page.getByRole('button', { exact: true, name: 'Retry' }).click()
+  await retryResponse
+
+  await expect(page.locator('#foo-error')).not.toBeVisible()
+  await expect(page.locator('#foo')).toContainText('foo value')
+})
+
 test('we are not caching deferred props after reload', async ({ page }) => {
   await gotoPageAndWaitForContent(page, '/deferred-props/page-1')
 

--- a/tests/deferred-props.spec.ts
+++ b/tests/deferred-props.spec.ts
@@ -54,6 +54,7 @@ test('can render rescued deferred props with error UI and recover on retry', asy
 
   await expect(page.getByText('Loading foo...')).not.toBeVisible()
   await expect(page.locator('#foo-error')).toContainText('Unable to load foo.')
+  await expect(page.locator('#reloading')).toContainText('false')
   await expect(page.locator('#foo')).toHaveCount(0)
 
   const retryResponse = page.waitForResponse(
@@ -61,6 +62,9 @@ test('can render rescued deferred props with error UI and recover on retry', asy
   )
 
   await page.getByRole('button', { exact: true, name: 'Retry' }).click()
+
+  await expect(page.locator('#reloading')).toContainText('true')
+
   await retryResponse
 
   await expect(page.locator('#foo-error')).not.toBeVisible()

--- a/tests/nested-props.spec.ts
+++ b/tests/nested-props.spec.ts
@@ -14,6 +14,34 @@ test('it can load nested deferred props without clobbering siblings', async ({ p
   await expect(page.locator('#user')).toContainText('User: John Doe')
 })
 
+test('it clears rescued child props when a parent path is reloaded', async ({ page }) => {
+  await page.goto('/nested-props/rescued-deferred')
+
+  await expect(page.locator('#user')).toContainText('User: John Doe')
+  await expect(page.locator('#retry')).toBeVisible()
+
+  await clickAndWaitForResponse(page, 'Retry auth', '/nested-props/rescued-deferred', 'button')
+
+  await expect(page.locator('#retry')).toHaveCount(0)
+  await expect(page.locator('#notifications')).toContainText(
+    'Notifications: Notification 1, Notification 2, Notification 3',
+  )
+  await expect(page.locator('#user')).toContainText('User: John Doe')
+})
+
+test('it preserves rescued child props when that child path is excluded from reload', async ({ page }) => {
+  await page.goto('/nested-props/rescued-deferred-except')
+
+  await expect(page.locator('#reload-except')).toBeVisible()
+
+  await clickAndWaitForResponse(page, 'Reload without notifications', '/nested-props/rescued-deferred-except', 'button')
+
+  await expect(page.locator('#reload-except')).toBeVisible()
+  await expect(page.locator('#notifications')).toHaveCount(0)
+  await expect(page.locator('#token')).toContainText('Token: secret-token-123')
+  await expect(page.locator('#status')).toContainText('Status: refreshed')
+})
+
 test('it can append to nested merge props', async ({ page }) => {
   await page.goto('/nested-props/merge')
 


### PR DESCRIPTION
This PR adds frontend support for rescued deferred props. When the Laravel adapter uses `rescue: true` on a deferred prop and the underlying computation throws an exception, the prop is marked as rescued and included in `rescuedProps` on the page object.

```php
return Inertia::render('Dashboard', [
    'stats' => Inertia::defer(fn () => Github::stats(), rescue: true),
]);
```

The `<Deferred>` component now exposes a `rescue` slot that renders when any of its props have been rescued, giving you a way to show error UI or a retry button instead of leaving the user stuck on the fallback. The slot receives a `reloading` boolean so you can disable the retry button while a reload is in progress.

Rescued prop state is tracked across partial reloads. If a reload targets the rescued prop, it's cleared from the rescued set so the component can attempt to render normally again.

```vue
<script setup>
import { Deferred, router } from '@inertiajs/vue3'

defineProps(['stats'])
</script>

<template>
  <Deferred data="stats">
    <template #fallback>
      <div>Loading...</div>
    </template>

    <template #rescue="{ reloading }">
      <button :disabled="reloading" @click="router.reload({ only: ['stats'] })">
        Retry
      </button>
    </template>

    <StatsOverview :stats="stats" />
  </Deferred>
</template>
```