### PR TITLE
[3.x] Add `host` option to SSR server

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -56,6 +56,7 @@ type AppCallback = (page: Page) => InertiaAppResponse
 type RouteHandler = (request: IncomingMessage, response: ServerResponse) => Promise<unknown>
 type ServerOptions = {
   port?: number
+  host?: string
   cluster?: boolean
   formatErrors?: boolean
 }
@@ -71,7 +72,7 @@ const readableToString: (readable: IncomingMessage) => Promise<string> = (readab
 
 export default (render: AppCallback, options?: Port | ServerOptions): AppCallback => {
   const opts = typeof options === 'number' ? { port: options } : options
-  const { port = 13714, cluster: useCluster = false, formatErrors = true } = opts ?? {}
+  const { port = 13714, host = '0.0.0.0', cluster: useCluster = false, formatErrors = true } = opts ?? {}
 
   const log = (message: string) => {
     console.log(
@@ -156,7 +157,7 @@ export default (render: AppCallback, options?: Port | ServerOptions): AppCallbac
     }
 
     response.end()
-  }).listen(port, () => log('Inertia SSR server started.'))
+  }).listen({ port, host }, () => log('Inertia SSR server started.'))
 
   log(`Starting SSR server on port ${port}...`)
 

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -1,0 +1,17 @@
+import * as http from 'http'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import createSSRServer from '../src/server'
+
+describe('SSR Server', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('forwards the host option to listen', () => {
+    const listenSpy = vi.spyOn(http.Server.prototype, 'listen').mockReturnThis()
+
+    createSSRServer(() => Promise.resolve({ body: '', head: [] }), { port: 19990, host: '127.0.0.1' })
+
+    expect(listenSpy).toHaveBeenCalledWith({ port: 19990, host: '127.0.0.1' }, expect.any(Function))
+  })
+})

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -144,7 +144,7 @@ export default function inertia(options: InertiaPluginOptions = {}): Plugin {
         result =
           wrapWithServerBootstrap(
             result,
-            { port: ssr.port, cluster: ssr.cluster, formatErrors: ssr.formatErrors },
+            { port: ssr.port, host: ssr.host, cluster: ssr.cluster, formatErrors: ssr.formatErrors },
             frameworks,
           ) ?? result
       }

--- a/packages/vite/src/ssr.ts
+++ b/packages/vite/src/ssr.ts
@@ -38,6 +38,11 @@ export interface InertiaSSROptions {
   port?: number
 
   /**
+   * Host to bind the SSR server to (used in production builds).
+   */
+  host?: string
+
+  /**
    * Enable cluster mode for the SSR server (used in production builds).
    */
   cluster?: boolean

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -101,6 +101,12 @@ export interface SSROptions {
   port?: number
 
   /**
+   * Host to bind the SSR server to.
+   * Used in production when running the SSR server as a separate process.
+   */
+  host?: string
+
+  /**
    * Whether to enable cluster mode for the SSR server.
    * Cluster mode spawns multiple worker processes for better performance.
    */

--- a/packages/vite/tests/ssrTransform.test.ts
+++ b/packages/vite/tests/ssrTransform.test.ts
@@ -97,11 +97,11 @@ createInertiaApp({})`
       `)
     })
 
-    it('includes port and cluster config', () => {
+    it('includes port, host and cluster config', () => {
       const code = `import { createInertiaApp } from '@inertiajs/svelte'
 createInertiaApp({})`
 
-      expect(wrap(code, { port: 13715, cluster: true })).toMatchInlineSnapshot(`
+      expect(wrap(code, { port: 13715, host: '127.0.0.1', cluster: true })).toMatchInlineSnapshot(`
         "import { createInertiaApp } from '@inertiajs/svelte'
         import createServer from '@inertiajs/svelte/server'
         import { render } from 'svelte/server'
@@ -111,7 +111,7 @@ createInertiaApp({})`
         const renderPage = (page) => ssr(page, render)
 
         if (import.meta.env.PROD) {
-          createServer(renderPage, {"port":13715,"cluster":true})
+          createServer(renderPage, {"port":13715,"host":"127.0.0.1","cluster":true})
         }
 
         export default renderPage"

--- a/playgrounds/vue3/vite.config.ts
+++ b/playgrounds/vue3/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       ssr: 'resources/js/ssr.ts',
       refresh: true,
     }),
-    inertia({ ssr: { handleErrors: false } }),
+    inertia(),
     vue({
       template: {
         transformAssetUrls: {


### PR DESCRIPTION
This PR adds a `host` option to the SSR server, allowing you to control which network interface the server binds to. The default remains `0.0.0.0` to preserve existing behavior.