### PR TITLE
[3.x] Sandbox error dialog iframe to prevent `window.parent` access

### DIFF
--- a/packages/core/src/dialog.ts
+++ b/packages/core/src/dialog.ts
@@ -15,6 +15,7 @@ export default {
     iframe.style.borderRadius = '5px'
     iframe.style.width = '100%'
     iframe.style.height = '100%'
+    iframe.setAttribute('sandbox', 'allow-scripts')
 
     return { iframe, page }
   },
@@ -66,12 +67,6 @@ export default {
 
     dialog.focus()
 
-    if (!iframe.contentWindow) {
-      throw new Error('iframe not yet ready.')
-    }
-
-    iframe.contentWindow.document.open()
-    iframe.contentWindow.document.write(page.outerHTML)
-    iframe.contentWindow.document.close()
+    iframe.srcdoc = page.outerHTML
   },
 }

--- a/packages/react/test-app/Pages/ErrorModal.tsx
+++ b/packages/react/test-app/Pages/ErrorModal.tsx
@@ -9,6 +9,10 @@ export default () => {
     router.post('/json')
   }
 
+  const invalidVisitXss = () => {
+    router.post('/non-inertia/xss')
+  }
+
   return (
     <div>
       <span onClick={invalidVisit} className="invalid-visit">
@@ -16,6 +20,9 @@ export default () => {
       </span>
       <span onClick={invalidVisitJson} className="invalid-visit-json">
         Invalid Visit (JSON response)
+      </span>
+      <span onClick={invalidVisitXss} className="invalid-visit-xss">
+        Invalid Visit (XSS)
       </span>
     </div>
   )

--- a/packages/svelte/test-app/Pages/ErrorModal.svelte
+++ b/packages/svelte/test-app/Pages/ErrorModal.svelte
@@ -8,6 +8,10 @@
   const invalidVisitJson = () => {
     router.post('/json')
   }
+
+  const invalidVisitXss = () => {
+    router.post('/non-inertia/xss')
+  }
 </script>
 
 <div>
@@ -24,5 +28,12 @@
     role="button"
     tabindex="0"
     class="invalid-visit-json">Invalid Visit (JSON response)</span
+  >
+  <span
+    onclick={invalidVisitXss}
+    onkeydown={(e) => e.key === 'Enter' && invalidVisitXss()}
+    role="button"
+    tabindex="0"
+    class="invalid-visit-xss">Invalid Visit (XSS)</span
   >
 </div>

--- a/packages/vue3/test-app/Pages/ErrorModal.vue
+++ b/packages/vue3/test-app/Pages/ErrorModal.vue
@@ -8,11 +8,16 @@ const invalidVisit = () => {
 const invalidVisitJson = () => {
   router.post('/json')
 }
+
+const invalidVisitXss = () => {
+  router.post('/non-inertia/xss')
+}
 </script>
 
 <template>
   <div>
     <span @click="invalidVisit" class="invalid-visit">Invalid Visit</span>
     <span @click="invalidVisitJson" class="invalid-visit-json">Invalid Visit (JSON response)</span>
+    <span @click="invalidVisitXss" class="invalid-visit-xss">Invalid Visit (XSS)</span>
   </div>
 </template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -34,6 +34,19 @@ app.all('/non-inertia', (req, res) =>
   `),
 )
 
+app.post('/non-inertia/xss', (req, res) =>
+  res.status(200).send(`
+    <!DOCTYPE html>
+    <html>
+      <head><title>XSS Test Page</title></head>
+      <body>
+        <script>window.parent.xssExecuted = true;<\/script>
+        <p>XSS test page</p>
+      </body>
+    </html>
+  `),
+)
+
 app.get('/non-inertia/download', (req, res) => {
   const query = new URLSearchParams(req.query).toString()
   res.setHeader('Content-Type', 'text/plain')

--- a/tests/error-modal.spec.ts
+++ b/tests/error-modal.spec.ts
@@ -47,4 +47,11 @@ test.describe('error modal', () => {
     await page.mouse.click(25, 25)
     await expect(page.frameLocator('iframe').getByText('This is a page that does not')).toBeHidden()
   })
+
+  test('it does not execute scripts in the error dialog iframe', async ({ page }) => {
+    await page.getByText('Invalid Visit (XSS)', { exact: true }).click()
+    await expect(page.locator('dialog#inertia-error-dialog > iframe')).toBeVisible()
+    const xssExecuted = await page.evaluate(() => (window as any).xssExecuted)
+    expect(xssExecuted).toBeUndefined()
+  })
 })


### PR DESCRIPTION
When Inertia renders a non-Inertia response in the error dialog, it displays the raw HTML inside an iframe. Without restrictions, scripts in that response can call `window.parent` and interact with the host page. This PR adds `sandbox="allow-scripts"` to the iframe, blocking cross-origin access to `window.parent` while still allowing scripts to execute.