### PR TITLE
[3.x] Escape title content in SSR head output

### DIFF
--- a/packages/core/src/head.ts
+++ b/packages/core/src/head.ts
@@ -114,7 +114,7 @@ export default function createHeadManager(
         }
 
         if (element.indexOf('<title ') === 0) {
-          const title = element.match(/(<title [^>]+>)(.*?)(<\/title>)/)
+          const title = element.match(/(<title [^>]+>)(.*?)(<\/title>)/s)
           carry.title = title ? `${title[1]}${titleCallback(title[2])}${title[3]}` : element
           return carry
         }

--- a/packages/core/tests/head.test.ts
+++ b/packages/core/tests/head.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import createHeadManager from '../src/head'
+
+describe('createHeadManager', () => {
+  describe('SSR title escaping', () => {
+    it('escapes HTML in the title element to prevent XSS injection via newline bypass', () => {
+      const collected: string[][] = []
+
+      const manager = createHeadManager(
+        true,
+        (title) => title,
+        (elements) => collected.push(elements),
+      )
+
+      const provider = manager.createProvider()
+      provider.update([`<title data-inertia="">Safe Title\n</title><script>alert('xss')</script></title>`])
+
+      const head = collected[collected.length - 1].join('')
+
+      expect(head).not.toContain('<script>alert(')
+    })
+
+  })
+})

--- a/packages/core/tests/head.test.ts
+++ b/packages/core/tests/head.test.ts
@@ -19,6 +19,5 @@ describe('createHeadManager', () => {
 
       expect(head).not.toContain('<script>alert(')
     })
-
   })
 })

--- a/packages/react/src/Head.ts
+++ b/packages/react/src/Head.ts
@@ -111,7 +111,7 @@ const Head: InertiaHead = function ({ children, title }) {
       .map((node) => renderNode(node as ReactElement<any>))
 
     if (title && !elements.find((tag) => tag.startsWith('<title'))) {
-      elements.push(`<title data-inertia="">${title}</title>`)
+      elements.push(`<title data-inertia="">${escape(title)}</title>`)
     }
 
     return elements

--- a/packages/react/test-app/Pages/SSR/HeadWithXssTitle.tsx
+++ b/packages/react/test-app/Pages/SSR/HeadWithXssTitle.tsx
@@ -1,0 +1,12 @@
+import { Head } from '@inertiajs/react'
+
+export default ({ title }: { title: string }) => {
+  return (
+    <>
+      <Head title={title} />
+      <div>
+        <p>Head title escaping test</p>
+      </div>
+    </>
+  )
+}

--- a/packages/vue3/src/head.ts
+++ b/packages/vue3/src/head.ts
@@ -107,7 +107,7 @@ function renderTag(node: VNode): string {
 
 function addTitleElement(elements: string[], title?: string): string[] {
   if (title && !elements.find((tag) => tag.startsWith('<title'))) {
-    elements.push(`<title data-inertia="">${title}</title>`)
+    elements.push(`<title data-inertia="">${escape(title)}</title>`)
   }
 
   return elements

--- a/packages/vue3/test-app/Pages/SSR/HeadWithXssTitle.vue
+++ b/packages/vue3/test-app/Pages/SSR/HeadWithXssTitle.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3'
+
+defineProps<{
+  title: string
+}>()
+</script>
+
+<template>
+  <Head :title="title" />
+  <div>
+    <p>Head title escaping test</p>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -91,6 +91,15 @@ app.get('/ssr/layout-props-callback', (req, res) =>
   }),
 )
 
+app.get('/ssr/head-with-xss-title', (req, res) =>
+  inertia.renderSSR(req, res, {
+    component: 'SSR/HeadWithXssTitle',
+    props: {
+      title: "Safe Title\n</title><script>alert('xss')</script>",
+    },
+  }),
+)
+
 // SSR auto-transform test routes (uses the Vite plugin SSR transform)
 app.get('/ssr-auto/page1', (req, res) =>
   inertia.renderSSRAuto(req, res, {

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -89,6 +89,20 @@ test.describe('SSR', () => {
   })
 })
 
+test.describe('Head title escaping', () => {
+  test.beforeEach(() => {
+    test.skip(process.env.PACKAGE === 'svelte', 'Svelte adapter has no Head component')
+  })
+
+  test('it escapes HTML in the title prop to prevent XSS in SSR output', async ({ page }) => {
+    const response = await page.request.get('/ssr/head-with-xss-title')
+    const html = await response.text()
+
+    expect(html).not.toContain('<script>alert(')
+    expect(html).toContain('&lt;/title&gt;&lt;script&gt;')
+  })
+})
+
 test.describe('layout props', () => {
   test('it does not leak layout props between SSR requests', async ({ page, browserName }) => {
     const responseA = await page.request.get('/ssr/layout-props-a')

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -98,7 +98,7 @@ test.describe('Head title escaping', () => {
     const response = await page.request.get('/ssr/head-with-xss-title')
     const html = await response.text()
 
-    expect(html).not.toContain('<script>alert(')
+    expect(html).not.toContain('</title><script>alert(')
     expect(html).toContain('&lt;/title&gt;&lt;script&gt;')
   })
 })


### PR DESCRIPTION
This PR ensures the `title` prop passed to the `<Head>` component is HTML-escaped before being inserted into the `<title>` tag during SSR.