### PR TITLE
[3.x] Improve CSP support for progress bar and error dialog

### DIFF
--- a/packages/core/src/dialog.ts
+++ b/packages/core/src/dialog.ts
@@ -1,3 +1,55 @@
+import { config } from './config'
+
+const DIALOG_ID = 'inertia-error-dialog'
+
+const STYLE_CONTENT = `
+  #${DIALOG_ID} {
+    width: calc(100vw - 100px);
+    height: calc(100vh - 100px);
+    padding: 0;
+    margin: auto;
+    border: none;
+    background-color: transparent;
+  }
+
+  #${DIALOG_ID} > iframe {
+    background-color: white;
+    border-radius: 5px;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    display: block;
+  }
+
+  #${DIALOG_ID}::backdrop {
+    background-color: rgba(0, 0, 0, 0.6);
+  }
+
+  #${DIALOG_ID}:focus {
+    outline: none;
+  }
+`
+
+let styleInstalled = false
+
+const installStyle = (): void => {
+  if (styleInstalled) {
+    return
+  }
+
+  const style = document.createElement('style')
+  const nonce = config.get('nonce')
+
+  if (nonce) {
+    style.nonce = nonce
+  }
+
+  style.textContent = STYLE_CONTENT
+  document.head.appendChild(style)
+
+  styleInstalled = true
+}
+
 export default {
   createIframeAndPage(html: Record<string, unknown> | string): { iframe: HTMLIFrameElement; page: HTMLElement } {
     if (typeof html === 'object') {
@@ -11,10 +63,6 @@ export default {
     page.querySelectorAll('a').forEach((a) => a.setAttribute('target', '_top'))
 
     const iframe = document.createElement('iframe')
-    iframe.style.backgroundColor = 'white'
-    iframe.style.borderRadius = '5px'
-    iframe.style.width = '100%'
-    iframe.style.height = '100%'
     iframe.setAttribute('sandbox', 'allow-scripts')
 
     return { iframe, page }
@@ -23,32 +71,10 @@ export default {
   show(html: Record<string, unknown> | string): void {
     const { iframe, page } = this.createIframeAndPage(html)
 
-    iframe.style.boxSizing = 'border-box'
-    iframe.style.display = 'block'
+    installStyle()
 
     const dialog = document.createElement('dialog')
-    dialog.id = 'inertia-error-dialog'
-
-    Object.assign(dialog.style, {
-      width: 'calc(100vw - 100px)',
-      height: 'calc(100vh - 100px)',
-      padding: '0',
-      margin: 'auto',
-      border: 'none',
-      backgroundColor: 'transparent',
-    })
-
-    const dialogStyleElement = document.createElement('style')
-    dialogStyleElement.textContent = `
-      dialog#inertia-error-dialog::backdrop {
-        background-color: rgba(0, 0, 0, 0.6);
-      }
-
-      dialog#inertia-error-dialog:focus {
-        outline: none;
-      }
-    `
-    document.head.appendChild(dialogStyleElement)
+    dialog.id = DIALOG_ID
 
     dialog.addEventListener('click', (event: MouseEvent) => {
       if (event.target === dialog) {
@@ -57,7 +83,6 @@ export default {
     })
 
     dialog.addEventListener('close', () => {
-      dialogStyleElement.remove()
       dialog.remove()
     })
 

--- a/packages/core/src/dialog.ts
+++ b/packages/core/src/dialog.ts
@@ -1,55 +1,5 @@
 import { config } from './config'
 
-const DIALOG_ID = 'inertia-error-dialog'
-
-const STYLE_CONTENT = `
-  #${DIALOG_ID} {
-    width: calc(100vw - 100px);
-    height: calc(100vh - 100px);
-    padding: 0;
-    margin: auto;
-    border: none;
-    background-color: transparent;
-  }
-
-  #${DIALOG_ID} > iframe {
-    background-color: white;
-    border-radius: 5px;
-    width: 100%;
-    height: 100%;
-    box-sizing: border-box;
-    display: block;
-  }
-
-  #${DIALOG_ID}::backdrop {
-    background-color: rgba(0, 0, 0, 0.6);
-  }
-
-  #${DIALOG_ID}:focus {
-    outline: none;
-  }
-`
-
-let styleInstalled = false
-
-const installStyle = (): void => {
-  if (styleInstalled) {
-    return
-  }
-
-  const style = document.createElement('style')
-  const nonce = config.get('nonce')
-
-  if (nonce) {
-    style.nonce = nonce
-  }
-
-  style.textContent = STYLE_CONTENT
-  document.head.appendChild(style)
-
-  styleInstalled = true
-}
-
 export default {
   createIframeAndPage(html: Record<string, unknown> | string): { iframe: HTMLIFrameElement; page: HTMLElement } {
     if (typeof html === 'object') {
@@ -63,6 +13,10 @@ export default {
     page.querySelectorAll('a').forEach((a) => a.setAttribute('target', '_top'))
 
     const iframe = document.createElement('iframe')
+    iframe.style.backgroundColor = 'white'
+    iframe.style.borderRadius = '5px'
+    iframe.style.width = '100%'
+    iframe.style.height = '100%'
     iframe.setAttribute('sandbox', 'allow-scripts')
 
     return { iframe, page }
@@ -71,10 +25,39 @@ export default {
   show(html: Record<string, unknown> | string): void {
     const { iframe, page } = this.createIframeAndPage(html)
 
-    installStyle()
+    iframe.style.boxSizing = 'border-box'
+    iframe.style.display = 'block'
 
     const dialog = document.createElement('dialog')
-    dialog.id = DIALOG_ID
+    dialog.id = 'inertia-error-dialog'
+
+    Object.assign(dialog.style, {
+      width: 'calc(100vw - 100px)',
+      height: 'calc(100vh - 100px)',
+      padding: '0',
+      margin: 'auto',
+      border: 'none',
+      backgroundColor: 'transparent',
+    })
+
+    const dialogStyleElement = document.createElement('style')
+    dialogStyleElement.textContent = `
+      dialog#inertia-error-dialog::backdrop {
+        background-color: rgba(0, 0, 0, 0.6);
+      }
+
+      dialog#inertia-error-dialog:focus {
+        outline: none;
+      }
+    `
+
+    const nonce = config.get('nonce')
+
+    if (nonce) {
+      dialogStyleElement.nonce = nonce
+    }
+
+    document.head.appendChild(dialogStyleElement)
 
     dialog.addEventListener('click', (event: MouseEvent) => {
       if (event.target === dialog) {
@@ -83,6 +66,7 @@ export default {
     })
 
     dialog.addEventListener('close', () => {
+      dialogStyleElement.remove()
       dialog.remove()
     })
 

--- a/packages/core/src/progress-component.ts
+++ b/packages/core/src/progress-component.ts
@@ -1,6 +1,7 @@
 /* NProgress, (c) 2013, 2014 Rico Sta. Cruz - http://ricostacruz.com/nprogress
  * @license MIT */
 
+import { config } from './config'
 import { ProgressSettings } from './types'
 
 const baseComponentSelector = 'nprogress'
@@ -20,7 +21,6 @@ const settings: ProgressSettings = {
   parent: 'body',
   color: '#29d',
   includeCSS: true,
-  nonce: undefined,
   popover: null,
   template: [
     '<div class="bar" role="bar">',
@@ -41,7 +41,7 @@ const configure = (options: Partial<ProgressSettings>) => {
   usePopover = settings.popover ?? 'popover' in HTMLElement.prototype
 
   if (settings.includeCSS) {
-    injectCSS(settings.color, settings.nonce)
+    injectCSS(settings.color)
   }
 
   progress = document.createElement('div')
@@ -284,8 +284,9 @@ const queue = (() => {
   }
 })()
 
-const injectCSS = (color: string, nonce?: string): void => {
+const injectCSS = (color: string): void => {
   const element = document.createElement('style')
+  const nonce = config.get('nonce')
 
   if (nonce) {
     element.nonce = nonce

--- a/packages/core/src/progress.ts
+++ b/packages/core/src/progress.ts
@@ -86,21 +86,10 @@ function finish(event: GlobalEvent<'finish'>, timeout: NodeJS.Timeout): void {
   }
 }
 
-const defaultNonce = (): string => {
-  for (const script of document.querySelectorAll('script')) {
-    if (script.nonce) {
-      return script.nonce
-    }
-  }
-
-  return ''
-}
-
 export default function setupProgress({
   delay = 250,
   color = '#29d',
   includeCSS = true,
-  nonce = false,
   showSpinner = false,
   popover = null,
 }: ProgressOptions = {}): void {
@@ -108,7 +97,6 @@ export default function setupProgress({
   ProgressComponent.configure({
     showSpinner,
     includeCSS,
-    nonce: nonce === true ? defaultNonce() : nonce ? nonce : undefined,
     color,
     popover,
   })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -546,7 +546,6 @@ export type ProgressOptions = {
   delay?: number
   color?: string
   includeCSS?: boolean
-  nonce?: string | boolean
   showSpinner?: boolean
   popover?: boolean | null
 }
@@ -635,6 +634,7 @@ export type InertiaAppConfig = {
     cacheFor: CacheForOption | CacheForOption[]
     hoverDelay: number
   }
+  nonce?: string
   visitOptions?: (href: string, options: VisitOptions) => VisitOptions
 }
 
@@ -709,7 +709,6 @@ export type ProgressSettings = {
   parent: string
   template: string
   includeCSS: boolean
-  nonce?: string
   color: string
   popover: boolean | null
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -556,6 +556,7 @@ interface BaseCreateInertiaAppOptions<TComponentResolver, TSetupOptions, TSetupR
   layout?: (name: string, page: Page) => unknown
   setup: (options: TSetupOptions) => TSetupReturn
   title?: HeadManagerTitleCallback
+  nonce?: string
   defaults?: FirstLevelOptional<InertiaAppConfig & TAdditionalInertiaAppConfig>
   /** HTTP client or options to use for requests. Defaults to XhrHttpClient. */
   http?: HttpClient | HttpClientOptions
@@ -600,6 +601,7 @@ export interface CreateInertiaAppOptions<TComponentResolver, TSetupOptions, TSet
   setup?: (options: TSetupOptions) => TSetupReturn
   title?: HeadManagerTitleCallback
   progress?: ProgressOptions | false
+  nonce?: string
   defaults?: FirstLevelOptional<InertiaAppConfig & TAdditionalInertiaAppConfig>
   /** HTTP client or options to use for requests. Defaults to XhrHttpClient. */
   http?: HttpClient | HttpClientOptions

--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -98,6 +98,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     page,
     render,
     defaults = {},
+    nonce,
     http,
     layout,
     strictMode = false,
@@ -108,6 +109,10 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     | InertiaAppOptionsAuto<SharedProps> = {} as InertiaAppOptionsAuto<SharedProps>,
 ): Promise<InertiaAppSSRResponse | RenderFunction<SharedProps> | void> {
   config.replace(defaults)
+
+  if (nonce) {
+    config.set('nonce', nonce)
+  }
 
   if (http) {
     httpModule.setClient(http)

--- a/packages/react/test-app/app.tsx
+++ b/packages/react/test-app/app.tsx
@@ -83,11 +83,7 @@ createInertiaApp({
   ...(params.get('popover') === 'false' && {
     progress: { popover: false },
   }),
-  ...(params.get('nonce') === 'default' && {
-    progress: { nonce: true },
+  ...(params.has('nonce') && {
+    defaults: { nonce: params.get('nonce') === 'default' ? 'test-default-nonce' : 'test-nonce' },
   }),
-  ...(params.has('nonce') &&
-    params.get('nonce') !== 'default' && {
-      progress: { nonce: 'test-nonce' },
-    }),
 })

--- a/packages/react/test-app/app.tsx
+++ b/packages/react/test-app/app.tsx
@@ -84,6 +84,6 @@ createInertiaApp({
     progress: { popover: false },
   }),
   ...(params.has('nonce') && {
-    defaults: { nonce: params.get('nonce') === 'default' ? 'test-default-nonce' : 'test-nonce' },
+    nonce: params.get('nonce') === 'default' ? 'test-default-nonce' : 'test-nonce',
   }),
 })

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -75,6 +75,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     progress = {},
     page,
     defaults = {},
+    nonce,
     http,
     layout,
     withApp,
@@ -83,6 +84,10 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     | InertiaAppOptionsAuto<SharedProps> = {} as InertiaAppOptionsAuto<SharedProps>,
 ): Promise<InertiaAppSSRResponse | RenderFunction<SharedProps> | void> {
   config.replace(defaults)
+
+  if (nonce) {
+    config.set('nonce', nonce)
+  }
 
   if (http) {
     httpModule.setClient(http)

--- a/packages/svelte/test-app/app.ts
+++ b/packages/svelte/test-app/app.ts
@@ -75,11 +75,7 @@ createInertiaApp({
   ...(params.get('popover') === 'false' && {
     progress: { popover: false },
   }),
-  ...(params.get('nonce') === 'default' && {
-    progress: { nonce: true },
+  ...(params.has('nonce') && {
+    defaults: { nonce: params.get('nonce') === 'default' ? 'test-default-nonce' : 'test-nonce' },
   }),
-  ...(params.has('nonce') &&
-    params.get('nonce') !== 'default' && {
-      progress: { nonce: 'test-nonce' },
-    }),
 })

--- a/packages/svelte/test-app/app.ts
+++ b/packages/svelte/test-app/app.ts
@@ -76,6 +76,6 @@ createInertiaApp({
     progress: { popover: false },
   }),
   ...(params.has('nonce') && {
-    defaults: { nonce: params.get('nonce') === 'default' ? 'test-default-nonce' : 'test-nonce' },
+    nonce: params.get('nonce') === 'default' ? 'test-default-nonce' : 'test-nonce',
   }),
 })

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -94,6 +94,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     page,
     render,
     defaults = {},
+    nonce,
     http,
     layout,
     withApp,
@@ -103,6 +104,10 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     | InertiaAppOptionsAuto<SharedProps> = {} as InertiaAppOptionsAuto<SharedProps>,
 ): Promise<InertiaAppSSRResponse | RenderFunction<SharedProps> | void> {
   config.replace(defaults)
+
+  if (nonce) {
+    config.set('nonce', nonce)
+  }
 
   if (http) {
     httpModule.setClient(http)

--- a/packages/vue3/test-app/app.ts
+++ b/packages/vue3/test-app/app.ts
@@ -77,6 +77,6 @@ createInertiaApp({
     progress: { popover: false },
   }),
   ...(params.has('nonce') && {
-    defaults: { nonce: params.get('nonce') === 'default' ? 'test-default-nonce' : 'test-nonce' },
+    nonce: params.get('nonce') === 'default' ? 'test-default-nonce' : 'test-nonce',
   }),
 })

--- a/packages/vue3/test-app/app.ts
+++ b/packages/vue3/test-app/app.ts
@@ -76,11 +76,7 @@ createInertiaApp({
   ...(params.get('popover') === 'false' && {
     progress: { popover: false },
   }),
-  ...(params.get('nonce') === 'default' && {
-    progress: { nonce: true },
+  ...(params.has('nonce') && {
+    defaults: { nonce: params.get('nonce') === 'default' ? 'test-default-nonce' : 'test-nonce' },
   }),
-  ...(params.has('nonce') &&
-    params.get('nonce') !== 'default' && {
-      progress: { nonce: 'test-nonce' },
-    }),
 })

--- a/tests/error-modal.spec.ts
+++ b/tests/error-modal.spec.ts
@@ -54,4 +54,35 @@ test.describe('error modal', () => {
     const xssExecuted = await page.evaluate(() => (window as any).xssExecuted)
     expect(xssExecuted).toBeUndefined()
   })
+
+  test('does not set a nonce on the dialog style tag by default', async ({ page }) => {
+    await page.getByText('Invalid Visit', { exact: true }).click()
+    await expect(page.locator('dialog#inertia-error-dialog')).toBeVisible()
+
+    const nonce = await page.evaluate(() => {
+      const style = Array.from(document.head.querySelectorAll('style')).find((el) =>
+        el.textContent?.includes('inertia-error-dialog'),
+      )
+      return style?.nonce ?? null
+    })
+
+    await expect(nonce).toBe('')
+  })
+})
+
+test('applies the configured nonce to the injected dialog style tag', async ({ page }) => {
+  pageLoads.watch(page)
+  await page.goto('/error-modal?nonce')
+
+  await page.getByText('Invalid Visit', { exact: true }).click()
+  await expect(page.locator('dialog#inertia-error-dialog')).toBeVisible()
+
+  const nonce = await page.evaluate(() => {
+    const style = Array.from(document.head.querySelectorAll('style')).find((el) =>
+      el.textContent?.includes('inertia-error-dialog'),
+    )
+    return style?.nonce ?? null
+  })
+
+  await expect(nonce).toBe('test-nonce')
 })

--- a/tests/progress-component.spec.ts
+++ b/tests/progress-component.spec.ts
@@ -175,19 +175,6 @@ test.describe('Progress Component', () => {
     await expect(nonce).toBe('test-nonce')
   })
 
-  test('inherits the nonce from the existing script tag when configured with nonce=true', async ({ page }) => {
-    await page.goto('/progress-component?nonce=default')
-
-    const nonce = await page.evaluate(() => {
-      const style = Array.from(document.head.querySelectorAll('style')).find((el) =>
-        el.textContent?.includes('#nprogress'),
-      )
-      return style?.nonce ?? null
-    })
-
-    await expect(nonce).toBe('test-default-nonce')
-  })
-
   test('does not set a nonce on the progress style tag by default', async ({ page }) => {
     const nonce = await page.evaluate(() => {
       const style = Array.from(document.head.querySelectorAll('style')).find((el) =>


### PR DESCRIPTION
This PR improves CSP compatibility by letting you configure a nonce that is applied to the inline styles Inertia injects for the progress bar and the error dialog. The nonce is now configured once on `createInertiaApp` and read by both subsystems through Inertia's internal config.

```js
createInertiaApp({
  nonce: '...',
})
```

Apps that don't enforce CSP are unaffected.