### PR TITLE
[2.x] Prevent accessing `window.parent` from error iframe

### DIFF
--- a/packages/core/src/dialog.ts
+++ b/packages/core/src/dialog.ts
@@ -51,12 +51,6 @@ export default {
     // Focus the dialog so the 'Escape' key works immediately
     dialog.focus()
 
-    if (!iframe.contentWindow) {
-      throw new Error('iframe not yet ready.')
-    }
-
-    iframe.contentWindow.document.open()
-    iframe.contentWindow.document.write(page.outerHTML)
-    iframe.contentWindow.document.close()
+    iframe.srcdoc = page.outerHTML
   },
 }

--- a/packages/core/src/modal.ts
+++ b/packages/core/src/modal.ts
@@ -18,6 +18,7 @@ export default {
     iframe.style.borderRadius = '5px'
     iframe.style.width = '100%'
     iframe.style.height = '100%'
+    iframe.setAttribute('sandbox', 'allow-scripts')
 
     return { iframe, page }
   },
@@ -38,12 +39,8 @@ export default {
 
     document.body.prepend(this.modal)
     document.body.style.overflow = 'hidden'
-    if (!iframe.contentWindow) {
-      throw new Error('iframe not yet ready.')
-    }
-    iframe.contentWindow.document.open()
-    iframe.contentWindow.document.write(page.outerHTML)
-    iframe.contentWindow.document.close()
+
+    iframe.srcdoc = page.outerHTML
 
     this.listener = this.hideOnEscape.bind(this)
     document.addEventListener('keydown', this.listener)

--- a/packages/react/test-app/Pages/ErrorModal.tsx
+++ b/packages/react/test-app/Pages/ErrorModal.tsx
@@ -9,6 +9,10 @@ export default ({ dialog }: { dialog: boolean }) => {
     router.post('/json')
   }
 
+  const invalidVisitXss = () => {
+    router.post('/non-inertia/xss')
+  }
+
   if (dialog) {
     config.set('future.useDialogForErrorModal', true)
   }
@@ -20,6 +24,9 @@ export default ({ dialog }: { dialog: boolean }) => {
       </span>
       <span onClick={invalidVisitJson} className="invalid-visit-json">
         Invalid Visit (JSON response)
+      </span>
+      <span onClick={invalidVisitXss} className="invalid-visit-xss">
+        Invalid Visit (XSS)
       </span>
     </div>
   )

--- a/packages/svelte/test-app/Pages/ErrorModal.svelte
+++ b/packages/svelte/test-app/Pages/ErrorModal.svelte
@@ -11,6 +11,10 @@
     router.post('/json')
   }
 
+  const invalidVisitXss = () => {
+    router.post('/non-inertia/xss')
+  }
+
   if (dialog) {
     config.set('future.useDialogForErrorModal', true)
   }
@@ -30,5 +34,12 @@
     role="button"
     tabindex="0"
     class="invalid-visit-json">Invalid Visit (JSON response)</span
+  >
+  <span
+    on:click={invalidVisitXss}
+    on:keydown={(e) => e.key === 'Enter' && invalidVisitXss()}
+    role="button"
+    tabindex="0"
+    class="invalid-visit-xss">Invalid Visit (XSS)</span
   >
 </div>

--- a/packages/vue3/test-app/Pages/ErrorModal.vue
+++ b/packages/vue3/test-app/Pages/ErrorModal.vue
@@ -13,6 +13,10 @@ const invalidVisitJson = () => {
   router.post('/json')
 }
 
+const invalidVisitXss = () => {
+  router.post('/non-inertia/xss')
+}
+
 if (props.dialog) {
   config.set('future.useDialogForErrorModal', true)
 }
@@ -22,5 +26,6 @@ if (props.dialog) {
   <div>
     <span @click="invalidVisit" class="invalid-visit">Invalid Visit</span>
     <span @click="invalidVisitJson" class="invalid-visit-json">Invalid Visit (JSON response)</span>
+    <span @click="invalidVisitXss" class="invalid-visit-xss">Invalid Visit (XSS)</span>
   </div>
 </template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -34,6 +34,19 @@ app.all('/non-inertia', (req, res) =>
   `),
 )
 
+app.post('/non-inertia/xss', (req, res) =>
+  res.status(200).send(`
+    <!DOCTYPE html>
+    <html>
+      <head><title>XSS Test Page</title></head>
+      <body>
+        <script>window.parent.xssExecuted = true;<\/script>
+        <p>XSS test page</p>
+      </body>
+    </html>
+  `),
+)
+
 app.get('/non-inertia/download', (req, res) => {
   const query = new URLSearchParams(req.query).toString()
   res.setHeader('Content-Type', 'text/plain')

--- a/tests/error-modal.spec.ts
+++ b/tests/error-modal.spec.ts
@@ -56,3 +56,12 @@ elements.forEach((element) => {
     })
   })
 })
+
+test('it does not execute scripts in the error dialog iframe', async ({ page }) => {
+  pageLoads.watch(page)
+  await page.goto('/error-modal?dialog=1')
+  await page.getByText('Invalid Visit (XSS)', { exact: true }).click()
+  await expect(page.locator('dialog#inertia-error-dialog > iframe')).toBeVisible()
+  const xssExecuted = await page.evaluate(() => (window as any).xssExecuted)
+  expect(xssExecuted).toBeUndefined()
+})

--- a/tests/error-modal.spec.ts
+++ b/tests/error-modal.spec.ts
@@ -55,4 +55,11 @@ elements.forEach((element) => {
       await expect(page.frameLocator('iframe').getByText('This is a page that does not')).toBeHidden()
     })
   })
+
+  test('it does not execute scripts in the error dialog iframe', async ({ page }) => {
+    await page.getByText('Invalid Visit (XSS)', { exact: true }).click()
+    await expect(page.locator('dialog#inertia-error-dialog > iframe')).toBeVisible()
+    const xssExecuted = await page.evaluate(() => (window as any).xssExecuted)
+    expect(xssExecuted).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Backport of #3078.