### PR TITLE
[3.x] Add `inertia:cacheHit` event and `cached` flag on `inertia:navigate`

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -31,8 +31,8 @@ export const fireBeforeUpdateEvent: GlobalEventTrigger<'beforeUpdate'> = (page) 
   return fireEvent('beforeUpdate', { detail: { page } })
 }
 
-export const fireNavigateEvent: GlobalEventTrigger<'navigate'> = (page) => {
-  return fireEvent('navigate', { detail: { page } })
+export const fireNavigateEvent: GlobalEventTrigger<'navigate'> = (page, cached = false) => {
+  return fireEvent('navigate', { detail: { page, cached } })
 }
 
 export const fireProgressEvent: GlobalEventTrigger<'progress'> = (progress) => {
@@ -53,6 +53,10 @@ export const firePrefetchedEvent: GlobalEventTrigger<'prefetched'> = (response, 
 
 export const firePrefetchingEvent: GlobalEventTrigger<'prefetching'> = (visit) => {
   return fireEvent('prefetching', { detail: { visit } })
+}
+
+export const fireCacheHitEvent: GlobalEventTrigger<'cacheHit'> = (visit) => {
+  return fireEvent('cacheHit', { detail: { visit } })
 }
 
 export const fireFlashEvent: GlobalEventTrigger<'flash'> = (flash) => {

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -51,11 +51,13 @@ class CurrentPage {
       preserveScroll = false,
       preserveState = false,
       viewTransition = false,
+      cached = false,
     }: {
       replace?: boolean
       preserveScroll?: boolean
       preserveState?: boolean
       viewTransition?: Visit['viewTransition']
+      cached?: boolean
     } = {},
   ): Promise<void> {
     if (Object.keys(page.deferredProps || {}).length) {
@@ -155,7 +157,7 @@ class CurrentPage {
           this.pendingDeferredProps = null
 
           if (!replace) {
-            fireNavigateEvent(page)
+            fireNavigateEvent(page, cached)
           }
         })
       })

--- a/packages/core/src/prefetched.ts
+++ b/packages/core/src/prefetched.ts
@@ -1,5 +1,6 @@
 import { cloneDeep } from 'es-toolkit'
 import { get } from 'es-toolkit/compat'
+import { fireCacheHitEvent } from './events'
 import { objectsAreEqual } from './objectUtils'
 import { page as currentPage } from './page'
 import { Response } from './response'
@@ -193,6 +194,13 @@ class PrefetchedRequests {
 
     this.currentUseId = id
 
+    const consumedParams: ActiveVisit = {
+      ...params,
+      cached: true,
+    }
+
+    fireCacheHitEvent(consumedParams)
+
     return prefetched.response.then((response) => {
       if (this.currentUseId !== id) {
         // They've since gone on to `use` a different request,
@@ -200,7 +208,7 @@ class PrefetchedRequests {
         return
       }
 
-      response.mergeParams({ ...params, onPrefetched: () => {} })
+      response.mergeParams({ ...consumedParams, onPrefetched: () => {} })
 
       // If this was a one-time cache, remove it
       // (generally a prefetch="click" request with no specified cache value)
@@ -271,6 +279,7 @@ class PrefetchedRequests {
         'optimistic',
         'component',
         'pageProps',
+        'cached',
       ],
     )
   }

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -245,6 +245,7 @@ export class Response {
       preserveScroll: this.requestParams.all().preserveScroll as boolean,
       preserveState: this.requestParams.all().preserveState as boolean,
       viewTransition: this.requestParams.all().viewTransition,
+      cached: this.requestParams.all().cached,
     })
   }
 

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -655,6 +655,7 @@ export class Router {
       viewTransition: false,
       component: null,
       pageProps: null,
+      cached: false,
       ...options,
       ...configuredOptions,
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -333,6 +333,7 @@ export type Visit<T extends RequestPayload = RequestPayload> = {
     | Record<string, unknown>
     | ((currentProps: PageProps, sharedProps: Partial<PageProps>) => Record<string, unknown>)
     | null
+  cached: boolean
 }
 
 export type GlobalEventsMap<T extends RequestPayload = RequestPayload> = {
@@ -377,9 +378,10 @@ export type GlobalEventsMap<T extends RequestPayload = RequestPayload> = {
     result: void
   }
   navigate: {
-    parameters: [Page<SharedPageProps>]
+    parameters: [Page<SharedPageProps>, boolean?]
     details: {
       page: Page<SharedPageProps>
+      cached: boolean
     }
     result: void
   }
@@ -421,6 +423,13 @@ export type GlobalEventsMap<T extends RequestPayload = RequestPayload> = {
     result: void
   }
   prefetching: {
+    parameters: [ActiveVisit<T>]
+    details: {
+      visit: ActiveVisit<T>
+    }
+    result: void
+  }
+  cacheHit: {
     parameters: [ActiveVisit<T>]
     details: {
       visit: ActiveVisit<T>
@@ -936,6 +945,7 @@ declare global {
     'inertia:finish': GlobalEvent<'finish'>
     'inertia:beforeUpdate': GlobalEvent<'beforeUpdate'>
     'inertia:navigate': GlobalEvent<'navigate'>
+    'inertia:cacheHit': GlobalEvent<'cacheHit'>
     'inertia:flash': GlobalEvent<'flash'>
   }
 }

--- a/tests/prefetch.spec.ts
+++ b/tests/prefetch.spec.ts
@@ -120,6 +120,59 @@ test('can prefetch using link props', async ({ page }) => {
   await expect(requests.requests.length).toBe(0)
 })
 
+test('it fires inertia:cacheHit and inertia:navigate with cached flag when consuming a prefetch', async ({ page }) => {
+  await page.goto('prefetch/2')
+
+  await page.evaluate(() => {
+    ;(window as any)._startEvents = []
+    ;(window as any)._cacheHitEvents = []
+    ;(window as any)._navigateEvents = []
+    document.addEventListener('inertia:start', (e: any) => {
+      ;(window as any)._startEvents.push({
+        url: e.detail.visit.url.pathname,
+        prefetch: e.detail.visit.prefetch,
+        cached: e.detail.visit.cached,
+      })
+    })
+    document.addEventListener('inertia:cacheHit', (e: any) => {
+      ;(window as any)._cacheHitEvents.push({
+        url: e.detail.visit.url.pathname,
+        cached: e.detail.visit.cached,
+      })
+    })
+    document.addEventListener('inertia:navigate', (e: any) => {
+      ;(window as any)._navigateEvents.push({
+        url: e.detail.page.url,
+        cached: e.detail.cached,
+      })
+    })
+  })
+
+  const prefetch1 = page.waitForResponse('prefetch/1')
+  await page.getByRole('link', { name: 'On Hover (Default)' }).hover()
+  await prefetch1
+
+  await page.getByRole('link', { name: 'On Hover (Default)' }).click()
+  await isPrefetchPage(page, 1)
+
+  const startEvents = await page.evaluate(() => (window as any)._startEvents)
+  const cacheHitEvents = await page.evaluate(() => (window as any)._cacheHitEvents)
+  const navigateEvents = await page.evaluate(() => (window as any)._navigateEvents)
+
+  const startsForUrl = startEvents.filter((e: any) => e.url === '/prefetch/1')
+  expect(startsForUrl).toHaveLength(1)
+  expect(startsForUrl[0].prefetch).toBe(true)
+  expect(startsForUrl[0].cached).toBe(false)
+
+  const cacheHit = cacheHitEvents.find((e: any) => e.url === '/prefetch/1')
+  expect(cacheHit).toBeDefined()
+  expect(cacheHit.cached).toBe(true)
+
+  const navigate = navigateEvents.find((e: any) => e.url === '/prefetch/1')
+  expect(navigate).toBeDefined()
+  expect(navigate.cached).toBe(true)
+})
+
 test('can prefetch using link props with keyboard events', async ({ page }) => {
   // These two prefetch requests should be made on mount
   const prefetch2 = page.waitForResponse('prefetch/2')


### PR DESCRIPTION
This PR introduces a new `inertia:cacheHit` global event that fires from `prefetchedRequests.use()` whenever a prefetched response is consumed. The event detail carries the active visit with a new `cached: true` flag. The existing `inertia:navigate` event also gains a `cached` boolean on its detail, which is `true` when the page was rendered from a prefetched response and `false` for every other navigation.