### PR TITLE
[2.x] fix: prevent explicit undefined values from overwriting visit defaults

### DIFF
--- a/packages/core/src/objectUtils.ts
+++ b/packages/core/src/objectUtils.ts
@@ -1,3 +1,15 @@
+export const stripTopLevelUndefined = <T extends Record<string, unknown>>(obj: T): T => {
+  const result = {} as T
+
+  for (const key of Object.keys(obj) as (keyof T)[]) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key]
+    }
+  }
+
+  return result
+}
+
 export const objectsAreEqual = <T extends Record<string, any>>(
   obj1: T,
   obj2: T,

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -5,6 +5,7 @@ import { eventHandler } from './eventHandler'
 import { fireBeforeEvent, fireFlashEvent } from './events'
 import { history } from './history'
 import { InitialVisit } from './initialVisit'
+import { stripTopLevelUndefined } from './objectUtils'
 import { page as currentPage } from './page'
 import { polls } from './polls'
 import { prefetchedRequests } from './prefetched'
@@ -572,8 +573,8 @@ export class Router {
       prefetch: false,
       invalidateCacheTags: [],
       viewTransition: false,
-      ...options,
-      ...configuredOptions,
+      ...stripTopLevelUndefined(options),
+      ...stripTopLevelUndefined(configuredOptions),
     }
 
     const [url, _data] = transformUrlAndData(


### PR DESCRIPTION
Backport of #3019 