### PR TITLE
[3.x] Pin GitHub Actions to commit SHAs and harden CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "2.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       github-actions:
         patterns:
-          - "*"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+          - '*'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-    target-branch: "2.x"
+      interval: 'weekly'
+    target-branch: '2.x'
     groups:
       github-actions:
         patterns:
-          - "*"
+          - '*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -49,15 +51,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -35,6 +35,6 @@ jobs:
         run: pnpm run format
 
       - name: Commit linted files
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: 'Fix code style'

--- a/.github/workflows/es2022-compatibility.yml
+++ b/.github/workflows/es2022-compatibility.yml
@@ -18,15 +18,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/playwright-chromium.yml
+++ b/.github/workflows/playwright-chromium.yml
@@ -16,15 +16,17 @@ jobs:
         http: ['default', 'axios']
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -40,7 +42,7 @@ jobs:
         run: echo "version=$(node -e "console.log(require('playwright/package.json').version)")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -61,7 +63,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: playwright-failure-screenshots-${{ matrix.adapter }}-chromium-${{ matrix.http }}
           path: test-results
@@ -77,15 +79,17 @@ jobs:
         node-version: ['22.x', '24.x', 'latest']
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -101,7 +105,7 @@ jobs:
         run: echo "version=$(node -e "console.log(require('playwright/package.json').version)")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -120,7 +124,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: playwright-failure-screenshots-${{ matrix.adapter }}-chromium-ssr-node-${{ matrix.node-version }}
           path: test-results

--- a/.github/workflows/playwright-firefox.yml
+++ b/.github/workflows/playwright-firefox.yml
@@ -16,15 +16,17 @@ jobs:
         shard: ['1', '2', '3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -40,7 +42,7 @@ jobs:
         run: echo "version=$(node -e "console.log(require('playwright/package.json').version)")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -59,7 +61,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: playwright-failure-screenshots-${{ matrix.adapter }}-firefox-shard-${{ matrix.shard }}
           path: test-results

--- a/.github/workflows/playwright-webkit.yml
+++ b/.github/workflows/playwright-webkit.yml
@@ -16,15 +16,17 @@ jobs:
         shard: ['1', '2', '3', '4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -40,7 +42,7 @@ jobs:
         run: echo "version=$(node -e "console.log(require('playwright/package.json').version)")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
           path: ~/Library/Caches/ms-playwright
@@ -59,7 +61,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: playwright-failure-screenshots-${{ matrix.adapter }}-webkit-shard-${{ matrix.shard }}
           path: test-results

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,6 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - name: Pin npm (OIDC trusted publishing requires >=11.5.1)
-        run: npm install -g npm@11.14.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,22 +16,23 @@ jobs:
         adapter: ['core', 'vue3', 'react', 'svelte', 'vite']
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
-        run: npm install -g npm@latest
+      - name: Pin npm (OIDC trusted publishing requires >=11.5.1)
+        run: npm install -g npm@11.14.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -39,7 +40,7 @@ jobs:
       - name: Audit dependencies
         run: pnpm audit
 
-      - name: 'Publish ${{ matrix.adapter }}'
+      - name: 'Build ${{ matrix.adapter }}'
         run: pnpm -r --filter ./packages/core --filter ./packages/${{ matrix.adapter }} build
 
       - name: Determine npm tag
@@ -52,4 +53,6 @@ jobs:
           fi
 
       - name: 'Publish ${{ matrix.adapter }} to npm'
-        run: cd ./packages/${{ matrix.adapter }} && pnpm publish --no-git-checks ${{ steps.tag.outputs.flag }}
+        env:
+          NPM_TAG_FLAG: ${{ steps.tag.outputs.flag }}
+        run: cd "./packages/${{ matrix.adapter }}" && pnpm publish --no-git-checks $NPM_TAG_FLAG

--- a/.github/workflows/test-app-quality.yml
+++ b/.github/workflows/test-app-quality.yml
@@ -14,15 +14,17 @@ jobs:
         adapter: ['vue', 'react', 'svelte']
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,10 +4,9 @@ on:
   release:
     types: [released]
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   update:
-    permissions:
-      contents: write
     uses: laravel/.github/.github/workflows/update-changelog.yml@4bf890cc0e48724d6f2061c28f2e6ff48911adbd # main

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -10,4 +10,4 @@ jobs:
   update:
     permissions:
       contents: write
-    uses: laravel/.github/.github/workflows/update-changelog.yml@main
+    uses: laravel/.github/.github/workflows/update-changelog.yml@4bf890cc0e48724d6f2061c28f2e6ff48911adbd # main


### PR DESCRIPTION
This PR pins all third-party GitHub Actions to specific commit SHAs (with version comments) across every workflow file. `pnpm/action-setup` was already pinned in PR #3099.

Most workflows also gain `persist-credentials: false` on `actions/checkout`, which removes the `GITHUB_TOKEN` from the runner after checkout. The `coding-standards.yml` workflow keeps the default since `git-auto-commit-action` needs the credentials to push back. The `coding-standards.yml` and `publish.yml` workflows also drop `cache: pnpm`.

The publish workflow moves the `--tag` flag into an env var so that any future change to that step can't accidentally introduce a shell-injection path. 

Finally, this PR adds `.github/dependabot.yml` to enable weekly grouped version updates for the `github-actions` ecosystem on `3.x` and `2.x`.

An overview of the pinned actions:

| Action | Version | Hash | Release |
|--------|---------|------|---------|
| actions/checkout | v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | https://github.com/actions/checkout/releases/tag/v6.0.2 |
| actions/setup-node | v6.4.0 | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | https://github.com/actions/setup-node/releases/tag/v6.4.0 |
| actions/cache | v5.0.5 | `27d5ce7f107fe9357f9df03efb73ab90386fccae` | https://github.com/actions/cache/releases/tag/v5.0.5 |
| actions/upload-artifact | v6.0.0 | `b7c566a772e6b6bfb58ed0dc250532a479d7789f` | https://github.com/actions/upload-artifact/releases/tag/v6.0.0 |
| stefanzweifel/git-auto-commit-action | v7.1.0 | `04702edda442b2e678b25b537cec683a1493fcb9` | https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v7.1.0 |
| laravel/.github | main | `4bf890cc0e48724d6f2061c28f2e6ff48911adbd` | https://github.com/laravel/.github/commit/4bf890cc0e48724d6f2061c28f2e6ff48911adbd |