### PR TITLE
[3.x] Fix `httpException` event response data type

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -29,6 +29,10 @@ export interface HttpResponse {
   headers: HttpResponseHeaders
 }
 
+export interface HttpExceptionResponse extends Omit<HttpResponse, 'data'> {
+  data: string | Record<string, unknown>
+}
+
 export interface HttpClient {
   request(config: HttpRequestConfig): Promise<HttpResponse>
 }
@@ -398,9 +402,9 @@ export type GlobalEventsMap<T extends RequestPayload = RequestPayload> = {
     result: void
   }
   httpException: {
-    parameters: [HttpResponse]
+    parameters: [HttpExceptionResponse]
     details: {
-      response: HttpResponse
+      response: HttpExceptionResponse
     }
     result: boolean | void
   }


### PR DESCRIPTION
This PR fixes the type of `response.data` on the `httpException` event. The data was typed as `string`, but the router pre-parses JSON response bodies before firing the event.

A new `HttpExceptionResponse` type widens `data` to `string | Record<string, unknown>` and is used in the event payload to reflect the actual runtime shape. The `onHttpException` callback on `useHttp` keeps the raw `HttpResponse` type since that path passes the unparsed response straight from the HTTP client.

Fixes #3096.