### PR TITLE
[3.x] Skip DOM updates when `<InfiniteScroll>` request is cancelled

### DIFF
--- a/packages/core/src/infiniteScroll.ts
+++ b/packages/core/src/infiniteScroll.ts
@@ -40,14 +40,14 @@ export default function useInfiniteScroll(options: UseInfiniteScrollOptions): Us
     onCompletePreviousRequest: (_, details) => {
       options.onCompletePreviousRequest(details)
 
-      if (!details.wasCancelled) {
+      if (details.completed) {
         requestAnimationFrame(() => elementManager.processServerLoadedElements(details.page), 2)
       }
     },
     onCompleteNextRequest: (_, details) => {
       options.onCompleteNextRequest(details)
 
-      if (!details.wasCancelled) {
+      if (details.completed) {
         requestAnimationFrame(() => elementManager.processServerLoadedElements(details.page), 2)
       }
     },

--- a/packages/core/src/infiniteScroll.ts
+++ b/packages/core/src/infiniteScroll.ts
@@ -37,13 +37,19 @@ export default function useInfiniteScroll(options: UseInfiniteScrollOptions): Us
     // so they don't get confused with server-loaded content
     onBeforeUpdate: elementManager.processManuallyAddedElements,
     // After successful request, tag new server content
-    onCompletePreviousRequest: (loadedPage) => {
-      options.onCompletePreviousRequest()
-      requestAnimationFrame(() => elementManager.processServerLoadedElements(loadedPage), 2)
+    onCompletePreviousRequest: (_, details) => {
+      options.onCompletePreviousRequest(details)
+
+      if (!details.wasCancelled) {
+        requestAnimationFrame(() => elementManager.processServerLoadedElements(details.page), 2)
+      }
     },
-    onCompleteNextRequest: (loadedPage) => {
-      options.onCompleteNextRequest()
-      requestAnimationFrame(() => elementManager.processServerLoadedElements(loadedPage), 2)
+    onCompleteNextRequest: (_, details) => {
+      options.onCompleteNextRequest(details)
+
+      if (!details.wasCancelled) {
+        requestAnimationFrame(() => elementManager.processServerLoadedElements(details.page), 2)
+      }
     },
     onReset: options.onDataReset,
   })

--- a/packages/core/src/infiniteScroll/data.ts
+++ b/packages/core/src/infiniteScroll/data.ts
@@ -14,13 +14,24 @@ type InfiniteScrollState = {
   requestCount: number
 }
 
+export type InfiniteScrollPageIdentifier = string | number | null
+export type InfiniteScrollOnCompleteDetails = { page: InfiniteScrollPageIdentifier; wasCancelled: boolean }
+
 export const useInfiniteScrollData = (options: {
   getPropName: () => string
   onBeforeUpdate: () => void
   onBeforePreviousRequest: () => void
   onBeforeNextRequest: () => void
-  onCompletePreviousRequest: (loadedPage: string | number | null) => void
-  onCompleteNextRequest: (loadedPage: string | number | null) => void
+  onCompletePreviousRequest: (
+    /** @deprecated Use `details.page` instead. The positional `loadedPage` argument will be removed in the next major version. */
+    loadedPage: InfiniteScrollPageIdentifier,
+    details: InfiniteScrollOnCompleteDetails,
+  ) => void
+  onCompleteNextRequest: (
+    /** @deprecated Use `details.page` instead. The positional `loadedPage` argument will be removed in the next major version. */
+    loadedPage: InfiniteScrollPageIdentifier,
+    details: InfiniteScrollOnCompleteDetails,
+  ) => void
   onReset?: () => void
 }): UseInfiniteScrollDataManager => {
   const getScrollPropFromCurrentPage = (): ScrollProp => {
@@ -128,6 +139,8 @@ export const useInfiniteScrollData = (options: {
 
     state.loading = true
 
+    let wasCancelled = false
+
     router.reload({
       preserveErrors: true,
       ...reloadOptions,
@@ -137,6 +150,9 @@ export const useInfiniteScrollData = (options: {
       headers: {
         [MERGE_INTENT_HEADER]: side === 'previous' ? 'prepend' : 'append',
         ...reloadOptions.headers,
+      },
+      onCancel: () => {
+        wasCancelled = true
       },
       onBefore: (visit: PendingVisit) => {
         side === 'next' ? options.onBeforeNextRequest() : options.onBeforePreviousRequest()
@@ -152,9 +168,13 @@ export const useInfiniteScrollData = (options: {
       },
       onFinish: (visit: any) => {
         state.loading = false
+
+        const page = state.lastLoadedPage
+
         side === 'next'
-          ? options.onCompleteNextRequest(state.lastLoadedPage)
-          : options.onCompletePreviousRequest(state.lastLoadedPage)
+          ? options.onCompleteNextRequest(page, { page, wasCancelled })
+          : options.onCompletePreviousRequest(page, { page, wasCancelled })
+
         reloadOptions.onFinish?.(visit)
       },
     })

--- a/packages/core/src/infiniteScroll/data.ts
+++ b/packages/core/src/infiniteScroll/data.ts
@@ -1,4 +1,4 @@
-import { router } from '../index'
+import { ActiveVisit, router } from '../index'
 import { page as currentPage } from '../page'
 import { Page, PendingVisit, ReloadOptions, ScrollProp, UseInfiniteScrollDataManager } from '../types'
 
@@ -15,7 +15,7 @@ type InfiniteScrollState = {
 }
 
 export type InfiniteScrollPageIdentifier = string | number | null
-export type InfiniteScrollOnCompleteDetails = { page: InfiniteScrollPageIdentifier; wasCancelled: boolean }
+export type InfiniteScrollOnCompleteDetails = { page: InfiniteScrollPageIdentifier; completed: boolean }
 
 export const useInfiniteScrollData = (options: {
   getPropName: () => string
@@ -139,8 +139,6 @@ export const useInfiniteScrollData = (options: {
 
     state.loading = true
 
-    let wasCancelled = false
-
     router.reload({
       preserveErrors: true,
       ...reloadOptions,
@@ -150,9 +148,6 @@ export const useInfiniteScrollData = (options: {
       headers: {
         [MERGE_INTENT_HEADER]: side === 'previous' ? 'prepend' : 'append',
         ...reloadOptions.headers,
-      },
-      onCancel: () => {
-        wasCancelled = true
       },
       onBefore: (visit: PendingVisit) => {
         side === 'next' ? options.onBeforeNextRequest() : options.onBeforePreviousRequest()
@@ -166,14 +161,15 @@ export const useInfiniteScrollData = (options: {
         syncStateOnSuccess(side)
         reloadOptions.onSuccess?.(page)
       },
-      onFinish: (visit: any) => {
+      onFinish: (visit: ActiveVisit) => {
         state.loading = false
 
-        const page = state.lastLoadedPage
+        const completed = visit.completed
+        const page = completed ? state.lastLoadedPage : null
 
         side === 'next'
-          ? options.onCompleteNextRequest(page, { page, wasCancelled })
-          : options.onCompletePreviousRequest(page, { page, wasCancelled })
+          ? options.onCompleteNextRequest(page, { page, completed })
+          : options.onCompletePreviousRequest(page, { page, completed })
 
         reloadOptions.onFinish?.(visit)
       },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,6 @@
 import { NamedInputEvent, ValidationConfig, Validator } from 'laravel-precognition'
 import type { HttpCancelledError, HttpNetworkError, HttpResponseError } from './httpErrors'
+import { InfiniteScrollOnCompleteDetails, InfiniteScrollPageIdentifier } from './infiniteScroll/data'
 import { Response } from './response'
 
 export type HttpRequestHeaders = Record<string, unknown>
@@ -212,9 +213,9 @@ export interface PageProps {
 
 export type ScrollProp = {
   pageName: string
-  previousPage: number | string | null
-  nextPage: number | string | null
-  currentPage: number | string | null
+  previousPage: InfiniteScrollPageIdentifier
+  nextPage: InfiniteScrollPageIdentifier
+  currentPage: InfiniteScrollPageIdentifier
   reset: boolean
 }
 
@@ -837,13 +838,13 @@ export interface UseInfiniteScrollOptions {
   // Callbacks
   onBeforePreviousRequest: () => void
   onBeforeNextRequest: () => void
-  onCompletePreviousRequest: () => void
-  onCompleteNextRequest: () => void
+  onCompletePreviousRequest: (details: InfiniteScrollOnCompleteDetails) => void
+  onCompleteNextRequest: (details: InfiniteScrollOnCompleteDetails) => void
   onDataReset?: () => void
 }
 
 export interface UseInfiniteScrollDataManager {
-  getLastLoadedPage: () => number | string | null
+  getLastLoadedPage: () => InfiniteScrollPageIdentifier
   getPageName: () => string
   getRequestCount: () => number
   hasPrevious: () => boolean
@@ -860,7 +861,7 @@ export interface UseInfiniteScrollElementManager {
   refreshTriggers: () => void
   flushAll: () => void
   processManuallyAddedElements: () => void
-  processServerLoadedElements: (loadedPage: string | number | null) => void
+  processServerLoadedElements: (loadedPage: InfiniteScrollPageIdentifier) => void
 }
 
 export interface UseInfiniteScrollProps {

--- a/packages/react/src/InfiniteScroll.ts
+++ b/packages/react/src/InfiniteScroll.ts
@@ -209,17 +209,17 @@ const InfiniteScroll = forwardRef<InfiniteScrollRef, ComponentProps>(
         // Callbacks
         onBeforePreviousRequest: () => setLoadingPrevious(true),
         onBeforeNextRequest: () => setLoadingNext(true),
-        onCompletePreviousRequest: ({ wasCancelled }) => {
+        onCompletePreviousRequest: ({ completed }) => {
           setLoadingPrevious(false)
 
-          if (!wasCancelled) {
+          if (completed) {
             syncStateFromDataManager()
           }
         },
-        onCompleteNextRequest: ({ wasCancelled }) => {
+        onCompleteNextRequest: ({ completed }) => {
           setLoadingNext(false)
 
-          if (!wasCancelled) {
+          if (completed) {
             syncStateFromDataManager()
           }
         },

--- a/packages/react/src/InfiniteScroll.ts
+++ b/packages/react/src/InfiniteScroll.ts
@@ -209,13 +209,19 @@ const InfiniteScroll = forwardRef<InfiniteScrollRef, ComponentProps>(
         // Callbacks
         onBeforePreviousRequest: () => setLoadingPrevious(true),
         onBeforeNextRequest: () => setLoadingNext(true),
-        onCompletePreviousRequest: () => {
+        onCompletePreviousRequest: ({ wasCancelled }) => {
           setLoadingPrevious(false)
-          syncStateFromDataManager()
+
+          if (!wasCancelled) {
+            syncStateFromDataManager()
+          }
         },
-        onCompleteNextRequest: () => {
+        onCompleteNextRequest: ({ wasCancelled }) => {
           setLoadingNext(false)
-          syncStateFromDataManager()
+
+          if (!wasCancelled) {
+            syncStateFromDataManager()
+          }
         },
         onDataReset: syncStateFromDataManager,
       })

--- a/packages/react/test-app/Pages/InfiniteScroll/NavigateAway.tsx
+++ b/packages/react/test-app/Pages/InfiniteScroll/NavigateAway.tsx
@@ -1,0 +1,21 @@
+import { InfiniteScroll, Link } from '@inertiajs/react'
+import UserCard, { User } from './UserCard'
+
+export default ({ users }: { users: { data: User[] } }) => {
+  return (
+    <div>
+      <Link href="/article" id="leave">
+        Leave to /article
+      </Link>
+      <InfiniteScroll
+        data="users"
+        style={{ display: 'grid', gap: '20px' }}
+        loading={() => <div style={{ textAlign: 'center', padding: '20px' }}>Loading...</div>}
+      >
+        {users.data.map((user) => (
+          <UserCard key={user.id} user={user} />
+        ))}
+      </InfiniteScroll>
+    </div>
+  )
+}

--- a/packages/svelte/src/components/InfiniteScroll.svelte
+++ b/packages/svelte/src/components/InfiniteScroll.svelte
@@ -152,17 +152,17 @@
       // Request callbacks
       onBeforePreviousRequest: () => (loadingPrevious = true),
       onBeforeNextRequest: () => (loadingNext = true),
-      onCompletePreviousRequest: ({ wasCancelled }) => {
+      onCompletePreviousRequest: ({ completed }) => {
         loadingPrevious = false
 
-        if (!wasCancelled) {
+        if (completed) {
           syncStateFromDataManager()
         }
       },
-      onCompleteNextRequest: ({ wasCancelled }) => {
+      onCompleteNextRequest: ({ completed }) => {
         loadingNext = false
 
-        if (!wasCancelled) {
+        if (completed) {
           syncStateFromDataManager()
         }
       },

--- a/packages/svelte/src/components/InfiniteScroll.svelte
+++ b/packages/svelte/src/components/InfiniteScroll.svelte
@@ -152,13 +152,19 @@
       // Request callbacks
       onBeforePreviousRequest: () => (loadingPrevious = true),
       onBeforeNextRequest: () => (loadingNext = true),
-      onCompletePreviousRequest: () => {
+      onCompletePreviousRequest: ({ wasCancelled }) => {
         loadingPrevious = false
-        syncStateFromDataManager()
+
+        if (!wasCancelled) {
+          syncStateFromDataManager()
+        }
       },
-      onCompleteNextRequest: () => {
+      onCompleteNextRequest: ({ wasCancelled }) => {
         loadingNext = false
-        syncStateFromDataManager()
+
+        if (!wasCancelled) {
+          syncStateFromDataManager()
+        }
       },
       onDataReset: syncStateFromDataManager,
     })

--- a/packages/svelte/test-app/Pages/InfiniteScroll/NavigateAway.svelte
+++ b/packages/svelte/test-app/Pages/InfiniteScroll/NavigateAway.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { inertia, InfiniteScroll } from '@inertiajs/svelte'
+  import UserCard, { type User } from './UserCard.svelte'
+
+  interface Props {
+    users: { data: User[] }
+  }
+
+  let { users }: Props = $props()
+</script>
+
+<div>
+  <a href="/article" id="leave" use:inertia>Leave to /article</a>
+  <InfiniteScroll data="users" style="display: grid; gap: 20px">
+    {#snippet loading()}
+      <div style="text-align: center; padding: 20px">Loading...</div>
+    {/snippet}
+
+    {#each users.data as user (user.id)}
+      <UserCard {user} />
+    {/each}
+  </InfiniteScroll>
+</div>

--- a/packages/vue3/src/infiniteScroll.ts
+++ b/packages/vue3/src/infiniteScroll.ts
@@ -148,13 +148,19 @@ const InfiniteScroll = defineComponent({
       // Request callbacks
       onBeforePreviousRequest: () => (loadingPrevious.value = true),
       onBeforeNextRequest: () => (loadingNext.value = true),
-      onCompletePreviousRequest: () => {
+      onCompletePreviousRequest: ({ wasCancelled }) => {
         loadingPrevious.value = false
-        syncStateFromDataManager()
+
+        if (!wasCancelled) {
+          syncStateFromDataManager()
+        }
       },
-      onCompleteNextRequest: () => {
+      onCompleteNextRequest: ({ wasCancelled }) => {
         loadingNext.value = false
-        syncStateFromDataManager()
+
+        if (!wasCancelled) {
+          syncStateFromDataManager()
+        }
       },
       onDataReset: syncStateFromDataManager,
     })

--- a/packages/vue3/src/infiniteScroll.ts
+++ b/packages/vue3/src/infiniteScroll.ts
@@ -148,17 +148,17 @@ const InfiniteScroll = defineComponent({
       // Request callbacks
       onBeforePreviousRequest: () => (loadingPrevious.value = true),
       onBeforeNextRequest: () => (loadingNext.value = true),
-      onCompletePreviousRequest: ({ wasCancelled }) => {
+      onCompletePreviousRequest: ({ completed }) => {
         loadingPrevious.value = false
 
-        if (!wasCancelled) {
+        if (completed) {
           syncStateFromDataManager()
         }
       },
-      onCompleteNextRequest: ({ wasCancelled }) => {
+      onCompleteNextRequest: ({ completed }) => {
         loadingNext.value = false
 
-        if (!wasCancelled) {
+        if (completed) {
           syncStateFromDataManager()
         }
       },

--- a/packages/vue3/test-app/Pages/InfiniteScroll/NavigateAway.vue
+++ b/packages/vue3/test-app/Pages/InfiniteScroll/NavigateAway.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { InfiniteScroll, Link } from '@inertiajs/vue3'
+import { User, default as UserCard } from './UserCard.vue'
+
+defineProps<{
+  users: { data: User[] }
+}>()
+</script>
+
+<template>
+  <div>
+    <Link href="/article" id="leave">Leave to /article</Link>
+    <InfiniteScroll data="users" style="display: grid; gap: 20px">
+      <UserCard v-for="user in users.data" :key="user.id" :user="user" />
+
+      <template #loading>
+        <div style="text-align: center; padding: 20px">Loading...</div>
+      </template>
+    </InfiniteScroll>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2156,6 +2156,23 @@ app.get('/infinite-scroll/programmatic-ref', (req, res) =>
 app.get('/infinite-scroll/short-content', (req, res) =>
   renderInfiniteScroll(req, res, 'InfiniteScroll/ShortContent', 100, false, 5),
 )
+app.get('/infinite-scroll/navigate-away', (req, res) => {
+  const page = req.query.page ? parseInt(req.query.page) : 1
+  const partialReload = !!req.headers['x-inertia-partial-data']
+  const shouldAppend = req.headers['x-inertia-infinite-scroll-merge-intent'] !== 'prepend'
+  const { paginated, scrollProp } = paginateUsers(page, 15, 40, false)
+
+  setTimeout(
+    () =>
+      inertia.render(req, res, {
+        component: 'InfiniteScroll/NavigateAway',
+        props: { users: paginated },
+        [shouldAppend ? 'mergeProps' : 'prependProps']: ['users.data'],
+        scrollProps: { users: scrollProp },
+      }),
+    partialReload ? 1000 : 0,
+  )
+})
 app.get('/infinite-scroll/invisible-first-child', (req, res) =>
   renderInfiniteScroll(req, res, 'InfiniteScroll/InvisibleFirstChild'),
 )

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2162,16 +2162,15 @@ app.get('/infinite-scroll/navigate-away', (req, res) => {
   const shouldAppend = req.headers['x-inertia-infinite-scroll-merge-intent'] !== 'prepend'
   const { paginated, scrollProp } = paginateUsers(page, 15, 40, false)
 
-  setTimeout(
-    () =>
-      inertia.render(req, res, {
-        component: 'InfiniteScroll/NavigateAway',
-        props: { users: paginated },
-        [shouldAppend ? 'mergeProps' : 'prependProps']: ['users.data'],
-        scrollProps: { users: scrollProp },
-      }),
-    partialReload ? 1000 : 0,
-  )
+  const render = () =>
+    inertia.render(req, res, {
+      component: 'InfiniteScroll/NavigateAway',
+      props: { users: paginated },
+      [shouldAppend ? 'mergeProps' : 'prependProps']: ['users.data'],
+      scrollProps: { users: scrollProp },
+    })
+
+  partialReload ? setTimeout(render, 1000) : render()
 })
 app.get('/infinite-scroll/invisible-first-child', (req, res) =>
   renderInfiniteScroll(req, res, 'InfiniteScroll/InvisibleFirstChild'),

--- a/tests/infinite-scroll.spec.ts
+++ b/tests/infinite-scroll.spec.ts
@@ -2511,6 +2511,7 @@ test.describe('Optional scroll props via WhenVisible', () => {
 })
 
 test('it discards an in-flight infinite scroll request when navigating away', async ({ page }) => {
+  test.setTimeout(15000)
   consoleMessages.listen(page)
 
   await page.goto('/infinite-scroll/navigate-away')
@@ -2526,7 +2527,7 @@ test('it discards an in-flight infinite scroll request when navigating away', as
   await expect(page).toHaveURL('/article')
   await expect(page.getByRole('heading', { name: 'Article Header' })).toBeVisible()
 
-  await page.waitForTimeout(1500)
+  await page.waitForTimeout(500)
 
   expect(consoleMessages.errors).toEqual([])
 })

--- a/tests/infinite-scroll.spec.ts
+++ b/tests/infinite-scroll.spec.ts
@@ -2510,6 +2510,27 @@ test.describe('Optional scroll props via WhenVisible', () => {
   })
 })
 
+test('it discards an in-flight infinite scroll request when navigating away', async ({ page }) => {
+  consoleMessages.listen(page)
+
+  await page.goto('/infinite-scroll/navigate-away')
+
+  await expect(page.getByText('User 1', { exact: true })).toBeVisible()
+  await expect(page.getByText('User 15')).toBeVisible()
+
+  await scrollToBottom(page)
+  await expect(page.getByText('Loading...')).toBeVisible()
+
+  await page.locator('#leave').click()
+
+  await expect(page).toHaveURL('/article')
+  await expect(page.getByRole('heading', { name: 'Article Header' })).toBeVisible()
+
+  await page.waitForTimeout(1500)
+
+  expect(consoleMessages.errors).toEqual([])
+})
+
 test('it preserves validation errors when InfiniteScroll loads more data', async ({ page }) => {
   await page.goto('/infinite-scroll/preserve-errors')
 

--- a/tests/infinite-scroll.spec.ts
+++ b/tests/infinite-scroll.spec.ts
@@ -2511,7 +2511,7 @@ test.describe('Optional scroll props via WhenVisible', () => {
 })
 
 test('it discards an in-flight infinite scroll request when navigating away', async ({ page }) => {
-  test.setTimeout(15000)
+  test.setTimeout(10_000)
   consoleMessages.listen(page)
 
   await page.goto('/infinite-scroll/navigate-away')
@@ -2529,7 +2529,7 @@ test('it discards an in-flight infinite scroll request when navigating away', as
 
   await page.waitForTimeout(500)
 
-  expect(consoleMessages.errors).toEqual([])
+  expect(consoleMessages.errors).toHaveLength(0)
 })
 
 test('it preserves validation errors when InfiniteScroll loads more data', async ({ page }) => {


### PR DESCRIPTION
When using `<InfiniteScroll>` and navigating to a different page while a request is still in-flight, the cancelled request still triggered DOM updates against a component that had already unmounted. This PR ensures that DOM-related work is skipped when a request is cancelled, while still resetting the loading state correctly.

Related to #3104.