### PR TITLE
[2.x] Add `mode` option to `router.poll` and support dynamic `usePoll` data

### DIFF
--- a/packages/core/src/poll.ts
+++ b/packages/core/src/poll.ts
@@ -19,6 +19,7 @@ export class Poll {
   protected inFlight = false
   protected currentCancel: VoidFunction | null = null
   protected stopped = true
+  protected instanceId = 0
 
   constructor(interval: number, cb: PollCallback, options: PollOptions) {
     this.keepAlive = options.keepAlive ?? false
@@ -34,6 +35,9 @@ export class Poll {
 
   public stop() {
     this.stopped = true
+    this.instanceId++
+    this.inFlight = false
+    this.currentCancel = null
 
     if (this.intervalId) {
       clearInterval(this.intervalId)
@@ -59,15 +63,7 @@ export class Poll {
       return
     }
 
-    this.intervalId = window.setInterval(() => {
-      if (!this.throttle || this.cbCount % 10 === 0) {
-        this.fire()
-      }
-
-      if (this.throttle) {
-        this.cbCount++
-      }
-    }, this.interval)
+    this.intervalId = window.setInterval(() => this.tick(), this.interval)
   }
 
   public isInBackground(hidden: boolean) {
@@ -83,12 +79,22 @@ export class Poll {
       return
     }
 
-    const delay = this.throttle ? this.interval * 10 : this.interval
-
     this.timeoutId = window.setTimeout(() => {
       this.timeoutId = null
+      this.tick()
+    }, this.interval)
+  }
+
+  protected tick() {
+    if (!this.throttle || this.cbCount % 10 === 0) {
       this.fire()
-    }, delay)
+    } else if (this.mode === 'rest') {
+      this.scheduleNext()
+    }
+
+    if (this.throttle) {
+      this.cbCount++
+    }
   }
 
   protected fire() {
@@ -96,12 +102,22 @@ export class Poll {
       this.currentCancel?.()
     }
 
+    const instance = this.instanceId
+
     this.cb({
       onStart: (cancel) => {
+        if (instance !== this.instanceId) {
+          return
+        }
+
         this.inFlight = true
         this.currentCancel = cancel
       },
       onFinish: () => {
+        if (instance !== this.instanceId) {
+          return
+        }
+
         this.inFlight = false
         this.currentCancel = null
 

--- a/packages/core/src/poll.ts
+++ b/packages/core/src/poll.ts
@@ -1,15 +1,28 @@
 import { PollOptions } from './types'
 
+type PollHooks = {
+  onStart: (cancel: VoidFunction) => void
+  onFinish: VoidFunction
+}
+
+export type PollCallback = (hooks: PollHooks) => void
+
 export class Poll {
-  protected id: number | null = null
+  protected intervalId: number | null = null
+  protected timeoutId: number | null = null
   protected throttle = false
   protected keepAlive = false
-  protected cb: VoidFunction
+  protected cb: PollCallback
   protected interval: number
   protected cbCount = 0
+  protected mode: 'overlap' | 'cancel' | 'rest'
+  protected inFlight = false
+  protected currentCancel: VoidFunction | null = null
+  protected stopped = true
 
-  constructor(interval: number, cb: VoidFunction, options: PollOptions) {
+  constructor(interval: number, cb: PollCallback, options: PollOptions) {
     this.keepAlive = options.keepAlive ?? false
+    this.mode = options.mode ?? 'overlap'
 
     this.cb = cb
     this.interval = interval
@@ -20,10 +33,16 @@ export class Poll {
   }
 
   public stop() {
-    // console.log('stopping...', this.id)
-    if (this.id) {
-      //   console.log('clearing interval...')
-      clearInterval(this.id)
+    this.stopped = true
+
+    if (this.intervalId) {
+      clearInterval(this.intervalId)
+      this.intervalId = null
+    }
+
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId)
+      this.timeoutId = null
     }
   }
 
@@ -33,10 +52,16 @@ export class Poll {
     }
 
     this.stop()
+    this.stopped = false
 
-    this.id = window.setInterval(() => {
+    if (this.mode === 'rest') {
+      this.scheduleNext()
+      return
+    }
+
+    this.intervalId = window.setInterval(() => {
       if (!this.throttle || this.cbCount % 10 === 0) {
-        this.cb()
+        this.fire()
       }
 
       if (this.throttle) {
@@ -51,5 +76,39 @@ export class Poll {
     if (this.throttle) {
       this.cbCount = 0
     }
+  }
+
+  protected scheduleNext() {
+    if (this.stopped) {
+      return
+    }
+
+    const delay = this.throttle ? this.interval * 10 : this.interval
+
+    this.timeoutId = window.setTimeout(() => {
+      this.timeoutId = null
+      this.fire()
+    }, delay)
+  }
+
+  protected fire() {
+    if (this.inFlight && this.mode === 'cancel') {
+      this.currentCancel?.()
+    }
+
+    this.cb({
+      onStart: (cancel) => {
+        this.inFlight = true
+        this.currentCancel = cancel
+      },
+      onFinish: () => {
+        this.inFlight = false
+        this.currentCancel = null
+
+        if (this.mode === 'rest') {
+          this.scheduleNext()
+        }
+      },
+    })
   }
 }

--- a/packages/core/src/polls.ts
+++ b/packages/core/src/polls.ts
@@ -8,6 +8,10 @@ class Polls {
     this.setupVisibilityListener()
   }
 
+  public get count(): number {
+    return this.polls.length
+  }
+
   public add(
     interval: number,
     cb: PollCallback,
@@ -15,6 +19,7 @@ class Polls {
   ): {
     stop: VoidFunction
     start: VoidFunction
+    destroy: VoidFunction
   } {
     const poll = new Poll(interval, cb, options)
 
@@ -23,6 +28,10 @@ class Polls {
     return {
       stop: () => poll.stop(),
       start: () => poll.start(),
+      destroy: () => {
+        poll.stop()
+        this.polls = this.polls.filter((p) => p !== poll)
+      },
     }
   }
 

--- a/packages/core/src/polls.ts
+++ b/packages/core/src/polls.ts
@@ -1,4 +1,4 @@
-import { Poll } from './poll'
+import { Poll, PollCallback } from './poll'
 import { PollOptions } from './types'
 
 class Polls {
@@ -10,7 +10,7 @@ class Polls {
 
   public add(
     interval: number,
-    cb: VoidFunction,
+    cb: PollCallback,
     options: PollOptions,
   ): {
     stop: VoidFunction

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -183,6 +183,10 @@ export class Router {
     this.syncRequestStream.cancelInFlight()
   }
 
+  public get activePolls(): number {
+    return polls.count
+  }
+
   public cancelAll({ async = true, prefetch = true, sync = true } = {}): void {
     if (async) {
       this.asyncRequestStream.cancelInFlight({ prefetch })
@@ -193,19 +197,21 @@ export class Router {
     }
   }
 
-  public poll(interval: number, requestOptions: ReloadOptions = {}, options: PollOptions = {}) {
+  public poll(interval: number, requestOptions: ReloadOptions | (() => ReloadOptions) = {}, options: PollOptions = {}) {
     return polls.add(
       interval,
       ({ onStart, onFinish }) => {
+        const resolved = typeof requestOptions === 'function' ? requestOptions() : requestOptions
+
         this.reload({
-          ...requestOptions,
+          ...resolved,
           onCancelToken: (token) => {
             onStart(token.cancel)
-            requestOptions.onCancelToken?.(token)
+            resolved.onCancelToken?.(token)
           },
           onFinish: (visit) => {
             onFinish()
-            requestOptions.onFinish?.(visit)
+            resolved.onFinish?.(visit)
           },
         })
       },

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -194,10 +194,27 @@ export class Router {
   }
 
   public poll(interval: number, requestOptions: ReloadOptions = {}, options: PollOptions = {}) {
-    return polls.add(interval, () => this.reload(requestOptions), {
-      autoStart: options.autoStart ?? true,
-      keepAlive: options.keepAlive ?? false,
-    })
+    return polls.add(
+      interval,
+      ({ onStart, onFinish }) => {
+        this.reload({
+          ...requestOptions,
+          onCancelToken: (token) => {
+            onStart(token.cancel)
+            requestOptions.onCancelToken?.(token)
+          },
+          onFinish: (visit) => {
+            onFinish()
+            requestOptions.onFinish?.(visit)
+          },
+        })
+      },
+      {
+        autoStart: options.autoStart ?? true,
+        keepAlive: options.keepAlive ?? false,
+        mode: options.mode,
+      },
+    )
   }
 
   public visit<T extends RequestPayload = RequestPayload>(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -431,6 +431,7 @@ export type ReloadOptions<T extends RequestPayload = RequestPayload> = Omit<
 export type PollOptions = {
   keepAlive?: boolean
   autoStart?: boolean
+  mode?: 'overlap' | 'cancel' | 'rest'
 }
 
 export type VisitHelperOptions<T extends RequestPayload = RequestPayload> = Omit<VisitOptions<T>, 'method' | 'data'>

--- a/packages/react/src/usePoll.ts
+++ b/packages/react/src/usePoll.ts
@@ -3,29 +3,29 @@ import { useEffect, useRef } from 'react'
 
 export default function usePoll(
   interval: number,
-  requestOptions: ReloadOptions = {},
+  requestOptions: ReloadOptions | (() => ReloadOptions) = {},
   options: PollOptions = {
     keepAlive: false,
     autoStart: true,
   },
 ) {
-  const pollRef = useRef(
-    router.poll(interval, requestOptions, {
-      ...options,
-      autoStart: false,
-    }),
-  )
+  const latest = useRef(requestOptions)
+  latest.current = requestOptions
+
+  const pollRef = useRef<ReturnType<typeof router.poll> | null>(null)
 
   useEffect(() => {
-    if (options.autoStart ?? true) {
-      pollRef.current.start()
-    }
+    pollRef.current = router.poll(
+      interval,
+      typeof requestOptions === 'function' ? () => (latest.current as () => ReloadOptions)() : requestOptions,
+      { ...options, autoStart: options.autoStart ?? true },
+    )
 
-    return () => pollRef.current.stop()
+    return () => pollRef.current?.destroy()
   }, [])
 
   return {
-    stop: pollRef.current.stop,
-    start: pollRef.current.start,
+    stop: () => pollRef.current?.stop(),
+    start: () => pollRef.current?.start(),
   }
 }

--- a/packages/react/test-app/Pages/Poll/DynamicData.tsx
+++ b/packages/react/test-app/Pages/Poll/DynamicData.tsx
@@ -1,0 +1,17 @@
+import { Link, router, usePoll } from '@inertiajs/react'
+
+export default ({ counter, last_received }: { counter: number; last_received: number | null }) => {
+  usePoll(300, () => ({
+    data: { counter_seen: counter },
+    only: ['last_received'],
+  }))
+
+  return (
+    <>
+      <div id="counter">counter: {counter}</div>
+      <div id="last_received">received: {last_received ?? 'null'}</div>
+      <button onClick={() => router.reload({ only: ['counter'], data: { bump: counter + 1 } })}>Increment</button>
+      <Link href="/">Home</Link>
+    </>
+  )
+}

--- a/packages/react/test-app/Pages/Poll/Overlap.tsx
+++ b/packages/react/test-app/Pages/Poll/Overlap.tsx
@@ -4,18 +4,24 @@ export default ({ mode, time }: { mode: string; time: number }) => {
   const params = new URLSearchParams(window.location.search)
   const interval = parseInt(params.get('interval') || '200')
 
-  const options: { mode?: 'overlap' | 'cancel' | 'rest' } = {}
+  const options: { mode?: 'overlap' | 'cancel' | 'rest'; keepAlive?: boolean } = {}
 
   if (mode === 'overlap' || mode === 'cancel' || mode === 'rest') {
     options.mode = mode
   }
 
-  usePoll(interval, {}, options)
+  if (params.get('keepAlive') === '1') {
+    options.keepAlive = true
+  }
+
+  const { start, stop } = usePoll(interval, {}, options)
 
   return (
     <div>
       <span id="mode">{mode}</span>
       <span id="time">{time}</span>
+      <button onClick={stop}>Stop</button>
+      <button onClick={start}>Start</button>
     </div>
   )
 }

--- a/packages/react/test-app/Pages/Poll/Overlap.tsx
+++ b/packages/react/test-app/Pages/Poll/Overlap.tsx
@@ -1,0 +1,21 @@
+import { usePoll } from '@inertiajs/react'
+
+export default ({ mode, time }: { mode: string; time: number }) => {
+  const params = new URLSearchParams(window.location.search)
+  const interval = parseInt(params.get('interval') || '200')
+
+  const options: { mode?: 'overlap' | 'cancel' | 'rest' } = {}
+
+  if (mode === 'overlap' || mode === 'cancel' || mode === 'rest') {
+    options.mode = mode
+  }
+
+  usePoll(interval, {}, options)
+
+  return (
+    <div>
+      <span id="mode">{mode}</span>
+      <span id="time">{time}</span>
+    </div>
+  )
+}

--- a/packages/svelte/src/usePoll.ts
+++ b/packages/svelte/src/usePoll.ts
@@ -3,13 +3,13 @@ import { onDestroy, onMount } from 'svelte'
 
 export default function usePoll(
   interval: number,
-  requestOptions: ReloadOptions = {},
+  requestOptions: ReloadOptions | (() => ReloadOptions) = {},
   options: PollOptions = {
     keepAlive: false,
     autoStart: true,
   },
 ) {
-  const { stop, start } = router.poll(interval, requestOptions, {
+  const { stop, start, destroy } = router.poll(interval, requestOptions, {
     ...options,
     autoStart: false,
   })
@@ -21,7 +21,7 @@ export default function usePoll(
   })
 
   onDestroy(() => {
-    stop()
+    destroy()
   })
 
   return { stop, start }

--- a/packages/svelte/test-app/Pages/Poll/DynamicData.svelte
+++ b/packages/svelte/test-app/Pages/Poll/DynamicData.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { Link, router, usePoll } from '@inertiajs/svelte'
+
+  export let counter: number
+  export let last_received: number | null = null
+
+  usePoll(300, () => ({
+    data: { counter_seen: counter },
+    only: ['last_received'],
+  }))
+</script>
+
+<div id="counter">counter: {counter}</div>
+<div id="last_received">received: {last_received ?? 'null'}</div>
+<button on:click={() => router.reload({ only: ['counter'], data: { bump: counter + 1 } })}>Increment</button>
+<Link href="/">Home</Link>

--- a/packages/svelte/test-app/Pages/Poll/Overlap.svelte
+++ b/packages/svelte/test-app/Pages/Poll/Overlap.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { usePoll } from '@inertiajs/svelte'
+
+  export let mode: string
+  export let time: number
+
+  const params = new URLSearchParams(window.location.search)
+  const interval = parseInt(params.get('interval') || '200')
+
+  const initialMode = mode
+  const options: { mode?: 'overlap' | 'cancel' | 'rest' } = {}
+
+  if (initialMode === 'overlap' || initialMode === 'cancel' || initialMode === 'rest') {
+    options.mode = initialMode
+  }
+
+  usePoll(interval, {}, options)
+</script>
+
+<div>
+  <span id="mode">{mode}</span>
+  <span id="time">{time}</span>
+</div>

--- a/packages/svelte/test-app/Pages/Poll/Overlap.svelte
+++ b/packages/svelte/test-app/Pages/Poll/Overlap.svelte
@@ -8,16 +8,22 @@
   const interval = parseInt(params.get('interval') || '200')
 
   const initialMode = mode
-  const options: { mode?: 'overlap' | 'cancel' | 'rest' } = {}
+  const options: { mode?: 'overlap' | 'cancel' | 'rest'; keepAlive?: boolean } = {}
 
   if (initialMode === 'overlap' || initialMode === 'cancel' || initialMode === 'rest') {
     options.mode = initialMode
   }
 
-  usePoll(interval, {}, options)
+  if (params.get('keepAlive') === '1') {
+    options.keepAlive = true
+  }
+
+  const { start, stop } = usePoll(interval, {}, options)
 </script>
 
 <div>
   <span id="mode">{mode}</span>
   <span id="time">{time}</span>
+  <button on:click={stop}>Stop</button>
+  <button on:click={start}>Start</button>
 </div>

--- a/packages/vue3/src/usePoll.ts
+++ b/packages/vue3/src/usePoll.ts
@@ -3,7 +3,7 @@ import { onMounted, onUnmounted } from 'vue'
 
 export default function usePoll(
   interval: number,
-  requestOptions: ReloadOptions = {},
+  requestOptions: ReloadOptions | (() => ReloadOptions) = {},
   options: PollOptions = {
     keepAlive: false,
     autoStart: true,
@@ -12,7 +12,7 @@ export default function usePoll(
   stop: VoidFunction
   start: VoidFunction
 } {
-  const { stop, start } = router.poll(interval, requestOptions, {
+  const { stop, start, destroy } = router.poll(interval, requestOptions, {
     ...options,
     autoStart: false,
   })
@@ -24,7 +24,7 @@ export default function usePoll(
   })
 
   onUnmounted(() => {
-    stop()
+    destroy()
   })
 
   return {

--- a/packages/vue3/test-app/Pages/Poll/DynamicData.vue
+++ b/packages/vue3/test-app/Pages/Poll/DynamicData.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { Link, router, usePoll } from '@inertiajs/vue3'
+
+const props = defineProps<{
+  counter: number
+  last_received: number | null
+}>()
+
+usePoll(300, () => ({
+  data: { counter_seen: props.counter },
+  only: ['last_received'],
+}))
+</script>
+
+<template>
+  <div id="counter">counter: {{ counter }}</div>
+  <div id="last_received">received: {{ last_received ?? 'null' }}</div>
+  <button @click="router.reload({ only: ['counter'], data: { bump: counter + 1 } })">Increment</button>
+  <Link href="/">Home</Link>
+</template>

--- a/packages/vue3/test-app/Pages/Poll/Overlap.vue
+++ b/packages/vue3/test-app/Pages/Poll/Overlap.vue
@@ -6,18 +6,24 @@ const props = defineProps<{ mode: string; time: number }>()
 const params = new URLSearchParams(window.location.search)
 const interval = parseInt(params.get('interval') || '200')
 
-const options: { mode?: 'overlap' | 'cancel' | 'rest' } = {}
+const options: { mode?: 'overlap' | 'cancel' | 'rest'; keepAlive?: boolean } = {}
 
 if (props.mode === 'overlap' || props.mode === 'cancel' || props.mode === 'rest') {
   options.mode = props.mode
 }
 
-usePoll(interval, {}, options)
+if (params.get('keepAlive') === '1') {
+  options.keepAlive = true
+}
+
+const { start, stop } = usePoll(interval, {}, options)
 </script>
 
 <template>
   <div>
     <span id="mode">{{ mode }}</span>
     <span id="time">{{ time }}</span>
+    <button @click="stop">Stop</button>
+    <button @click="start">Start</button>
   </div>
 </template>

--- a/packages/vue3/test-app/Pages/Poll/Overlap.vue
+++ b/packages/vue3/test-app/Pages/Poll/Overlap.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { usePoll } from '@inertiajs/vue3'
+
+const props = defineProps<{ mode: string; time: number }>()
+
+const params = new URLSearchParams(window.location.search)
+const interval = parseInt(params.get('interval') || '200')
+
+const options: { mode?: 'overlap' | 'cancel' | 'rest' } = {}
+
+if (props.mode === 'overlap' || props.mode === 'cancel' || props.mode === 'rest') {
+  options.mode = props.mode
+}
+
+usePoll(interval, {}, options)
+</script>
+
+<template>
+  <div>
+    <span id="mode">{{ mode }}</span>
+    <span id="time">{{ time }}</span>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -786,6 +786,16 @@ app.get('/prefetch/test-page', (req, res) =>
   }),
 )
 
+app.get('/poll/dynamic-data', (req, res) =>
+  inertia.render(req, res, {
+    component: 'Poll/DynamicData',
+    props: {
+      counter: req.query.bump !== undefined ? Number(req.query.bump) : 0,
+      last_received: req.query.counter_seen !== undefined ? Number(req.query.counter_seen) : null,
+    },
+  }),
+)
+
 app.get('/prefetch/form', (req, res) =>
   inertia.render(req, res, {
     component: 'Prefetch/Form',

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -753,6 +753,16 @@ app.post('/events/errors', (req, res) =>
 )
 
 app.get('/poll/hook', (req, res) => inertia.render(req, res, { component: 'Poll/Hook', props: {} }))
+app.get('/poll/overlap/:mode', (req, res) => {
+  const mode = req.params.mode
+  const delay = parseInt(req.query.delay) || 600
+  setTimeout(() => {
+    inertia.render(req, res, {
+      component: 'Poll/Overlap',
+      props: { mode, time: Date.now() },
+    })
+  }, delay)
+})
 app.get('/poll/hook/manual', (req, res) => inertia.render(req, res, { component: 'Poll/HookManual', props: {} }))
 app.get('/poll/router/manual', (req, res) => inertia.render(req, res, { component: 'Poll/RouterManual', props: {} }))
 app.get('/poll/unchanged-data', (req, res) =>

--- a/tests/poll.spec.ts
+++ b/tests/poll.spec.ts
@@ -106,3 +106,57 @@ Object.entries({
     await expect(page.locator('.replaceStateCalls')).toHaveText('1')
   })
 })
+
+const pollRequests = () => requests.requests.filter((r) => r.url().includes('/poll/overlap/'))
+const pollFinished = () => requests.finished.filter((r) => r.url().includes('/poll/overlap/'))
+const pollFailed = () => requests.failed.filter((r) => r.url().includes('/poll/overlap/'))
+
+test('it allows overlapping requests by default', async ({ page }) => {
+  await page.goto('/poll/overlap/none?interval=200&delay=600')
+
+  requests.listen(page)
+  requests.listenForFinished(page)
+
+  await page.waitForTimeout(2000)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(3)
+  await expect(pollFinished().length).toBeLessThan(pollRequests().length)
+})
+
+test('it allows overlapping requests with explicit mode: overlap', async ({ page }) => {
+  await page.goto('/poll/overlap/overlap?interval=200&delay=600')
+
+  requests.listen(page)
+  requests.listenForFinished(page)
+
+  await page.waitForTimeout(2000)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(3)
+  await expect(pollFinished().length).toBeLessThan(pollRequests().length)
+})
+
+test('it waits for the interval between requests with mode: rest', async ({ page }) => {
+  await page.goto('/poll/overlap/rest?interval=200&delay=400')
+
+  requests.listen(page)
+  requests.listenForFinished(page)
+  requests.listenForFailed(page)
+
+  await page.waitForTimeout(2000)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(2)
+  await expect(pollFinished().length).toBe(pollRequests().length)
+  await expect(pollFailed().length).toBe(0)
+})
+
+test('it cancels in-flight requests on each tick with mode: cancel', async ({ page }) => {
+  await page.goto('/poll/overlap/cancel?interval=200&delay=600')
+
+  requests.listen(page)
+  requests.listenForFailed(page)
+
+  await page.waitForTimeout(2000)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(3)
+  await expect(pollFailed().length).toBeGreaterThanOrEqual(pollRequests().length - 1)
+})

--- a/tests/poll.spec.ts
+++ b/tests/poll.spec.ts
@@ -86,8 +86,102 @@ manualData.forEach(({ method, url }) => {
   })
 })
 
-test.skip('it will throttle polling when in the background', async ({ page }) => {})
-test.skip('it is able to keep alive when in the background', async ({ page }) => {})
+const setHidden = (page, hidden: boolean) =>
+  page.evaluate((hidden) => {
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => (hidden ? 'hidden' : 'visible'),
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+  }, hidden)
+;['overlap', 'rest'].forEach((mode) => {
+  test(`it throttles polling when in the background and resumes when visible (${mode})`, async ({ page }) => {
+    await page.goto(`/poll/overlap/${mode}?interval=200&delay=10`)
+
+    await page.waitForResponse(page.url())
+
+    await setHidden(page, true)
+
+    requests.listen(page)
+    await page.waitForTimeout(1400)
+
+    const hiddenCount = pollRequests().length
+    await expect(hiddenCount).toBeGreaterThanOrEqual(1)
+    await expect(hiddenCount).toBeLessThanOrEqual(2)
+
+    await setHidden(page, false)
+
+    await page.waitForTimeout(1000)
+
+    const visibleCount = pollRequests().length - hiddenCount
+    await expect(visibleCount).toBeGreaterThanOrEqual(3)
+  })
+})
+
+test('it keeps the throttled cadence when staying in the background past one cycle', async ({ page }) => {
+  await page.goto('/poll/overlap/rest?interval=100&delay=10')
+
+  await page.waitForResponse(page.url())
+
+  await setHidden(page, true)
+
+  requests.listen(page)
+  // Two full 10x cycles (~2s) — expect ~2 fires (first tick, then 10th).
+  await page.waitForTimeout(2200)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(2)
+  await expect(pollRequests().length).toBeLessThanOrEqual(3)
+})
+
+test('it does not throttle when keepAlive is set, even when hidden', async ({ page }) => {
+  await page.goto('/poll/overlap/overlap?interval=200&delay=10&keepAlive=1')
+
+  await page.waitForResponse(page.url())
+
+  await setHidden(page, true)
+
+  requests.listen(page)
+  await page.waitForTimeout(1400)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(4)
+})
+
+test('it does not double-schedule when stopped and restarted mid-flight (rest)', async ({ page }) => {
+  await page.goto('/poll/overlap/rest?interval=200&delay=800')
+
+  await page.waitForRequest(page.url())
+
+  // First request is now in flight (won't finish for ~800ms).
+  // Stop+start immediately so the stale onFinish would, without the session guard,
+  // call scheduleNext and create a second concurrent chain.
+  await page.getByRole('button', { name: 'Stop' }).click()
+  await page.getByRole('button', { name: 'Start' }).click()
+
+  requests.listen(page)
+
+  // Two full cycles of the restarted chain (~2 requests). A double chain would yield ~4.
+  await page.waitForTimeout(2400)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(1)
+  await expect(pollRequests().length).toBeLessThanOrEqual(3)
+})
+
+test('it does not cancel skipped throttled ticks in cancel mode', async ({ page }) => {
+  await page.goto('/poll/overlap/cancel?interval=200&delay=10')
+
+  await page.waitForResponse(page.url())
+
+  await setHidden(page, true)
+
+  requests.listen(page)
+  requests.listenForFailed(page)
+  await page.waitForTimeout(1400)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(1)
+  await expect(pollRequests().length).toBeLessThanOrEqual(2)
+  await expect(pollFailed().length).toBe(0)
+})
 
 Object.entries({
   unencrypted: '/poll/unchanged-data',

--- a/tests/poll.spec.ts
+++ b/tests/poll.spec.ts
@@ -107,6 +107,67 @@ Object.entries({
   })
 })
 
+test('it re-evaluates poll request options on each tick when passed as a function', async ({ page }) => {
+  const url = '/poll/dynamic-data'
+
+  await page.goto(url)
+  await expect(page.locator('#counter')).toHaveText('counter: 0')
+
+  await page.waitForResponse(
+    (response) => response.url().includes(url) && new URL(response.url()).searchParams.get('counter_seen') === '0',
+  )
+  await expect(page.locator('#last_received')).toHaveText('received: 0')
+
+  await page.getByRole('button', { name: 'Increment' }).click()
+  await expect(page.locator('#counter')).toHaveText('counter: 1')
+
+  await page.waitForResponse(
+    (response) => response.url().includes(url) && new URL(response.url()).searchParams.get('counter_seen') === '1',
+  )
+  await expect(page.locator('#last_received')).toHaveText('received: 1')
+
+  await page.getByRole('button', { name: 'Increment' }).click()
+  await expect(page.locator('#counter')).toHaveText('counter: 2')
+
+  await page.waitForResponse(
+    (response) => response.url().includes(url) && new URL(response.url()).searchParams.get('counter_seen') === '2',
+  )
+  await expect(page.locator('#last_received')).toHaveText('received: 2')
+})
+
+test('it cleans up the poll on unmount and does not leak across rerenders', async ({ page }) => {
+  await page.goto('/poll/dynamic-data')
+  await expect(page.locator('#counter')).toHaveText('counter: 0')
+
+  await page.waitForResponse(
+    (response) =>
+      response.url().includes('/poll/dynamic-data') && new URL(response.url()).searchParams.get('counter_seen') === '0',
+  )
+
+  const pollsAfterMount = await page.evaluate(() => window.testing.Inertia.activePolls)
+  await expect(pollsAfterMount).toBe(1)
+
+  for (let i = 1; i <= 5; i++) {
+    await page.getByRole('button', { name: 'Increment' }).click()
+    await expect(page.locator('#counter')).toHaveText(`counter: ${i}`)
+  }
+
+  const pollsAfterRerenders = await page.evaluate(() => window.testing.Inertia.activePolls)
+  await expect(pollsAfterRerenders).toBe(1)
+
+  await page.getByRole('link', { name: 'Home' }).click()
+  await page.waitForURL('/')
+
+  requests.listen(page)
+  await page.waitForTimeout(1000)
+
+  const leftover = requests.requests.filter((r) => r.url().includes('/poll/dynamic-data'))
+  await expect(leftover).toHaveLength(0)
+
+  const pollsAfterUnmount = await page.evaluate(() => window.testing.Inertia.activePolls)
+  await expect(pollsAfterUnmount).toBe(0)
+})
+
 const pollRequests = () => requests.requests.filter((r) => r.url().includes('/poll/overlap/'))
 const pollFinished = () => requests.finished.filter((r) => r.url().includes('/poll/overlap/'))
 const pollFailed = () => requests.failed.filter((r) => r.url().includes('/poll/overlap/'))


### PR DESCRIPTION
Backports #3093 and #3098 to 2.x.