### PR TITLE
[2.x] Restore previous body overflow when closing the error modal

### DIFF
--- a/packages/core/src/modal.ts
+++ b/packages/core/src/modal.ts
@@ -1,6 +1,7 @@
 export default {
   modal: null,
   listener: null,
+  previousBodyOverflow: null,
 
   createIframeAndPage(html: Record<string, unknown> | string): { iframe: HTMLIFrameElement; page: HTMLElement } {
     if (typeof html === 'object') {
@@ -38,6 +39,7 @@ export default {
     this.modal.appendChild(iframe)
 
     document.body.prepend(this.modal)
+    this.previousBodyOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
 
     iframe.srcdoc = page.outerHTML
@@ -49,7 +51,8 @@ export default {
   hide(): void {
     this.modal.outerHTML = ''
     this.modal = null
-    document.body.style.overflow = 'visible'
+    document.body.style.overflow = this.previousBodyOverflow ?? ''
+    this.previousBodyOverflow = null
     document.removeEventListener('keydown', this.listener)
   },
 

--- a/packages/react/test-app/Pages/ErrorModalBodyOverflow.tsx
+++ b/packages/react/test-app/Pages/ErrorModalBodyOverflow.tsx
@@ -15,7 +15,7 @@ export default ({ mode }: { mode: 'stylesheet' | 'inline' }) => {
       styleTag.textContent = 'body { overflow-y: scroll; }'
       document.head.appendChild(styleTag)
     } else {
-      document.body.style.overflow = 'hidden'
+      document.body.style.overflow = 'scroll'
     }
 
     return () => {

--- a/packages/react/test-app/Pages/ErrorModalBodyOverflow.tsx
+++ b/packages/react/test-app/Pages/ErrorModalBodyOverflow.tsx
@@ -1,0 +1,38 @@
+import { router } from '@inertiajs/react'
+import { useEffect } from 'react'
+
+export default ({ mode }: { mode: 'stylesheet' | 'inline' }) => {
+  const invalidVisit = () => {
+    router.post('/non-inertia')
+  }
+
+  useEffect(() => {
+    let styleTag: HTMLStyleElement | null = null
+
+    if (mode === 'stylesheet') {
+      styleTag = document.createElement('style')
+      styleTag.id = 'body-overflow-style'
+      styleTag.textContent = 'body { overflow-y: scroll; }'
+      document.head.appendChild(styleTag)
+    } else {
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      if (styleTag) {
+        styleTag.remove()
+      }
+      if (mode === 'inline') {
+        document.body.style.overflow = ''
+      }
+    }
+  }, [mode])
+
+  return (
+    <div>
+      <span onClick={invalidVisit} className="invalid-visit">
+        Invalid Visit
+      </span>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/ErrorModalBodyOverflow.svelte
+++ b/packages/svelte/test-app/Pages/ErrorModalBodyOverflow.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { router } from '@inertiajs/svelte'
+  import { onDestroy, onMount } from 'svelte'
+
+  export let mode: 'stylesheet' | 'inline'
+
+  const invalidVisit = () => {
+    router.post('/non-inertia')
+  }
+
+  let styleTag: HTMLStyleElement | null = null
+
+  onMount(() => {
+    if (mode === 'stylesheet') {
+      styleTag = document.createElement('style')
+      styleTag.id = 'body-overflow-style'
+      styleTag.textContent = 'body { overflow-y: scroll; }'
+      document.head.appendChild(styleTag)
+    } else {
+      document.body.style.overflow = 'hidden'
+    }
+  })
+
+  onDestroy(() => {
+    if (styleTag) {
+      styleTag.remove()
+      styleTag = null
+    }
+    if (mode === 'inline') {
+      document.body.style.overflow = ''
+    }
+  })
+</script>
+
+<div>
+  <span
+    on:click={invalidVisit}
+    on:keydown={(e) => e.key === 'Enter' && invalidVisit()}
+    role="button"
+    tabindex="0"
+    class="invalid-visit">Invalid Visit</span
+  >
+</div>

--- a/packages/svelte/test-app/Pages/ErrorModalBodyOverflow.svelte
+++ b/packages/svelte/test-app/Pages/ErrorModalBodyOverflow.svelte
@@ -17,7 +17,7 @@
       styleTag.textContent = 'body { overflow-y: scroll; }'
       document.head.appendChild(styleTag)
     } else {
-      document.body.style.overflow = 'hidden'
+      document.body.style.overflow = 'scroll'
     }
   })
 

--- a/packages/vue3/test-app/Pages/ErrorModalBodyOverflow.vue
+++ b/packages/vue3/test-app/Pages/ErrorModalBodyOverflow.vue
@@ -19,7 +19,7 @@ onMounted(() => {
     styleTag.textContent = 'body { overflow-y: scroll; }'
     document.head.appendChild(styleTag)
   } else {
-    document.body.style.overflow = 'hidden'
+    document.body.style.overflow = 'scroll'
   }
 })
 

--- a/packages/vue3/test-app/Pages/ErrorModalBodyOverflow.vue
+++ b/packages/vue3/test-app/Pages/ErrorModalBodyOverflow.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+const props = defineProps<{
+  mode: 'stylesheet' | 'inline'
+}>()
+
+import { router } from '@inertiajs/vue3'
+import { onBeforeUnmount, onMounted } from 'vue'
+
+const invalidVisit = () => {
+  router.post('/non-inertia')
+}
+
+let styleTag: HTMLStyleElement | null = null
+
+onMounted(() => {
+  if (props.mode === 'stylesheet') {
+    styleTag = document.createElement('style')
+    styleTag.id = 'body-overflow-style'
+    styleTag.textContent = 'body { overflow-y: scroll; }'
+    document.head.appendChild(styleTag)
+  } else {
+    document.body.style.overflow = 'hidden'
+  }
+})
+
+onBeforeUnmount(() => {
+  if (styleTag) {
+    styleTag.remove()
+    styleTag = null
+  }
+  if (props.mode === 'inline') {
+    document.body.style.overflow = ''
+  }
+})
+</script>
+
+<template>
+  <div>
+    <span @click="invalidVisit" class="invalid-visit">Invalid Visit</span>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -173,6 +173,12 @@ app.get('/links/partial-reloads', (req, res) =>
 app.all('/error-modal', (req, res) =>
   inertia.render(req, res, { component: 'ErrorModal', props: { dialog: !!req.query.dialog } }),
 )
+app.all('/error-modal/body-overflow-stylesheet', (req, res) =>
+  inertia.render(req, res, { component: 'ErrorModalBodyOverflow', props: { mode: 'stylesheet' } }),
+)
+app.all('/error-modal/body-overflow-inline', (req, res) =>
+  inertia.render(req, res, { component: 'ErrorModalBodyOverflow', props: { mode: 'inline' } }),
+)
 app.all('/links/preserve-state-page-two', (req, res) =>
   inertia.render(req, res, { component: 'Links/PreserveState', props: { foo: req.query.foo } }),
 )

--- a/tests/error-modal.spec.ts
+++ b/tests/error-modal.spec.ts
@@ -80,9 +80,9 @@ test('it preserves a stylesheet-defined body overflow when closing the div modal
 test('it restores a caller-set inline body overflow when closing the div modal', async ({ page }) => {
   pageLoads.watch(page)
   await page.goto('/error-modal/body-overflow-inline')
-  await page.waitForFunction(() => document.body.style.overflow === 'hidden')
+  await page.waitForFunction(() => document.body.style.overflow === 'scroll')
 
-  expect(await page.evaluate(() => document.body.style.overflow)).toBe('hidden')
+  expect(await page.evaluate(() => document.body.style.overflow)).toBe('scroll')
 
   await page.getByText('Invalid Visit', { exact: true }).click()
   await expect(page.frameLocator('iframe').getByText('This is a page that does not')).toBeVisible()
@@ -92,7 +92,7 @@ test('it restores a caller-set inline body overflow when closing the div modal',
   await page.mouse.click(25, 25)
   await expect(page.frameLocator('iframe').getByText('This is a page that does not')).toBeHidden()
 
-  expect(await page.evaluate(() => document.body.style.overflow)).toBe('hidden')
+  expect(await page.evaluate(() => document.body.style.overflow)).toBe('scroll')
 })
 
 test('it does not execute scripts in the error dialog iframe', async ({ page }) => {

--- a/tests/error-modal.spec.ts
+++ b/tests/error-modal.spec.ts
@@ -57,6 +57,44 @@ elements.forEach((element) => {
   })
 })
 
+test('it preserves a stylesheet-defined body overflow when closing the div modal', async ({ page }) => {
+  pageLoads.watch(page)
+  await page.goto('/error-modal/body-overflow-stylesheet')
+  await page.waitForFunction(() => !!document.getElementById('body-overflow-style'))
+
+  expect(await page.evaluate(() => document.body.style.overflow)).toBe('')
+  expect(await page.evaluate(() => getComputedStyle(document.body).overflowY)).toBe('scroll')
+
+  await page.getByText('Invalid Visit', { exact: true }).click()
+  await expect(page.frameLocator('iframe').getByText('This is a page that does not')).toBeVisible()
+
+  expect(await page.evaluate(() => document.body.style.overflow)).toBe('hidden')
+
+  await page.mouse.click(25, 25)
+  await expect(page.frameLocator('iframe').getByText('This is a page that does not')).toBeHidden()
+
+  expect(await page.evaluate(() => document.body.style.overflow)).toBe('')
+  expect(await page.evaluate(() => getComputedStyle(document.body).overflowY)).toBe('scroll')
+})
+
+test('it restores a caller-set inline body overflow when closing the div modal', async ({ page }) => {
+  pageLoads.watch(page)
+  await page.goto('/error-modal/body-overflow-inline')
+  await page.waitForFunction(() => document.body.style.overflow === 'hidden')
+
+  expect(await page.evaluate(() => document.body.style.overflow)).toBe('hidden')
+
+  await page.getByText('Invalid Visit', { exact: true }).click()
+  await expect(page.frameLocator('iframe').getByText('This is a page that does not')).toBeVisible()
+
+  expect(await page.evaluate(() => document.body.style.overflow)).toBe('hidden')
+
+  await page.mouse.click(25, 25)
+  await expect(page.frameLocator('iframe').getByText('This is a page that does not')).toBeHidden()
+
+  expect(await page.evaluate(() => document.body.style.overflow)).toBe('hidden')
+})
+
 test('it does not execute scripts in the error dialog iframe', async ({ page }) => {
   pageLoads.watch(page)
   await page.goto('/error-modal?dialog=1')


### PR DESCRIPTION
The error modal sets `document.body.style.overflow` to `hidden` when it opens and then forces it back to `visible` when it closes. That overwrites any overflow value the host app had configured, breaking layouts that rely on `overflow-y: scroll` on the body (for example a Tailwind `overflow-y-scroll` class).

The modal now snapshots the previous inline overflow value before opening and restores it on close, so stylesheet rules and caller-set inline values both survive the modal lifecycle.