### PR TITLE
[3.x] Improve `router.poll` throttle semantics and stop+start handling

### DIFF
--- a/packages/core/src/poll.ts
+++ b/packages/core/src/poll.ts
@@ -19,6 +19,7 @@ export class Poll {
   protected inFlight = false
   protected currentCancel: VoidFunction | null = null
   protected stopped = true
+  protected sessionId = 0
 
   constructor(interval: number, cb: PollCallback, options: PollOptions) {
     this.keepAlive = options.keepAlive ?? false
@@ -34,6 +35,9 @@ export class Poll {
 
   public stop() {
     this.stopped = true
+    this.sessionId++
+    this.inFlight = false
+    this.currentCancel = null
 
     if (this.intervalId) {
       clearInterval(this.intervalId)
@@ -98,12 +102,22 @@ export class Poll {
       this.currentCancel?.()
     }
 
+    const session = this.sessionId
+
     this.cb({
       onStart: (cancel) => {
+        if (session !== this.sessionId) {
+          return
+        }
+
         this.inFlight = true
         this.currentCancel = cancel
       },
       onFinish: () => {
+        if (session !== this.sessionId) {
+          return
+        }
+
         this.inFlight = false
         this.currentCancel = null
 

--- a/packages/core/src/poll.ts
+++ b/packages/core/src/poll.ts
@@ -19,7 +19,7 @@ export class Poll {
   protected inFlight = false
   protected currentCancel: VoidFunction | null = null
   protected stopped = true
-  protected sessionId = 0
+  protected instanceId = 0
 
   constructor(interval: number, cb: PollCallback, options: PollOptions) {
     this.keepAlive = options.keepAlive ?? false
@@ -35,7 +35,7 @@ export class Poll {
 
   public stop() {
     this.stopped = true
-    this.sessionId++
+    this.instanceId++
     this.inFlight = false
     this.currentCancel = null
 
@@ -102,11 +102,11 @@ export class Poll {
       this.currentCancel?.()
     }
 
-    const session = this.sessionId
+    const instance = this.instanceId
 
     this.cb({
       onStart: (cancel) => {
-        if (session !== this.sessionId) {
+        if (instance !== this.instanceId) {
           return
         }
 
@@ -114,7 +114,7 @@ export class Poll {
         this.currentCancel = cancel
       },
       onFinish: () => {
-        if (session !== this.sessionId) {
+        if (instance !== this.instanceId) {
           return
         }
 

--- a/packages/core/src/poll.ts
+++ b/packages/core/src/poll.ts
@@ -59,15 +59,7 @@ export class Poll {
       return
     }
 
-    this.intervalId = window.setInterval(() => {
-      if (!this.throttle || this.cbCount % 10 === 0) {
-        this.fire()
-      }
-
-      if (this.throttle) {
-        this.cbCount++
-      }
-    }, this.interval)
+    this.intervalId = window.setInterval(() => this.tick(), this.interval)
   }
 
   public isInBackground(hidden: boolean) {
@@ -83,12 +75,22 @@ export class Poll {
       return
     }
 
-    const delay = this.throttle ? this.interval * 10 : this.interval
-
     this.timeoutId = window.setTimeout(() => {
       this.timeoutId = null
+      this.tick()
+    }, this.interval)
+  }
+
+  protected tick() {
+    if (!this.throttle || this.cbCount % 10 === 0) {
       this.fire()
-    }, delay)
+    } else if (this.mode === 'rest') {
+      this.scheduleNext()
+    }
+
+    if (this.throttle) {
+      this.cbCount++
+    }
   }
 
   protected fire() {

--- a/packages/react/test-app/Pages/Poll/Overlap.tsx
+++ b/packages/react/test-app/Pages/Poll/Overlap.tsx
@@ -4,18 +4,24 @@ export default ({ mode, time }: { mode: string; time: number }) => {
   const params = new URLSearchParams(window.location.search)
   const interval = parseInt(params.get('interval') || '200')
 
-  const options: { mode?: 'overlap' | 'cancel' | 'rest' } = {}
+  const options: { mode?: 'overlap' | 'cancel' | 'rest'; keepAlive?: boolean } = {}
 
   if (mode === 'overlap' || mode === 'cancel' || mode === 'rest') {
     options.mode = mode
   }
 
-  usePoll(interval, {}, options)
+  if (params.get('keepAlive') === '1') {
+    options.keepAlive = true
+  }
+
+  const { start, stop } = usePoll(interval, {}, options)
 
   return (
     <div>
       <span id="mode">{mode}</span>
       <span id="time">{time}</span>
+      <button onClick={stop}>Stop</button>
+      <button onClick={start}>Start</button>
     </div>
   )
 }

--- a/packages/svelte/test-app/Pages/Poll/Overlap.svelte
+++ b/packages/svelte/test-app/Pages/Poll/Overlap.svelte
@@ -8,16 +8,22 @@
 
   // svelte-ignore state_referenced_locally
   const initialMode = mode
-  const options: { mode?: 'overlap' | 'cancel' | 'rest' } = {}
+  const options: { mode?: 'overlap' | 'cancel' | 'rest'; keepAlive?: boolean } = {}
 
   if (initialMode === 'overlap' || initialMode === 'cancel' || initialMode === 'rest') {
     options.mode = initialMode
   }
 
-  usePoll(interval, {}, options)
+  if (params.get('keepAlive') === '1') {
+    options.keepAlive = true
+  }
+
+  const { start, stop } = usePoll(interval, {}, options)
 </script>
 
 <div>
   <span id="mode">{mode}</span>
   <span id="time">{time}</span>
+  <button onclick={stop}>Stop</button>
+  <button onclick={start}>Start</button>
 </div>

--- a/packages/vue3/test-app/Pages/Poll/Overlap.vue
+++ b/packages/vue3/test-app/Pages/Poll/Overlap.vue
@@ -6,18 +6,24 @@ const props = defineProps<{ mode: string; time: number }>()
 const params = new URLSearchParams(window.location.search)
 const interval = parseInt(params.get('interval') || '200')
 
-const options: { mode?: 'overlap' | 'cancel' | 'rest' } = {}
+const options: { mode?: 'overlap' | 'cancel' | 'rest'; keepAlive?: boolean } = {}
 
 if (props.mode === 'overlap' || props.mode === 'cancel' || props.mode === 'rest') {
   options.mode = props.mode
 }
 
-usePoll(interval, {}, options)
+if (params.get('keepAlive') === '1') {
+  options.keepAlive = true
+}
+
+const { start, stop } = usePoll(interval, {}, options)
 </script>
 
 <template>
   <div>
     <span id="mode">{{ mode }}</span>
     <span id="time">{{ time }}</span>
+    <button @click="stop">Stop</button>
+    <button @click="start">Start</button>
   </div>
 </template>

--- a/tests/poll.spec.ts
+++ b/tests/poll.spec.ts
@@ -300,9 +300,8 @@ test('it waits for the interval between requests with mode: rest', async ({ page
   await page.waitForTimeout(2000)
 
   await expect(pollRequests().length).toBeGreaterThanOrEqual(2)
+  await expect(pollFinished().length).toBe(pollRequests().length)
   await expect(pollFailed().length).toBe(0)
-  // At most one in-flight; rest mode never overlaps so all but the last must be finished.
-  await expect(pollFinished().length).toBeGreaterThanOrEqual(pollRequests().length - 1)
 })
 
 test('it cancels in-flight requests on each tick with mode: cancel', async ({ page }) => {

--- a/tests/poll.spec.ts
+++ b/tests/poll.spec.ts
@@ -134,7 +134,54 @@ test('it keeps the throttled cadence when staying in the background past one cyc
   await expect(pollRequests().length).toBeLessThanOrEqual(3)
 })
 
-test.skip('it is able to keep alive when in the background', async ({ page }) => {})
+test('it does not throttle when keepAlive is set, even when hidden', async ({ page }) => {
+  await page.goto('/poll/overlap/overlap?interval=200&delay=10&keepAlive=1')
+
+  await page.waitForResponse(page.url())
+
+  await setHidden(page, true)
+
+  requests.listen(page)
+  await page.waitForTimeout(1400)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(4)
+})
+
+test('it does not double-schedule when stopped and restarted mid-flight (rest)', async ({ page }) => {
+  await page.goto('/poll/overlap/rest?interval=200&delay=800')
+
+  await page.waitForRequest(page.url())
+
+  // First request is now in flight (won't finish for ~800ms).
+  // Stop+start immediately so the stale onFinish would, without the session guard,
+  // call scheduleNext and create a second concurrent chain.
+  await page.getByRole('button', { name: 'Stop' }).click()
+  await page.getByRole('button', { name: 'Start' }).click()
+
+  requests.listen(page)
+
+  // Two full cycles of the restarted chain (~2 requests). A double chain would yield ~4.
+  await page.waitForTimeout(2400)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(1)
+  await expect(pollRequests().length).toBeLessThanOrEqual(3)
+})
+
+test('it does not cancel skipped throttled ticks in cancel mode', async ({ page }) => {
+  await page.goto('/poll/overlap/cancel?interval=200&delay=10')
+
+  await page.waitForResponse(page.url())
+
+  await setHidden(page, true)
+
+  requests.listen(page)
+  requests.listenForFailed(page)
+  await page.waitForTimeout(1400)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(1)
+  await expect(pollRequests().length).toBeLessThanOrEqual(2)
+  await expect(pollFailed().length).toBe(0)
+})
 
 Object.entries({
   unencrypted: '/poll/unchanged-data',
@@ -253,8 +300,9 @@ test('it waits for the interval between requests with mode: rest', async ({ page
   await page.waitForTimeout(2000)
 
   await expect(pollRequests().length).toBeGreaterThanOrEqual(2)
-  await expect(pollFinished().length).toBe(pollRequests().length)
   await expect(pollFailed().length).toBe(0)
+  // At most one in-flight; rest mode never overlaps so all but the last must be finished.
+  await expect(pollFinished().length).toBeGreaterThanOrEqual(pollRequests().length - 1)
 })
 
 test('it cancels in-flight requests on each tick with mode: cancel', async ({ page }) => {

--- a/tests/poll.spec.ts
+++ b/tests/poll.spec.ts
@@ -86,7 +86,54 @@ manualData.forEach(({ method, url }) => {
   })
 })
 
-test.skip('it will throttle polling when in the background', async ({ page }) => {})
+const setHidden = (page, hidden: boolean) =>
+  page.evaluate((hidden) => {
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => (hidden ? 'hidden' : 'visible'),
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+  }, hidden)
+;['overlap', 'rest'].forEach((mode) => {
+  test(`it throttles polling when in the background and resumes when visible (${mode})`, async ({ page }) => {
+    await page.goto(`/poll/overlap/${mode}?interval=200&delay=10`)
+
+    await page.waitForResponse(page.url())
+
+    await setHidden(page, true)
+
+    requests.listen(page)
+    await page.waitForTimeout(1400)
+
+    const hiddenCount = pollRequests().length
+    await expect(hiddenCount).toBeGreaterThanOrEqual(1)
+    await expect(hiddenCount).toBeLessThanOrEqual(2)
+
+    await setHidden(page, false)
+
+    await page.waitForTimeout(1000)
+
+    const visibleCount = pollRequests().length - hiddenCount
+    await expect(visibleCount).toBeGreaterThanOrEqual(3)
+  })
+})
+
+test('it keeps the throttled cadence when staying in the background past one cycle', async ({ page }) => {
+  await page.goto('/poll/overlap/rest?interval=100&delay=10')
+
+  await page.waitForResponse(page.url())
+
+  await setHidden(page, true)
+
+  requests.listen(page)
+  // Two full 10x cycles (~2s) — expect ~2 fires (first tick, then 10th).
+  await page.waitForTimeout(2200)
+
+  await expect(pollRequests().length).toBeGreaterThanOrEqual(2)
+  await expect(pollRequests().length).toBeLessThanOrEqual(3)
+})
+
 test.skip('it is able to keep alive when in the background', async ({ page }) => {})
 
 Object.entries({


### PR DESCRIPTION
This PR follows up on #3093. The three modes had inconsistent background-throttle behavior. All three modes now share the same throttle gate, so background polling behaves the same regardless of mode.

It also fixes a stale-callback bug when `stop()` and `start()` were called while a request was still in flight. The old request's `onFinish` could schedule a second concurrent chain in rest mode, or clobber the new session's in-flight tracking in cancel mode. Stop now bumps a session counter so stale callbacks no-op.