### PR TITLE
[3.x] Await user-provided Form onSuccess callback before completing submission

### DIFF
--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -236,8 +236,8 @@ const Form = forwardRef<FormComponentRef, FormProps>(
         onProgress,
         onFinish,
         onCancel,
-        onSuccess: (...args) => {
-          onSuccess(...args)
+        onSuccess: async (...args) => {
+          const result = await onSuccess(...args)
           onSubmitComplete({
             reset,
             defaults,
@@ -247,6 +247,8 @@ const Form = forwardRef<FormComponentRef, FormProps>(
           if (setDefaultsOnSuccess === true) {
             defaults()
           }
+
+          return result
         },
         onError(...args) {
           onError(...args)

--- a/packages/react/test-app/Pages/FormComponent/AsyncOnSuccess.tsx
+++ b/packages/react/test-app/Pages/FormComponent/AsyncOnSuccess.tsx
@@ -1,0 +1,24 @@
+import { Form } from '@inertiajs/react'
+
+export default () => {
+  return (
+    <div>
+      <h1>Form Async OnSuccess Test</h1>
+
+      <Form
+        method="post"
+        action="/form-component/async-on-success/submit"
+        disableWhileProcessing
+        onSuccess={() => new Promise<void>((resolve) => setTimeout(resolve, 1500))}
+      >
+        <div>
+          <input type="text" name="name" placeholder="Name" defaultValue="John Doe" />
+        </div>
+
+        <div>
+          <button type="submit">Submit</button>
+        </div>
+      </Form>
+    </div>
+  )
+}

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -174,10 +174,8 @@
       onProgress,
       onFinish,
       onCancel,
-      onSuccess: (...args) => {
-        if (onSuccess) {
-          onSuccess(...args)
-        }
+      onSuccess: async (...args) => {
+        const result = onSuccess ? await onSuccess(...args) : undefined
 
         if (onSubmitComplete) {
           onSubmitComplete({
@@ -191,6 +189,8 @@
         if (setDefaultsOnSuccess === true) {
           defaults()
         }
+
+        return result
       },
       onError: (...args) => {
         if (onError) {

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -175,7 +175,7 @@
       onFinish,
       onCancel,
       onSuccess: async (...args) => {
-        const result = onSuccess ? await onSuccess(...args) : undefined
+        const result = await onSuccess?.(...args)
 
         if (onSubmitComplete) {
           onSubmitComplete({

--- a/packages/svelte/test-app/Pages/FormComponent/AsyncOnSuccess.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/AsyncOnSuccess.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Form } from '@inertiajs/svelte'
+
+  const onSuccess = () => new Promise<void>((resolve) => setTimeout(resolve, 1500))
+</script>
+
+<div>
+  <h1>Form Async OnSuccess Test</h1>
+
+  <Form method="post" action="/form-component/async-on-success/submit" disableWhileProcessing {onSuccess}>
+    {#snippet children()}
+      <div>
+        <input type="text" name="name" placeholder="Name" value="John Doe" />
+      </div>
+
+      <div>
+        <button type="submit">Submit</button>
+      </div>
+    {/snippet}
+  </Form>
+</div>

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -286,14 +286,16 @@ const Form = defineComponent({
         onProgress: props.onProgress,
         onFinish: props.onFinish,
         onCancel: props.onCancel,
-        onSuccess: (...args) => {
-          props.onSuccess?.(...args)
+        onSuccess: async (...args) => {
+          const result = await props.onSuccess?.(...args)
           props.onSubmitComplete?.(exposed)
           maybeReset(props.resetOnSuccess)
 
           if (props.setDefaultsOnSuccess === true) {
             defaults()
           }
+
+          return result
         },
         onError: (...args) => {
           props.onError?.(...args)

--- a/packages/vue3/test-app/Pages/FormComponent/AsyncOnSuccess.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/AsyncOnSuccess.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3'
+
+const onSuccess = () => new Promise<void>((resolve) => setTimeout(resolve, 1500))
+</script>
+
+<template>
+  <div>
+    <h1>Form Async OnSuccess Test</h1>
+
+    <Form
+      method="post"
+      action="/form-component/async-on-success/submit"
+      disable-while-processing
+      :on-success="onSuccess"
+    >
+      <div>
+        <input type="text" name="name" placeholder="Name" value="John Doe" />
+      </div>
+
+      <div>
+        <button type="submit">Submit</button>
+      </div>
+    </Form>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -1978,6 +1978,12 @@ app.post('/form-component/disable-while-processing/:disable/submit', upload.any(
     500,
   ),
 )
+app.get('/form-component/async-on-success', upload.any(), async (req, res) =>
+  inertia.render(req, res, { component: 'FormComponent/AsyncOnSuccess' }),
+)
+app.post('/form-component/async-on-success/submit', upload.any(), async (req, res) =>
+  inertia.render(req, res, { component: 'FormComponent/AsyncOnSuccess' }),
+)
 app.post('/form-component/events/success', async (req, res) =>
   inertia.render(req, res, { component: 'FormComponent/Events' }),
 )

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -572,6 +572,22 @@ test.describe('Form Component', () => {
     await expect(page.locator('form[inert]')).not.toBeVisible()
   })
 
+  test('keeps the form processing until an async onSuccess resolves', async ({ page }) => {
+    await page.goto('/form-component/async-on-success')
+
+    const responsePromise = page.waitForResponse('**/form-component/async-on-success/submit')
+    await page.getByRole('button', { name: 'Submit' }).click()
+    await responsePromise
+
+    // The server has responded, but the user-supplied onSuccess returns
+    // a Promise that resolves after 1500ms. The Form awaits it, so the
+    // form stays inert (disableWhileProcessing) for the full duration.
+    await expect(page.locator('form[inert]')).toBeVisible()
+
+    // Once the Promise resolves, the form is no longer inert.
+    await expect(page.locator('form[inert]')).not.toBeVisible({ timeout: 3000 })
+  })
+
   test('submit without an action attribute uses the current URL', async ({ page }) => {
     await page.goto('/form-component/url/with/segements')
     await expect(page.locator('#error_name')).not.toBeVisible()

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -579,12 +579,7 @@ test.describe('Form Component', () => {
     await page.getByRole('button', { name: 'Submit' }).click()
     await responsePromise
 
-    // The server has responded, but the user-supplied onSuccess returns
-    // a Promise that resolves after 1500ms. The Form awaits it, so the
-    // form stays inert (disableWhileProcessing) for the full duration.
     await expect(page.locator('form[inert]')).toBeVisible()
-
-    // Once the Promise resolves, the form is no longer inert.
     await expect(page.locator('form[inert]')).not.toBeVisible({ timeout: 3000 })
   })
 


### PR DESCRIPTION
The `<Form>` component wraps the user-provided `onSuccess` callback in a synchronous closure that fires `onSubmitComplete` immediately after the user's callback returns. `onSubmitComplete` flips `processing` back to `false`, which removes `disableWhileProcessing`'s `inert` attribute and lets `processing`-driven UI (spinners, disabled inputs) reset.

If the user's `onSuccess` returns a Promise — for example, polling a background job before reloading — the form's processing state clears before that work finishes, defeating `disableWhileProcessing` and any UI bound to `processing`.

`useForm`'s internal submit already awaits `options.onSuccess` and returns its result, so the Form wrappers are the only place this awaitability is dropped. This PR propagates it.