### PR TITLE
[3.x] Pass props to withApp callback

### DIFF
--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -30,7 +30,10 @@ type ComponentResolver = (
   page?: Page<SharedPageProps>,
 ) => ReactComponent | Promise<ReactComponent> | { default: ReactComponent }
 
-type ReactWithApp = (app: ReactElement, options: { ssr: boolean, props: InertiaAppProps<SharedProps> }) => ReactElement
+type ReactWithApp<SharedProps extends PageProps> = (
+  app: ReactElement,
+  options: { ssr: boolean; page: Page<SharedProps> },
+) => ReactElement
 
 type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForCSR<
   SharedProps,
@@ -68,7 +71,7 @@ type InertiaAppOptionsAuto<SharedProps extends PageProps> = Omit<
   render?: undefined
   strictMode?: boolean
 } & (
-    | { setup?: undefined; withApp?: ReactWithApp }
+    | { setup?: undefined; withApp?: ReactWithApp<SharedProps> }
     | { setup: (options: SetupOptions<HTMLElement | null, SharedProps>) => ReactElement | void; withApp?: never }
   )
 
@@ -158,7 +161,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
         reactApp = wrapWithStrictMode(createElement(App, props))
 
         if (withApp) {
-          reactApp = withApp(reactApp, { ssr: true, props: props })
+          reactApp = withApp(reactApp, { ssr: true, page })
         }
       }
 
@@ -207,7 +210,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     let appElement = wrapWithStrictMode(createElement(App, props))
 
     if (withApp) {
-      appElement = withApp(appElement, { ssr: false, props: props })
+      appElement = withApp(appElement, { ssr: false, page: initialPage })
     }
 
     if (el.hasAttribute('data-server-rendered')) {

--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -30,7 +30,7 @@ type ComponentResolver = (
   page?: Page<SharedPageProps>,
 ) => ReactComponent | Promise<ReactComponent> | { default: ReactComponent }
 
-type ReactWithApp = (app: ReactElement, options: { ssr: boolean }) => ReactElement
+type ReactWithApp = (app: ReactElement, options: { ssr: boolean, props: InertiaAppProps<SharedProps> }) => ReactElement
 
 type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForCSR<
   SharedProps,
@@ -158,7 +158,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
         reactApp = wrapWithStrictMode(createElement(App, props))
 
         if (withApp) {
-          reactApp = withApp(reactApp, { ssr: true })
+          reactApp = withApp(reactApp, { ssr: true, props: props })
         }
       }
 
@@ -207,7 +207,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     let appElement = wrapWithStrictMode(createElement(App, props))
 
     if (withApp) {
-      appElement = withApp(appElement, { ssr: false })
+      appElement = withApp(appElement, { ssr: false, props: props })
     }
 
     if (el.hasAttribute('data-server-rendered')) {

--- a/packages/react/test-app/Pages/SSR/WithApp.tsx
+++ b/packages/react/test-app/Pages/SSR/WithApp.tsx
@@ -1,6 +1,16 @@
 import { createContext, useContext } from 'react'
 
-export const WithAppContext = createContext('not-injected')
+type WithAppValue = {
+  injected: string
+  locale: string
+  component: string
+}
+
+export const WithAppContext = createContext<WithAppValue>({
+  injected: 'not-injected',
+  locale: 'not-injected',
+  component: 'not-injected',
+})
 
 export default () => {
   const withAppValue = useContext(WithAppContext)
@@ -8,7 +18,9 @@ export default () => {
   return (
     <div>
       <h1 data-testid="with-app-title">SSR WithApp</h1>
-      <p data-testid="with-app-value">Value: {withAppValue}</p>
+      <p data-testid="with-app-value">Value: {withAppValue.injected}</p>
+      <p data-testid="with-app-locale">Locale: {withAppValue.locale}</p>
+      <p data-testid="with-app-component">Component: {withAppValue.component}</p>
     </div>
   )
 }

--- a/packages/react/test-app/app-unified.tsx
+++ b/packages/react/test-app/app-unified.tsx
@@ -1,11 +1,13 @@
 import type { VisitOptions } from '@inertiajs/core'
 import { createInertiaApp, type ResolvedComponent, router } from '@inertiajs/react'
+import { createElement } from 'react'
+import { WithAppContext } from './Pages/SSR/WithApp'
 
 window.testing = { Inertia: router }
 
 const params = new URLSearchParams(window.location.search)
 
-createInertiaApp({
+createInertiaApp<{ locale?: string }>({
   strictMode: params.has('strictMode'),
   resolve: async (name) => {
     const pages = import.meta.glob<ResolvedComponent>('./Pages/**/*.tsx', { eager: true })
@@ -27,4 +29,13 @@ createInertiaApp({
       },
     },
   }),
+  withApp(app, { page }) {
+    const value = {
+      injected: 'injected-via-withApp',
+      locale: page.props.locale ?? 'unknown',
+      component: page.component,
+    }
+
+    return createElement(WithAppContext.Provider, { value }, app)
+  },
 })

--- a/packages/react/test-app/ssr-auto.tsx
+++ b/packages/react/test-app/ssr-auto.tsx
@@ -8,12 +8,18 @@ import { WithAppContext } from './Pages/SSR/WithApp'
 // 2. Import and use the React server renderer
 // 3. Export a default render function
 
-createInertiaApp({
+createInertiaApp<{ locale?: string }>({
   resolve: (name) => {
     const pages = import.meta.glob<ResolvedComponent>('./Pages/SSR/**/*.tsx', { eager: true })
     return pages[`./Pages/${name}.tsx`]
   },
-  withApp(app) {
-    return createElement(WithAppContext.Provider, { value: 'injected-via-withApp' }, app)
+  withApp(app, { page }) {
+    const value = {
+      injected: 'injected-via-withApp',
+      locale: page.props.locale ?? 'unknown',
+      component: page.component,
+    }
+
+    return createElement(WithAppContext.Provider, { value }, app)
   },
 })

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -24,7 +24,10 @@ type SetupOptions<SharedProps extends PageProps> = {
   props: InertiaAppProps<SharedProps>
 }
 
-type SvelteWithApp = (context: Map<any, any>, options: { ssr: boolean, props: InertiaAppProps<SharedProps> }) => void
+type SvelteWithApp<SharedProps extends PageProps> = (
+  context: Map<any, any>,
+  options: { ssr: boolean; page: Page<SharedProps> },
+) => void
 
 type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForCSR<
   SharedProps,
@@ -47,7 +50,7 @@ type InertiaAppOptionsAuto<SharedProps extends PageProps> = Omit<
 > & {
   page?: Page<SharedProps>
 } & (
-    | { setup?: undefined; withApp?: SvelteWithApp }
+    | { setup?: undefined; withApp?: SvelteWithApp<SharedProps> }
     | { setup: (options: SetupOptions<SharedProps>) => SvelteRenderResult | void; withApp?: never }
   )
 
@@ -122,7 +125,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
         const context = new Map()
 
         if (withApp) {
-          withApp(context, { ssr: true, props: props })
+          withApp(context, { ssr: true, page })
         }
 
         svelteApp = render(App, { props, context })
@@ -175,7 +178,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     const context = new Map()
 
     if (withApp) {
-      withApp(context, { ssr: false, props: props })
+      withApp(context, { ssr: false, page: initialPage })
     }
 
     if (target.hasAttribute('data-server-rendered')) {

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -24,7 +24,7 @@ type SetupOptions<SharedProps extends PageProps> = {
   props: InertiaAppProps<SharedProps>
 }
 
-type SvelteWithApp = (context: Map<any, any>, options: { ssr: boolean }) => void
+type SvelteWithApp = (context: Map<any, any>, options: { ssr: boolean, props: InertiaAppProps<SharedProps> }) => void
 
 type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForCSR<
   SharedProps,
@@ -122,7 +122,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
         const context = new Map()
 
         if (withApp) {
-          withApp(context, { ssr: true })
+          withApp(context, { ssr: true, props: props })
         }
 
         svelteApp = render(App, { props, context })
@@ -175,7 +175,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     const context = new Map()
 
     if (withApp) {
-      withApp(context, { ssr: false })
+      withApp(context, { ssr: false, props: props })
     }
 
     if (target.hasAttribute('data-server-rendered')) {

--- a/packages/svelte/test-app/Pages/SSR/WithApp.svelte
+++ b/packages/svelte/test-app/Pages/SSR/WithApp.svelte
@@ -2,9 +2,13 @@
   import { getContext } from 'svelte'
 
   const withAppValue = getContext<string>('withAppValue') ?? 'not-injected'
+  const withAppLocale = getContext<string>('withAppLocale') ?? 'not-injected'
+  const withAppComponent = getContext<string>('withAppComponent') ?? 'not-injected'
 </script>
 
 <div>
   <h1 data-testid="with-app-title">SSR WithApp</h1>
   <p data-testid="with-app-value">Value: {withAppValue}</p>
+  <p data-testid="with-app-locale">Locale: {withAppLocale}</p>
+  <p data-testid="with-app-component">Component: {withAppComponent}</p>
 </div>

--- a/packages/svelte/test-app/app-unified.ts
+++ b/packages/svelte/test-app/app-unified.ts
@@ -5,7 +5,7 @@ window.testing = { Inertia: router }
 
 const withAppDefaults = new URLSearchParams(window.location.search).get('withAppDefaults')
 
-createInertiaApp({
+createInertiaApp<{ locale?: string }>({
   resolve: async (name) => {
     const pages = import.meta.glob<ResolvedComponent>('./Pages/**/*.svelte', { eager: true })
 
@@ -25,4 +25,9 @@ createInertiaApp({
       },
     },
   }),
+  withApp(context, { page }) {
+    context.set('withAppValue', 'injected-via-withApp')
+    context.set('withAppLocale', page.props.locale ?? 'unknown')
+    context.set('withAppComponent', page.component)
+  },
 })

--- a/packages/svelte/test-app/ssr-auto.ts
+++ b/packages/svelte/test-app/ssr-auto.ts
@@ -6,12 +6,14 @@ import { createInertiaApp, type ResolvedComponent } from '@inertiajs/svelte'
 // 2. Import and use the Svelte server renderer
 // 3. Export a default render function
 
-createInertiaApp({
+createInertiaApp<{ locale?: string }>({
   resolve: (name) => {
     const pages = import.meta.glob<ResolvedComponent>('./Pages/SSR/**/*.svelte', { eager: true })
     return pages[`./Pages/${name}.svelte`]
   },
-  withApp(context) {
+  withApp(context, { page }) {
     context.set('withAppValue', 'injected-via-withApp')
+    context.set('withAppLocale', page.props.locale ?? 'unknown')
+    context.set('withAppComponent', page.component)
   },
 })

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -29,7 +29,10 @@ type SetupOptions<ElementType, SharedProps extends PageProps> = {
   plugin: Plugin
 }
 
-type VueWithApp = (app: VueApp, options: { ssr: boolean, props: InertiaAppProps<SharedProps> }) => void
+type VueWithApp<SharedProps extends PageProps> = (
+  app: VueApp,
+  options: { ssr: boolean; page: Page<SharedProps> },
+) => void
 
 type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForCSR<
   SharedProps,
@@ -64,7 +67,7 @@ type InertiaAppOptionsAuto<SharedProps extends PageProps> = Omit<
   page?: Page<SharedProps>
   render?: undefined
 } & (
-    | { setup?: undefined; withApp?: VueWithApp }
+    | { setup?: undefined; withApp?: VueWithApp<SharedProps> }
     | { setup: (options: SetupOptions<HTMLElement | null, SharedProps>) => VueApp | void; withApp?: never }
   )
 
@@ -149,7 +152,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
         vueApp.use(plugin)
 
         if (withApp) {
-          withApp(vueApp, { ssr: true, props: props })
+          withApp(vueApp, { ssr: true, page })
         }
       }
 
@@ -203,7 +206,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
       app.use(plugin)
 
       if (withApp) {
-        withApp(app, { ssr: false, props: props })
+        withApp(app, { ssr: false, page: initialPage })
       }
 
       app.mount(el)
@@ -212,7 +215,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
       app.use(plugin)
 
       if (withApp) {
-        withApp(app, { ssr: false, props: props })
+        withApp(app, { ssr: false, page: initialPage })
       }
 
       app.mount(el)

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -29,7 +29,7 @@ type SetupOptions<ElementType, SharedProps extends PageProps> = {
   plugin: Plugin
 }
 
-type VueWithApp = (app: VueApp, options: { ssr: boolean }) => void
+type VueWithApp = (app: VueApp, options: { ssr: boolean, props: InertiaAppProps<SharedProps> }) => void
 
 type InertiaAppOptionsForCSR<SharedProps extends PageProps> = CreateInertiaAppOptionsForCSR<
   SharedProps,
@@ -149,7 +149,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
         vueApp.use(plugin)
 
         if (withApp) {
-          withApp(vueApp, { ssr: true })
+          withApp(vueApp, { ssr: true, props: props })
         }
       }
 
@@ -203,7 +203,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
       app.use(plugin)
 
       if (withApp) {
-        withApp(app, { ssr: false })
+        withApp(app, { ssr: false, props: props })
       }
 
       app.mount(el)
@@ -212,7 +212,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
       app.use(plugin)
 
       if (withApp) {
-        withApp(app, { ssr: false })
+        withApp(app, { ssr: false, props: props })
       }
 
       app.mount(el)

--- a/packages/vue3/test-app/Pages/SSR/WithApp.vue
+++ b/packages/vue3/test-app/Pages/SSR/WithApp.vue
@@ -2,11 +2,15 @@
 import { inject } from 'vue'
 
 const withAppValue = inject('withAppValue', 'not-injected')
+const withAppLocale = inject('withAppLocale', 'not-injected')
+const withAppComponent = inject('withAppComponent', 'not-injected')
 </script>
 
 <template>
   <div>
     <h1 data-testid="with-app-title">SSR WithApp</h1>
     <p data-testid="with-app-value">Value: {{ withAppValue }}</p>
+    <p data-testid="with-app-locale">Locale: {{ withAppLocale }}</p>
+    <p data-testid="with-app-component">Component: {{ withAppComponent }}</p>
   </div>
 </template>

--- a/packages/vue3/test-app/app-unified.ts
+++ b/packages/vue3/test-app/app-unified.ts
@@ -6,7 +6,7 @@ window.testing = { Inertia: router }
 
 const withAppDefaults = new URLSearchParams(window.location.search).get('withAppDefaults')
 
-createInertiaApp({
+createInertiaApp<{ locale?: string }>({
   resolve: async (name) => {
     const pages = import.meta.glob<DefineComponent>('./Pages/**/*.vue', { eager: true })
 
@@ -26,4 +26,9 @@ createInertiaApp({
       },
     },
   }),
+  withApp(app, { page }) {
+    app.provide('withAppValue', 'injected-via-withApp')
+    app.provide('withAppLocale', page.props.locale ?? 'unknown')
+    app.provide('withAppComponent', page.component)
+  },
 })

--- a/packages/vue3/test-app/ssr-auto.ts
+++ b/packages/vue3/test-app/ssr-auto.ts
@@ -7,12 +7,14 @@ import type { DefineComponent } from 'vue'
 // 2. Import and use the Vue server renderer
 // 3. Export a default render function
 
-createInertiaApp({
+createInertiaApp<{ locale?: string }>({
   resolve: (name) => {
     const pages = import.meta.glob<DefineComponent>('./Pages/SSR/**/*.vue', { eager: true })
     return pages[`./Pages/${name}.vue`]
   },
-  withApp(app) {
+  withApp(app, { page }) {
     app.provide('withAppValue', 'injected-via-withApp')
+    app.provide('withAppLocale', page.props.locale ?? 'unknown')
+    app.provide('withAppComponent', page.component)
   },
 })

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -137,7 +137,7 @@ app.get('/ssr-auto/page2', (req, res) =>
 app.get('/ssr-auto/with-app', (req, res) =>
   inertia.renderSSRAuto(req, res, {
     component: 'SSR/WithApp',
-    props: {},
+    props: { locale: 'en-CA' },
   }),
 )
 
@@ -185,6 +185,13 @@ app.get('/unified/strict-mode', (req, res) =>
   inertia.renderUnified(req, res, {
     component: 'Unified/StrictMode',
     props: {},
+  }),
+)
+
+app.get('/unified/with-app', (req, res) =>
+  inertia.renderUnified(req, res, {
+    component: 'SSR/WithApp',
+    props: { locale: 'en-CA' },
   }),
 )
 

--- a/tests/configure-inertia-app.spec.ts
+++ b/tests/configure-inertia-app.spec.ts
@@ -71,4 +71,12 @@ test.describe('createInertiaApp', () => {
     await expect(page.locator('#strict-mode-status')).toContainText('Rendered')
     expect(await hasStrictMode(page)).toBe(false)
   })
+
+  test('it passes the page object to the withApp callback', async ({ page }) => {
+    await page.goto('/unified/with-app')
+
+    await expect(page.getByTestId('with-app-value')).toHaveText('Value: injected-via-withApp')
+    await expect(page.getByTestId('with-app-locale')).toHaveText('Locale: en-CA')
+    await expect(page.getByTestId('with-app-component')).toHaveText('Component: SSR/WithApp')
+  })
 })

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -252,5 +252,13 @@ test.describe('SSR Auto Transform', () => {
       expect(html).toContain('SSR WithApp')
       expect(html).toMatch(/Value:.*injected-via-withApp/)
     })
+
+    test('it passes page object to withApp callback during SSR rendering', async ({ page }) => {
+      const response = await page.request.get('/ssr-auto/with-app')
+      const html = await response.text()
+
+      expect(html).toMatch(/Locale:.*en-CA/)
+      expect(html).toMatch(/Component:.*SSR\/WithApp/)
+    })
   })
 })


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When the `withApp` callback was added, I felt like it was a regression to use it instead of setup because we couldn't access the props passed to the `initialPage` (which can be necessary in ssr mode to access user locale for example).

I make this PR to improve user experience when using the `withApp` callback to start inertia application