### PR TITLE
[3.x] Vue 3 Playground: Fixes scroll + code issues

### DIFF
--- a/playgrounds/react/resources/js/Components/Layout.tsx
+++ b/playgrounds/react/resources/js/Components/Layout.tsx
@@ -5,7 +5,7 @@ export default function Layout({ children, padding = true }: { children: React.R
 
   return (
     <>
-      <nav className="flex items-center space-x-6 bg-slate-800 px-10 py-6 text-white">
+      <nav className="flex items-center space-x-6 bg-slate-800 px-10 py-6 text-white overflow-scroll">
         <div className="rounded-lg bg-slate-700 px-4 py-1">{appName}</div>
         <Link href="/" className="hover:underline" prefetch>
           Home

--- a/playgrounds/svelte5/resources/js/Components/Layout.svelte
+++ b/playgrounds/svelte5/resources/js/Components/Layout.svelte
@@ -6,7 +6,7 @@
   const page = usePage()
 </script>
 
-<nav class="flex items-center space-x-6 bg-slate-800 px-10 py-6 text-white">
+<nav class="flex items-center space-x-6 bg-slate-800 px-10 py-6 text-white overflow-scroll">
   <div class="rounded-lg bg-slate-700 px-4 py-1">{page.props.appName}</div>
   <a href="/" use:inertia class="hover:underline">Home</a>
   <a href="/users" use:inertia class="hover:underline">Users</a>

--- a/playgrounds/vue3/resources/js/Components/Layout.vue
+++ b/playgrounds/vue3/resources/js/Components/Layout.vue
@@ -10,7 +10,7 @@ const appName = computed(() => page.props.appName)
 </script>
 
 <template>
-  <nav class="flex items-center space-x-6 bg-slate-800 px-10 py-6 text-white">
+  <nav class="flex items-center space-x-6 bg-slate-800 px-10 py-6 text-white overflow-scroll">
     <div class="rounded-lg bg-slate-700 px-4 py-1">{{ appName }}</div>
     <Link href="/" class="hover:underline" prefetch>Home</Link>
     <Link href="/users" class="hover:underline" prefetch :cache-for="['2s', '1m']">Users</Link>

--- a/playgrounds/vue3/resources/js/Pages/Poll.vue
+++ b/playgrounds/vue3/resources/js/Pages/Poll.vue
@@ -40,7 +40,6 @@ const { start: startHookPolling, stop } = usePoll(
     },
   },
   {
-    mode:
     keepAlive: true,
     autoStart: false,
   },

--- a/playgrounds/vue3/resources/js/Pages/Poll.vue
+++ b/playgrounds/vue3/resources/js/Pages/Poll.vue
@@ -25,8 +25,6 @@ const triggerAsyncRedirect = () => {
   )
 }
 
-import { router } from "@inertiajs/vue3";
-
 router.once("start", () => {
     console.log(`Starting a visit `)
 });


### PR DESCRIPTION
Found some issues in the Vue 3 playground.

### Poll.vue
- Double import for `router`
- Empty `usePoll` option

### Navigation bar
Not all items in the navigation bar were visible + it caused the page to be wider than the viewport.

https://github.com/user-attachments/assets/b3a9fcf5-5559-40de-83a6-18b5c7f1c9f2

https://github.com/user-attachments/assets/43d62a87-9bc0-4291-a672-bfab7b717647

**Update:** Also applied the navigation bar fix to the other playgrounds

