### PR TITLE
[2.x] Bump axios floor to ^1.16.0 to exclude vulnerable range

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@types/lodash-es": "^4.17.12",
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "laravel-precognition": "^1.0.2",
     "lodash-es": "^4.18.1",
     "qs": "^6.15.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "es-check": "^9.6.1",
     "esbuild": "^0.27.3",
     "esbuild-node-externals": "^1.20.1",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -49,7 +49,7 @@
     "@sveltejs/kit": "^2.60.1",
     "@sveltejs/package": "^2.5.7",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "es-check": "^9.6.1",
     "publint": "^0.3.17",
     "svelte": "^4.2.20",

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -52,7 +52,7 @@
     "es2020-check": "pnpm build:with-deps && es-check es2020 \"dist/index.esm.js\" --checkFeatures --module --noCache --verbose"
   },
   "devDependencies": {
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "es-check": "^9.6.1",
     "esbuild": "^0.27.3",
     "esbuild-node-externals": "^1.20.1",

--- a/playgrounds/react/package.json
+++ b/playgrounds/react/package.json
@@ -16,7 +16,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
     "autosize": "^6.0.1",
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "laravel-vite-plugin": "^2.1.0",
     "lodash": "^4.17.23",
     "marked": "^17.0.3",

--- a/playgrounds/svelte4/package.json
+++ b/playgrounds/svelte4/package.json
@@ -14,7 +14,7 @@
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
     "@tailwindcss/vite": "^4.2.1",
     "@tsconfig/svelte": "^5.0.8",
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "laravel-vite-plugin": "^1.3.0",
     "lodash": "^4.17.23",
     "svelte": "^4.2.20",

--- a/playgrounds/svelte5/package.json
+++ b/playgrounds/svelte5/package.json
@@ -14,7 +14,7 @@
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tailwindcss/vite": "^4.2.1",
     "@tsconfig/svelte": "^5.0.8",
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "laravel-vite-plugin": "^2.1.0",
     "lodash": "^4.17.23",
     "svelte": "^5.55.9",

--- a/playgrounds/vue3/package.json
+++ b/playgrounds/vue3/package.json
@@ -14,7 +14,7 @@
     "@vitejs/plugin-vue": "^6.0.4",
     "@vue/server-renderer": "^3.5.29",
     "autosize": "^6.0.1",
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "laravel-vite-plugin": "^2.1.0",
     "lodash": "^4.17.23",
     "marked": "^17.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       axios:
-        specifier: ^1.13.5
+        specifier: ^1.16.0
         version: 1.16.1
       laravel-precognition:
         specifier: ^1.0.2
@@ -85,7 +85,7 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       axios:
-        specifier: ^1.13.5
+        specifier: ^1.16.0
         version: 1.16.1
       es-check:
         specifier: ^9.6.1
@@ -171,7 +171,7 @@ importers:
         specifier: ^3.1.2
         version: 3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@24.12.4)(lightningcss@1.32.0))
       axios:
-        specifier: ^1.13.5
+        specifier: ^1.16.0
         version: 1.16.1
       es-check:
         specifier: ^9.6.1
@@ -245,7 +245,7 @@ importers:
         version: 4.18.1
     devDependencies:
       axios:
-        specifier: ^1.13.5
+        specifier: ^1.16.0
         version: 1.16.1
       es-check:
         specifier: ^9.6.1
@@ -321,7 +321,7 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       axios:
-        specifier: ^1.13.5
+        specifier: ^1.16.0
         version: 1.16.1
       laravel-vite-plugin:
         specifier: ^2.1.0
@@ -366,7 +366,7 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8
       axios:
-        specifier: ^1.13.5
+        specifier: ^1.16.0
         version: 1.16.1
       laravel-vite-plugin:
         specifier: ^1.3.0
@@ -408,7 +408,7 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8
       axios:
-        specifier: ^1.13.5
+        specifier: ^1.16.0
         version: 1.16.1
       laravel-vite-plugin:
         specifier: ^2.1.0
@@ -459,7 +459,7 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       axios:
-        specifier: ^1.13.5
+        specifier: ^1.16.0
         version: 1.16.1
       laravel-vite-plugin:
         specifier: ^2.1.0


### PR DESCRIPTION
### What & why

On the 2.x line, `axios` is a runtime dependency of `@inertiajs/core` (and a dev/playground dependency elsewhere), currently pinned to `^1.13.5`. That range still allows installs affected by two High-severity advisories:

- [GHSA-777c-7fjr-54vf](https://github.com/advisories/GHSA-777c-7fjr-54vf) - fetch adapter ignores request/response size limits, so it can be pushed into resource exhaustion (axios 1.7.0–1.15.x).
- [GHSA-hfxv-24rg-xrqf](https://github.com/advisories/GHSA-hfxv-24rg-xrqf) - ReDoS via the XSRF cookie name (axios ≤1.15.0).

Both were fixed in axios 1.16.0.

A fresh install today already resolves to a patched 1.16.x, but since `^1.13.5` overlaps the vulnerable range, `pnpm audit` (now running on push/releases via #3132) and downstream audits still flag it. Bumping the floor to `^1.16.0` keeps the affected versions out for good, and it's still the same major so nothing breaks.

### What changed

- `axios` `^1.13.5` → `^1.16.0` everywhere it's declared:
  - `packages/core` (the runtime `dependencies` one consumers actually get)
  - `packages/react`, `packages/svelte`, `packages/vue3` (`devDependencies`)
  - `playgrounds/{react,svelte4,svelte5,vue3}`
- Regenerated `pnpm-lock.yaml` (just the specifiers; the resolved version was already 1.16.1).

### Verification

- `pnpm audit --audit-level high` comes back clean — no axios advisories left. The few remaining entries are pre-existing moderate svelte/vite ones this PR doesn't touch.
- Lockfile diff is only the axios specifier bumps, nothing else drifts.