### PR TITLE
[3.x] Add `inertia:clientVisit` event and visit correlation id

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -31,8 +31,12 @@ export const fireBeforeUpdateEvent: GlobalEventTrigger<'beforeUpdate'> = (page) 
   return fireEvent('beforeUpdate', { detail: { page } })
 }
 
-export const fireNavigateEvent: GlobalEventTrigger<'navigate'> = (page, cached = false) => {
-  return fireEvent('navigate', { detail: { page, cached } })
+export const fireNavigateEvent: GlobalEventTrigger<'navigate'> = (page, { cached = false, visitId } = {}) => {
+  return fireEvent('navigate', { detail: { page, cached, visitId } })
+}
+
+export const fireClientVisitEvent: GlobalEventTrigger<'clientVisit'> = (page, { replace, visitId }) => {
+  return fireEvent('clientVisit', { detail: { page, replace, visitId } })
 }
 
 export const fireProgressEvent: GlobalEventTrigger<'progress'> = (progress) => {
@@ -43,8 +47,8 @@ export const fireStartEvent: GlobalEventTrigger<'start'> = (visit) => {
   return fireEvent('start', { detail: { visit } })
 }
 
-export const fireSuccessEvent: GlobalEventTrigger<'success'> = (page) => {
-  return fireEvent('success', { detail: { page } })
+export const fireSuccessEvent: GlobalEventTrigger<'success'> = (page, { visitId } = {}) => {
+  return fireEvent('success', { detail: { page, visitId } })
 }
 
 export const firePrefetchedEvent: GlobalEventTrigger<'prefetched'> = (response, visit) => {

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -52,12 +52,14 @@ class CurrentPage {
       preserveState = false,
       viewTransition = false,
       cached = false,
+      visitId,
     }: {
       replace?: boolean
       preserveScroll?: boolean
       preserveState?: boolean
       viewTransition?: Visit['viewTransition']
       cached?: boolean
+      visitId?: number
     } = {},
   ): Promise<void> {
     if (Object.keys(page.deferredProps || {}).length) {
@@ -157,7 +159,7 @@ class CurrentPage {
           this.pendingDeferredProps = null
 
           if (!replace) {
-            fireNavigateEvent(page, cached)
+            fireNavigateEvent(page, { cached, visitId })
           }
         })
       })

--- a/packages/core/src/prefetched.ts
+++ b/packages/core/src/prefetched.ts
@@ -254,6 +254,7 @@ class PrefetchedRequests {
       this.withoutPurposePrefetchHeader(params1),
       this.withoutPurposePrefetchHeader(params2),
       [
+        'id',
         'showProgress',
         'replace',
         'prefetch',

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -113,7 +113,7 @@ export class Response {
       router.flush(currentPage.get().url)
     }
 
-    fireSuccessEvent(currentPage.get())
+    fireSuccessEvent(currentPage.get(), { visitId: this.requestParams.all().id })
 
     await this.requestParams.all().onSuccess(currentPage.get())
 
@@ -246,6 +246,7 @@ export class Response {
       preserveState: this.requestParams.all().preserveState as boolean,
       viewTransition: this.requestParams.all().viewTransition,
       cached: this.requestParams.all().cached,
+      visitId: this.requestParams.all().id,
     })
   }
 

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -3,7 +3,7 @@ import { get, set } from 'es-toolkit/compat'
 import { progress } from '.'
 import { config } from './config'
 import { eventHandler } from './eventHandler'
-import { fireBeforeEvent, fireFlashEvent } from './events'
+import { fireBeforeEvent, fireClientVisitEvent, fireFlashEvent } from './events'
 import { history } from './history'
 import { InitialVisit } from './initialVisit'
 import { stripTopLevelUndefined } from './objectUtils'
@@ -581,14 +581,19 @@ export class Router {
     const preserveScroll = RequestParams.resolvePreserveOption(params.preserveScroll ?? false, page)
     const preserveState = RequestParams.resolvePreserveOption(params.preserveState ?? false, page)
 
+    const visitId = this.createVisitId()
+
     return currentPage
       .set(page, {
         replace,
         preserveScroll,
         preserveState,
         viewTransition,
+        visitId,
       })
       .then(() => {
+        fireClientVisitEvent(currentPage.get(), { replace, visitId })
+
         const currentFlash = currentPage.get().flash
 
         if (Object.keys(currentFlash).length > 0) {
@@ -645,6 +650,7 @@ export class Router {
       preserveScroll: RequestParams.resolvePreserveOption(visit.preserveScroll, intermediatePage),
       preserveState: false,
       viewTransition: visit.viewTransition,
+      visitId: visit.id,
     })
   }
 
@@ -659,6 +665,12 @@ export class Router {
       }),
       ...this.getVisitEvents(options),
     }
+  }
+
+  protected visitIdCounter = 0
+
+  protected createVisitId(): number {
+    return ++this.visitIdCounter
   }
 
   protected getPendingVisit(href: string | URL | UrlMethodPair, options: VisitOptions): PendingVisit {
@@ -710,6 +722,7 @@ export class Router {
     )
 
     const visit = {
+      id: this.createVisitId(),
       cancelled: false,
       completed: false,
       interrupted: false,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -527,6 +527,7 @@ export type RouterInitParams<ComponentType = Component> = {
 }
 
 export type PendingVisitOptions = {
+  /** @internal */
   id: number
   url: URL
   completed: boolean

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -382,17 +382,28 @@ export type GlobalEventsMap<T extends RequestPayload = RequestPayload> = {
     result: void
   }
   navigate: {
-    parameters: [Page<SharedPageProps>, boolean?]
+    parameters: [Page<SharedPageProps>, { cached?: boolean; visitId?: number }?]
     details: {
       page: Page<SharedPageProps>
       cached?: boolean
+      visitId?: number
+    }
+    result: void
+  }
+  clientVisit: {
+    parameters: [Page<SharedPageProps>, { replace: boolean; visitId: number }]
+    details: {
+      page: Page<SharedPageProps>
+      replace: boolean
+      visitId: number
     }
     result: void
   }
   success: {
-    parameters: [Page<SharedPageProps>]
+    parameters: [Page<SharedPageProps>, { visitId?: number }?]
     details: {
       page: Page<SharedPageProps>
+      visitId?: number
     }
     result: void
   }
@@ -516,6 +527,7 @@ export type RouterInitParams<ComponentType = Component> = {
 }
 
 export type PendingVisitOptions = {
+  id: number
   url: URL
   completed: boolean
   cancelled: boolean
@@ -944,6 +956,7 @@ declare global {
     'inertia:finish': GlobalEvent<'finish'>
     'inertia:beforeUpdate': GlobalEvent<'beforeUpdate'>
     'inertia:navigate': GlobalEvent<'navigate'>
+    'inertia:clientVisit': GlobalEvent<'clientVisit'>
     'inertia:flash': GlobalEvent<'flash'>
   }
 }

--- a/packages/react/test-app/Pages/ClientSideVisit/Page1.tsx
+++ b/packages/react/test-app/Pages/ClientSideVisit/Page1.tsx
@@ -62,6 +62,14 @@ export default ({ foo, bar }: PageProps) => {
     })
   }
 
+  const pushSameUrl = () => {
+    router.push({
+      url: '/client-side-visit',
+      component: 'ClientSideVisit/Page1',
+      props: (props: PageProps) => ({ ...props, foo: 'foo from client' }),
+    })
+  }
+
   return (
     <div>
       <div>{foo}</div>
@@ -72,6 +80,7 @@ export default ({ foo, bar }: PageProps) => {
       </button>
       <button onClick={() => replaceAndPreserveStateWithErrors()}>Replace without errors</button>
       <button onClick={push}>Push</button>
+      <button onClick={pushSameUrl}>Push same URL</button>
       <button onClick={defaultErrors}>Errors (default)</button>
       <button onClick={bagErrors}>Errors (bag)</button>
       <div>Errors: {errors}</div>

--- a/packages/svelte/test-app/Pages/ClientSideVisit/Page1.svelte
+++ b/packages/svelte/test-app/Pages/ClientSideVisit/Page1.svelte
@@ -67,6 +67,14 @@
       props: { baz: 'baz from client' },
     })
   }
+
+  const pushSameUrl = () => {
+    router.push({
+      url: '/client-side-visit',
+      component: 'ClientSideVisit/Page1',
+      props: (props: PageProps) => ({ ...props, foo: 'foo from client' }),
+    })
+  }
 </script>
 
 <div>
@@ -78,6 +86,7 @@
   </button>
   <button onclick={() => replaceAndPreserveStateWithErrors()}>Replace without errors</button>
   <button onclick={push}>Push</button>
+  <button onclick={pushSameUrl}>Push same URL</button>
   <button onclick={defaultErrors}>Errors (default)</button>
   <button onclick={bagErrors}>Errors (bag)</button>
   <div>Errors: {errors}</div>

--- a/packages/vue3/test-app/Pages/ClientSideVisit/Page1.vue
+++ b/packages/vue3/test-app/Pages/ClientSideVisit/Page1.vue
@@ -73,6 +73,14 @@ const push = () => {
     },
   })
 }
+
+const pushSameUrl = () => {
+  router.push({
+    url: '/client-side-visit',
+    component: 'ClientSideVisit/Page1',
+    props: (props: PageProps) => ({ ...props, foo: 'foo from client' }),
+  })
+}
 </script>
 
 <template>
@@ -82,6 +90,7 @@ const push = () => {
   <button @click="() => replaceAndPreserveStateWithErrors({ name: 'Field is required' })">Replace with errors</button>
   <button @click="() => replaceAndPreserveStateWithErrors()">Replace without errors</button>
   <button @click="push">Push</button>
+  <button @click="pushSameUrl">Push same URL</button>
   <button @click="defaultErrors">Errors (default)</button>
   <button @click="bagErrors">Errors (bag)</button>
   <div>Errors: {{ errors }}</div>

--- a/tests/client-side-visits.spec.ts
+++ b/tests/client-side-visits.spec.ts
@@ -1,5 +1,36 @@
-import test, { expect } from '@playwright/test'
+import test, { expect, Page } from '@playwright/test'
 import { pageLoads, requests } from './support'
+
+const listenForGlobalMessages = async (page: Page, event) => {
+  await page.evaluate((eventName) => {
+    // @ts-ignore
+    window.globalMessages = window.globalMessages || {}
+
+    // @ts-ignore
+    window.globalMessages[eventName] = []
+
+    document.addEventListener(eventName, (e) => {
+      // @ts-ignore
+      window.globalMessages[eventName].push({
+        isCustomEvent: e instanceof CustomEvent,
+        type: e.type,
+        cancelable: e.cancelable,
+        detail: e.detail,
+      })
+    })
+  }, event)
+}
+
+const waitForGlobalMessages = async (page: Page, event: string, count?: number): Promise<any[string]> => {
+  if (typeof count === 'number') {
+    await page.waitForFunction(({ count, event }) => (window as any).globalMessages[event].length === count, {
+      count,
+      event,
+    })
+  }
+
+  return await page.evaluate((event) => (window as any).globalMessages[event], event)
+}
 
 test('replaces the page client side', async ({ page, browserName }) => {
   pageLoads.watch(page)
@@ -93,7 +124,7 @@ test('pushes the page client side', async ({ page, browserName }) => {
   await expect(page.getByText('bar from server')).toBeVisible()
   await expect(page.getByText('baz from client')).not.toBeVisible()
 
-  await page.getByRole('button', { name: 'Push' }).click()
+  await page.getByRole('button', { name: 'Push', exact: true }).click()
 
   await expect(page).toHaveURL('/client-side-visit-2')
   await expect(page.getByText('foo from server')).not.toBeVisible()
@@ -105,4 +136,48 @@ test('pushes the page client side', async ({ page, browserName }) => {
   const historyLength = await page.evaluate(() => window.history.length)
   // Firefox doesn't count the initial about:blank page in history.length
   await expect(historyLength).toBe(browserName === 'firefox' ? 2 : 3)
+})
+
+test('it pairs client-side push visitId with navigate', async ({ page }) => {
+  pageLoads.watch(page)
+
+  await page.goto('/client-side-visit')
+  await listenForGlobalMessages(page, 'inertia:navigate')
+  await listenForGlobalMessages(page, 'inertia:clientVisit')
+
+  await page.getByRole('button', { name: 'Push', exact: true }).click()
+
+  const clientVisitMessages = await waitForGlobalMessages(page, 'inertia:clientVisit', 1)
+  const navigateMessages = await waitForGlobalMessages(page, 'inertia:navigate', 1)
+  const visitId = clientVisitMessages[0].detail.visitId
+
+  await expect(clientVisitMessages[0].detail.replace).toBe(false)
+  await expect(typeof visitId).toBe('number')
+  await expect(navigateMessages[0].detail.visitId).toBe(visitId)
+})
+
+test('it records client-side replace visitIds without navigate events', async ({ page }) => {
+  pageLoads.watch(page)
+
+  await page.goto('/client-side-visit')
+  await listenForGlobalMessages(page, 'inertia:navigate')
+  await listenForGlobalMessages(page, 'inertia:clientVisit')
+
+  await page.getByRole('button', { name: 'Replace', exact: true }).click()
+
+  const replaceClientVisitMessages = await waitForGlobalMessages(page, 'inertia:clientVisit', 1)
+  const replaceNavigateMessages = await waitForGlobalMessages(page, 'inertia:navigate')
+
+  await expect(replaceClientVisitMessages[0].detail.replace).toBe(true)
+  await expect(typeof replaceClientVisitMessages[0].detail.visitId).toBe('number')
+  await expect(replaceNavigateMessages).toHaveLength(0)
+
+  await page.getByRole('button', { name: 'Push same URL' }).click()
+
+  const clientVisitMessages = await waitForGlobalMessages(page, 'inertia:clientVisit', 2)
+  const navigateMessages = await waitForGlobalMessages(page, 'inertia:navigate')
+
+  await expect(clientVisitMessages[1].detail.replace).toBe(false)
+  await expect(typeof clientVisitMessages[1].detail.visitId).toBe('number')
+  await expect(navigateMessages).toHaveLength(0)
 })

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -30,6 +30,7 @@ const assertVisitObject = async (visit) => {
   await expect(visit.data).toBeDefined()
   await expect(visit.headers).toBeDefined()
   await expect(visit.preserveState).toBeDefined()
+  await expect(typeof visit.id).toBe('number')
 }
 
 const assertPageObject = async (page) => {
@@ -113,6 +114,56 @@ test.describe('Events', () => {
   test.beforeEach(async ({ page }) => {
     pageLoads.watch(page)
     await page.goto('/events')
+  })
+
+  test.describe('visitId', () => {
+    test('it uses one id across the server visit lifecycle', async ({ page }) => {
+      await listenForGlobalMessages(page, 'inertia:before')
+      await listenForGlobalMessages(page, 'inertia:start')
+      await listenForGlobalMessages(page, 'inertia:success')
+      await listenForGlobalMessages(page, 'inertia:navigate')
+      await listenForGlobalMessages(page, 'inertia:finish')
+
+      await page.getByRole('link', { exact: true, name: 'Navigate Event' }).click()
+
+      const beforeMessages = await waitForGlobalMessages(page, 'inertia:before', 1)
+      const startMessages = await waitForGlobalMessages(page, 'inertia:start', 1)
+      const successMessages = await waitForGlobalMessages(page, 'inertia:success', 1)
+      const navigateMessages = await waitForGlobalMessages(page, 'inertia:navigate', 1)
+      const finishMessages = await waitForGlobalMessages(page, 'inertia:finish', 1)
+      const visitId = beforeMessages[0].detail.visit.id
+
+      await expect(startMessages[0].detail.visit.id).toBe(visitId)
+      await expect(finishMessages[0].detail.visit.id).toBe(visitId)
+      await expect(successMessages[0].detail.visitId).toBe(visitId)
+      await expect(navigateMessages[0].detail.visitId).toBe(visitId)
+    })
+
+    test('it assigns distinct increasing ids to distinct server visits', async ({ page }) => {
+      await listenForGlobalMessages(page, 'inertia:before')
+
+      await page.locator('.navigate').dispatchEvent('click')
+      await waitForGlobalMessages(page, 'inertia:before', 1)
+      await page.goBack()
+      await page.locator('.navigate').dispatchEvent('click')
+
+      const beforeMessages = await waitForGlobalMessages(page, 'inertia:before', 2)
+
+      await expect(beforeMessages[1].detail.visit.id).toBeGreaterThan(beforeMessages[0].detail.visit.id)
+    })
+
+    test('it leaves navigate events without a visit id for popstate navigations', async ({ page }) => {
+      await listenForGlobalMessages(page, 'inertia:navigate')
+
+      await page.getByRole('link', { exact: true, name: 'Navigate Event' }).click()
+      await waitForGlobalMessages(page, 'inertia:navigate', 1)
+      await page.goBack()
+
+      const navigateMessages = await waitForGlobalMessages(page, 'inertia:navigate', 2)
+
+      await expect(typeof navigateMessages[0].detail.visitId).toBe('number')
+      await expect(navigateMessages[1].detail.visitId).toBeUndefined()
+    })
   })
 
   test.describe('Listeners', () => {


### PR DESCRIPTION
This PR adds an `inertia:clientVisit` event that fires for client-side visits made through `router.push()` and `router.replace()`. Previously there was no reliable way to detect these, since `inertia:navigate` only fires when a history entry is pushed, so `router.replace()` and pushes to the same URL went unnoticed. The event carries a `replace` flag reflecting which method was called.

It also introduces a visit id that ties together every event belonging to a single visit. Events that already carry the visit object (`before`, `start`, `progress`, `finish`, and so on) expose it as `visit.id`, while `success`, `navigate`, and `clientVisit` expose it as a top-level `visitId`. This makes it possible to correlate the multiple events fired during a single visit.