### PR TITLE
[3.x] Add page and visit id to error event detail

### DIFF
--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -6,6 +6,7 @@ import { router } from './index'
 import { page as currentPage } from './page'
 import { Scroll } from './scroll'
 import { GlobalEvent, GlobalEventNames, GlobalEventResult, InternalEvent } from './types'
+import { uid } from './uid'
 import { hrefToUrl } from './url'
 
 class EventHandler {
@@ -107,8 +108,10 @@ class EventHandler {
         router.cancelAll({ prefetch: false })
 
         currentPage.setQuietly(data, { preserveState: false }).then(() => {
+          const visitId = uid()
+
           Scroll.restore(history.getScrollRegions())
-          fireNavigateEvent(currentPage.get())
+          fireNavigateEvent(currentPage.get(), { visitId })
 
           const pendingDeferred: Record<string, string[]> = {}
           const pageProps = currentPage.get().props

--- a/packages/core/src/eventHandler.ts
+++ b/packages/core/src/eventHandler.ts
@@ -6,7 +6,6 @@ import { router } from './index'
 import { page as currentPage } from './page'
 import { Scroll } from './scroll'
 import { GlobalEvent, GlobalEventNames, GlobalEventResult, InternalEvent } from './types'
-import { uid } from './uid'
 import { hrefToUrl } from './url'
 
 class EventHandler {
@@ -108,10 +107,8 @@ class EventHandler {
         router.cancelAll({ prefetch: false })
 
         currentPage.setQuietly(data, { preserveState: false }).then(() => {
-          const visitId = uid()
-
           Scroll.restore(history.getScrollRegions())
-          fireNavigateEvent(currentPage.get(), { visitId })
+          fireNavigateEvent(currentPage.get())
 
           const pendingDeferred: Record<string, string[]> = {}
           const pageProps = currentPage.get().props

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -11,8 +11,8 @@ export const fireBeforeEvent: GlobalEventTrigger<'before'> = (visit) => {
   return fireEvent('before', { cancelable: true, detail: { visit } })
 }
 
-export const fireErrorEvent: GlobalEventTrigger<'error'> = (errors) => {
-  return fireEvent('error', { detail: { errors } })
+export const fireErrorEvent: GlobalEventTrigger<'error'> = (errors, { page, visitId } = {}) => {
+  return fireEvent('error', { detail: { errors, page, visitId } })
 }
 
 export const fireNetworkErrorEvent: GlobalEventTrigger<'networkError'> = (error) => {

--- a/packages/core/src/initialVisit.ts
+++ b/packages/core/src/initialVisit.ts
@@ -6,6 +6,7 @@ import { page as currentPage } from './page'
 import { Scroll } from './scroll'
 import { SessionStorage } from './sessionStorage'
 import { LocationVisit, Page } from './types'
+import { uid } from './uid'
 
 export class InitialVisit {
   public static handle(): void {
@@ -33,9 +34,11 @@ export class InitialVisit {
     history
       .decrypt()
       .then((data) => {
-        currentPage.set(data, { preserveScroll: true, preserveState: true }).then(() => {
+        const visitId = uid()
+
+        currentPage.set(data, { preserveScroll: true, preserveState: true, visitId }).then(() => {
           Scroll.restore(scrollRegions)
-          fireNavigateEvent(currentPage.get())
+          fireNavigateEvent(currentPage.get(), { visitId })
         })
       })
       .catch(() => {
@@ -64,6 +67,7 @@ export class InitialVisit {
     history
       .decrypt(currentPage.get())
       .then(() => {
+        const visitId = uid()
         const rememberedState = history.getState<Page['rememberedState']>(history.rememberedState, {})
         const scrollRegions = history.getScrollRegions()
         currentPage.remember(rememberedState)
@@ -72,13 +76,14 @@ export class InitialVisit {
           .set(currentPage.get(), {
             preserveScroll: locationVisit.preserveScroll,
             preserveState: true,
+            visitId,
           })
           .then(() => {
             if (locationVisit.preserveScroll) {
               Scroll.restore(scrollRegions)
             }
 
-            this.fireInitialEvents()
+            this.fireInitialEvents(visitId)
           })
       })
       .catch(() => {
@@ -93,21 +98,23 @@ export class InitialVisit {
       currentPage.setUrlHash(window.location.hash)
     }
 
-    currentPage.set(currentPage.get(), { preserveScroll: true, preserveState: true }).then(() => {
+    const visitId = uid()
+
+    currentPage.set(currentPage.get(), { preserveScroll: true, preserveState: true, visitId }).then(() => {
       if (navigationType.isReload()) {
         Scroll.restore(history.getScrollRegions())
       } else {
         Scroll.scrollToAnchor()
       }
 
-      this.fireInitialEvents()
+      this.fireInitialEvents(visitId)
     })
   }
 
-  protected static fireInitialEvents(): void {
+  protected static fireInitialEvents(visitId: string): void {
     const page = currentPage.get()
 
-    fireNavigateEvent(page)
+    fireNavigateEvent(page, { visitId })
 
     if (Object.keys(page.flash).length > 0) {
       queueMicrotask(() => fireFlashEvent(page.flash))

--- a/packages/core/src/prefetched.ts
+++ b/packages/core/src/prefetched.ts
@@ -277,6 +277,7 @@ class PrefetchedRequests {
         'optimistic',
         'component',
         'pageProps',
+        'cached',
       ],
     )
   }

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -100,7 +100,7 @@ export class Response {
     if (Object.keys(errors).length > 0) {
       const scopedErrors = this.getScopedErrors(errors)
 
-      fireErrorEvent(scopedErrors)
+      fireErrorEvent(scopedErrors, { page: currentPage.get(), visitId: this.requestParams.all().id })
 
       return this.requestParams.all().onError(scopedErrors)
     }

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -708,6 +708,7 @@ export class Router {
       viewTransition: false,
       component: null,
       pageProps: null,
+      cached: false,
       ...stripTopLevelUndefined(options),
       ...stripTopLevelUndefined(configuredOptions),
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -338,6 +338,7 @@ export type Visit<T extends RequestPayload = RequestPayload> = {
     | Record<string, unknown>
     | ((currentProps: PageProps, sharedProps: Partial<PageProps>) => Record<string, unknown>)
     | null
+  cached: boolean
 }
 
 export type GlobalEventsMap<T extends RequestPayload = RequestPayload> = {
@@ -408,9 +409,11 @@ export type GlobalEventsMap<T extends RequestPayload = RequestPayload> = {
     result: void
   }
   error: {
-    parameters: [Errors]
+    parameters: [Errors, { page?: Page<SharedPageProps>; visitId?: string }?]
     details: {
       errors: Errors
+      page?: Page<SharedPageProps>
+      visitId?: string
     }
     result: void
   }

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -435,6 +435,18 @@ test.describe('Events', () => {
         await expect(messages[1]).toEqual({ foo: 'bar' })
         await assertGlobalErrorEvent(globalMessages[0])
       })
+
+      test('includes the page and visit id in the event detail', async ({ page }) => {
+        await listenForGlobalMessages(page, 'inertia:before')
+        await listenForGlobalMessages(page, 'inertia:error')
+        await clickAndWaitForResponse(page, 'Error Event', 'events/errors')
+
+        const beforeMessages = await waitForGlobalMessages(page, 'inertia:before', 1)
+        const globalMessages = await waitForGlobalMessages(page, 'inertia:error', 1)
+
+        await assertPageObject(globalMessages[0].detail.page)
+        await expect(globalMessages[0].detail.visitId).toBe(beforeMessages[0].detail.visit.id)
+      })
     })
 
     test.describe('Local Event Callbacks', () => {


### PR DESCRIPTION
This PR adds the current page and the originating visit id to the error event detail, so error handlers can tie a validation failure back to the specific visit that triggered it. The initial visit now also threads its visit id through to the navigate event, keeping navigate consistent with the rest of the lifecycle.

Visits gain a cached boolean as well, set when a prefetched response is used and surfaced on the navigate event so you can tell a fresh server response apart from a cached one.