### PR TITLE
[3.x] Add internal request and response interceptors

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,7 @@ export { http } from './http'
 export { HttpCancelledError, HttpError, HttpNetworkError, HttpResponseError } from './httpErrors'
 export { default as useInfiniteScroll } from './infiniteScroll'
 /** @internal Not part of the public API. May change or be removed without notice. */
-export { interceptors } from './interceptors'
+export { exposeInterceptors, interceptors } from './interceptors'
 export {
   createLayoutPropsStore,
   isPropsObject,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,8 @@ export { default as createHeadManager } from './head'
 export { http } from './http'
 export { HttpCancelledError, HttpError, HttpNetworkError, HttpResponseError } from './httpErrors'
 export { default as useInfiniteScroll } from './infiniteScroll'
+/** @internal Not part of the public API. May change or be removed without notice. */
+export { interceptors } from './interceptors'
 export {
   createLayoutPropsStore,
   isPropsObject,

--- a/packages/core/src/interceptors.ts
+++ b/packages/core/src/interceptors.ts
@@ -10,10 +10,7 @@ type VisitRequestHandler = (
   config: HttpRequestConfig,
 ) => HttpRequestConfig | Promise<HttpRequestConfig>
 
-type VisitResponseHandler = (
-  visit: InternalActiveVisit,
-  response: HttpResponse,
-) => HttpResponse | Promise<HttpResponse>
+type VisitResponseHandler = (visit: InternalActiveVisit, response: HttpResponse) => HttpResponse | Promise<HttpResponse>
 
 class VisitInterceptors {
   protected requestHandlers: VisitRequestHandler[] = []

--- a/packages/core/src/interceptors.ts
+++ b/packages/core/src/interceptors.ts
@@ -1,0 +1,62 @@
+// Internal extension point for first-party tooling. This is intentionally not
+// part of the public API and is not documented. It lets internal packages observe
+// and transform a visit's outgoing request and incoming response without coupling
+// the framework-agnostic HTTP client (`http`) to Inertia visit internals. Mirrors
+// the mechanism of `httpHandlers`, with the originating visit added as context.
+import type { HttpRequestConfig, HttpResponse, InternalActiveVisit } from './types'
+
+type VisitRequestHandler = (
+  visit: InternalActiveVisit,
+  config: HttpRequestConfig,
+) => HttpRequestConfig | Promise<HttpRequestConfig>
+
+type VisitResponseHandler = (
+  visit: InternalActiveVisit,
+  response: HttpResponse,
+) => HttpResponse | Promise<HttpResponse>
+
+class VisitInterceptors {
+  protected requestHandlers: VisitRequestHandler[] = []
+  protected responseHandlers: VisitResponseHandler[] = []
+
+  public onVisitRequest(handler: VisitRequestHandler): () => void {
+    this.requestHandlers.push(handler)
+
+    return () => {
+      this.requestHandlers = this.requestHandlers.filter((h) => h !== handler)
+    }
+  }
+
+  public onVisitResponse(handler: VisitResponseHandler): () => void {
+    this.responseHandlers.push(handler)
+
+    return () => {
+      this.responseHandlers = this.responseHandlers.filter((h) => h !== handler)
+    }
+  }
+
+  public async processRequest(visit: InternalActiveVisit, config: HttpRequestConfig): Promise<HttpRequestConfig> {
+    let result = config
+
+    for (const handler of this.requestHandlers) {
+      result = await handler(visit, result)
+    }
+
+    return result
+  }
+
+  public async processResponse(visit: InternalActiveVisit, response: HttpResponse): Promise<HttpResponse> {
+    let result = response
+
+    for (const handler of this.responseHandlers) {
+      result = await handler(visit, result)
+    }
+
+    return result
+  }
+}
+
+/**
+ * @internal Not part of the public API. May change or be removed without notice.
+ */
+export const interceptors = new VisitInterceptors()

--- a/packages/core/src/interceptors.ts
+++ b/packages/core/src/interceptors.ts
@@ -57,3 +57,18 @@ class VisitInterceptors {
  * @internal Not part of the public API. May change or be removed without notice.
  */
 export const interceptors = new VisitInterceptors()
+
+/**
+ * Expose the interceptor registry on the window so development tooling can hook
+ * into visit requests and responses from outside the bundle. Gated behind the
+ * `dev` option of `createInertiaApp`, so it is inert in production builds.
+ *
+ * @internal Not part of the public API. May change or be removed without notice.
+ */
+export function exposeInterceptors(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  ;(window as Window & { __inertia_interceptors__?: VisitInterceptors }).__inertia_interceptors__ = interceptors
+}

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -8,11 +8,12 @@ import {
 } from './events'
 import { http } from './http'
 import { HttpCancelledError, HttpResponseError } from './httpErrors'
+import { interceptors } from './interceptors'
 import { page as currentPage } from './page'
 import { RequestParams } from './requestParams'
 import { Response } from './response'
 import type { ActiveVisit, Page } from './types'
-import { HttpProgressEvent, HttpRequestHeaders } from './types'
+import { HttpProgressEvent, HttpRequestConfig, HttpRequestHeaders } from './types'
 import { urlWithoutHash } from './url'
 
 export class Request {
@@ -64,16 +65,20 @@ export class Request {
     // as a regular response once the prefetch is done
     const originallyPrefetch = this.requestParams.all().prefetch
 
+    const config: HttpRequestConfig = {
+      method: this.requestParams.all().method,
+      url: urlWithoutHash(this.requestParams.all().url).href,
+      data: this.requestParams.data(),
+      signal: this.cancelToken.signal,
+      headers: this.getHeaders(),
+      onUploadProgress: this.onProgress.bind(this),
+    }
+
+    const processedConfig = await interceptors.processRequest(this.requestParams.all(), config)
+
     return http
       .getClient()
-      .request({
-        method: this.requestParams.all().method,
-        url: urlWithoutHash(this.requestParams.all().url).href,
-        data: this.requestParams.data(),
-        signal: this.cancelToken.signal,
-        headers: this.getHeaders(),
-        onUploadProgress: this.onProgress.bind(this),
-      })
+      .request(processedConfig)
       .then((response) => {
         this.response = Response.create(this.requestParams, response, this.page)
 

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -11,6 +11,7 @@ import {
   fireSuccessEvent,
 } from './events'
 import { history } from './history'
+import { interceptors } from './interceptors'
 import { page as currentPage } from './page'
 import { partialReloadRequestsProp } from './partialReload'
 import Queue from './queue'
@@ -225,6 +226,8 @@ export class Response {
     if (!this.shouldSetPage(pageResponse)) {
       return Promise.resolve()
     }
+
+    this.response = await interceptors.processResponse(this.requestParams.all(), this.response)
 
     this.mergeProps(pageResponse)
     currentPage.mergeOncePropsIntoResponse(pageResponse)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -584,6 +584,8 @@ interface BaseCreateInertiaAppOptions<TComponentResolver, TSetupOptions, TSetupR
   defaults?: FirstLevelOptional<InertiaAppConfig & TAdditionalInertiaAppConfig>
   /** HTTP client or options to use for requests. Defaults to XhrHttpClient. */
   http?: HttpClient | HttpClientOptions
+  /** Enable development-only integrations. Defaults to `import.meta.env.DEV`. */
+  dev?: boolean
 }
 
 export interface CreateInertiaAppOptionsForCSR<
@@ -629,6 +631,8 @@ export interface CreateInertiaAppOptions<TComponentResolver, TSetupOptions, TSet
   defaults?: FirstLevelOptional<InertiaAppConfig & TAdditionalInertiaAppConfig>
   /** HTTP client or options to use for requests. Defaults to XhrHttpClient. */
   http?: HttpClient | HttpClientOptions
+  /** Enable development-only integrations. Defaults to `import.meta.env.DEV`. */
+  dev?: boolean
 }
 export type HeadManagerOnUpdateCallback = (elements: string[]) => void
 export type HeadManager = {

--- a/packages/core/tests/interceptors.test.ts
+++ b/packages/core/tests/interceptors.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { interceptors } from '../src/interceptors'
+import type { HttpRequestConfig, HttpResponse, InternalActiveVisit } from '../src/types'
+
+const makeVisit = (overrides: Partial<InternalActiveVisit> = {}): InternalActiveVisit =>
+  ({ id: 'visit-1', ...overrides }) as InternalActiveVisit
+
+const makeRequest = (overrides: Partial<HttpRequestConfig> = {}): HttpRequestConfig =>
+  ({ method: 'get', url: '/users', headers: {}, ...overrides }) as HttpRequestConfig
+
+const makeResponse = (overrides: Partial<HttpResponse> = {}): HttpResponse =>
+  ({ status: 200, data: '', headers: {}, ...overrides }) as HttpResponse
+
+describe('interceptors', () => {
+  let unsubscribes: VoidFunction[] = []
+
+  beforeEach(() => {
+    unsubscribes.forEach((unsubscribe) => unsubscribe())
+    unsubscribes = []
+  })
+
+  function track(unsubscribe: VoidFunction): VoidFunction {
+    unsubscribes.push(unsubscribe)
+
+    return unsubscribe
+  }
+
+  describe('request interceptors', () => {
+    it('runs registered handlers with the visit and request config', async () => {
+      const handler = vi.fn((_visit, config) => config)
+      track(interceptors.onVisitRequest(handler))
+
+      const visit = makeVisit()
+      const config = makeRequest()
+      await interceptors.processRequest(visit, config)
+
+      expect(handler).toHaveBeenCalledWith(visit, config)
+    })
+
+    it('lets a handler transform the outgoing headers and data', async () => {
+      track(
+        interceptors.onVisitRequest((visit, config) => ({
+          ...config,
+          headers: { ...config.headers, 'X-Visit': visit.id },
+          data: { mutated: true },
+        })),
+      )
+
+      const result = await interceptors.processRequest(makeVisit({ id: 'abc' }), makeRequest())
+
+      expect(result.headers).toMatchObject({ 'X-Visit': 'abc' })
+      expect(result.data).toEqual({ mutated: true })
+    })
+
+    it('pipes the result of each handler into the next, in registration order', async () => {
+      track(interceptors.onVisitRequest((_visit, config) => ({ ...config, url: `${config.url}/a` })))
+      track(interceptors.onVisitRequest((_visit, config) => ({ ...config, url: `${config.url}/b` })))
+
+      const result = await interceptors.processRequest(makeVisit(), makeRequest({ url: '/users' }))
+
+      expect(result.url).toBe('/users/a/b')
+    })
+
+    it('awaits async handlers', async () => {
+      track(
+        interceptors.onVisitRequest(async (_visit, config) => ({
+          ...config,
+          headers: { ...config.headers, 'X-Async': 'yes' },
+        })),
+      )
+
+      const result = await interceptors.processRequest(makeVisit(), makeRequest())
+
+      expect(result.headers).toMatchObject({ 'X-Async': 'yes' })
+    })
+
+    it('stops calling a handler once it is unsubscribed', async () => {
+      const handler = vi.fn((_visit, config) => config)
+      const unsubscribe = interceptors.onVisitRequest(handler)
+
+      await interceptors.processRequest(makeVisit(), makeRequest())
+      unsubscribe()
+      await interceptors.processRequest(makeVisit(), makeRequest())
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('response interceptors', () => {
+    it('runs registered handlers with the visit and response', async () => {
+      const handler = vi.fn((_visit, response) => response)
+      track(interceptors.onVisitResponse(handler))
+
+      const visit = makeVisit()
+      const response = makeResponse({ headers: { 'x-foo': 'bar' } })
+      await interceptors.processResponse(visit, response)
+
+      expect(handler).toHaveBeenCalledWith(visit, response)
+    })
+
+    it('pipes the result of each handler into the next', async () => {
+      track(interceptors.onVisitResponse((_visit, response) => ({ ...response, status: response.status + 1 })))
+      track(interceptors.onVisitResponse((_visit, response) => ({ ...response, status: response.status + 1 })))
+
+      const result = await interceptors.processResponse(makeVisit(), makeResponse({ status: 200 }))
+
+      expect(result.status).toBe(202)
+    })
+
+    it('stops calling a handler once it is unsubscribed', async () => {
+      const handler = vi.fn((_visit, response) => response)
+      const unsubscribe = interceptors.onVisitResponse(handler)
+
+      await interceptors.processResponse(makeVisit(), makeResponse())
+      unsubscribe()
+      await interceptors.processResponse(makeVisit(), makeResponse())
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/react/src/createInertiaApp.ts
+++ b/packages/react/src/createInertiaApp.ts
@@ -1,8 +1,10 @@
+/// <reference path="./env.d.ts" />
 import {
   buildSSRBody,
   CreateInertiaAppOptions,
   CreateInertiaAppOptionsForCSR,
   CreateInertiaAppOptionsForSSR,
+  exposeInterceptors,
   getInitialPageFromDOM,
   http as httpModule,
   InertiaAppSSRResponse,
@@ -106,6 +108,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     layout,
     strictMode = false,
     withApp,
+    dev = !!import.meta.env?.DEV,
   }:
     | InertiaAppOptionsForCSR<SharedProps>
     | InertiaAppOptionsForSSR<SharedProps>
@@ -119,6 +122,10 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   if (http) {
     httpModule.setClient(http)
+  }
+
+  if (dev) {
+    exposeInterceptors()
   }
 
   const isServer = typeof window === 'undefined'

--- a/packages/react/src/env.d.ts
+++ b/packages/react/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly DEV: boolean
+}
+
+interface ImportMeta {
+  readonly env?: ImportMetaEnv
+}

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -1,5 +1,6 @@
 import {
   buildSSRBody,
+  exposeInterceptors,
   getInitialPageFromDOM,
   http as httpModule,
   router,
@@ -82,6 +83,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     http,
     layout,
     withApp,
+    dev = !!import.meta.env?.DEV,
   }:
     | InertiaAppOptionsForCSR<SharedProps>
     | InertiaAppOptionsAuto<SharedProps> = {} as InertiaAppOptionsAuto<SharedProps>,
@@ -94,6 +96,10 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   if (http) {
     httpModule.setClient(http)
+  }
+
+  if (dev) {
+    exposeInterceptors()
   }
 
   const isServer = typeof window === 'undefined'

--- a/packages/svelte/src/env.d.ts
+++ b/packages/svelte/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly DEV: boolean
+}
+
+interface ImportMeta {
+  readonly env?: ImportMetaEnv
+}

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -1,8 +1,10 @@
+/// <reference path="./env.d.ts" />
 import {
   buildSSRBody,
   CreateInertiaAppOptions,
   CreateInertiaAppOptionsForCSR,
   CreateInertiaAppOptionsForSSR,
+  exposeInterceptors,
   getInitialPageFromDOM,
   http as httpModule,
   InertiaAppSSRResponse,
@@ -101,6 +103,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     http,
     layout,
     withApp,
+    dev = !!import.meta.env?.DEV,
   }:
     | InertiaAppOptionsForCSR<SharedProps>
     | InertiaAppOptionsForSSR<SharedProps>
@@ -114,6 +117,10 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   if (http) {
     httpModule.setClient(http)
+  }
+
+  if (dev) {
+    exposeInterceptors()
   }
 
   const isServer = typeof window === 'undefined'

--- a/packages/vue3/src/env.d.ts
+++ b/packages/vue3/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly DEV: boolean
+}
+
+interface ImportMeta {
+  readonly env?: ImportMetaEnv
+}


### PR DESCRIPTION
This PR adds an internal interceptor registry to the core package, giving tooling a single place to observe and transform a visit's outgoing request and incoming response. A request interceptor receives the visit along with the full outgoing request config, so it may read or change the headers, body, url, or method before the request is sent, and a response interceptor receives the visit and the response.