### PR TITLE
fix(core): prevent error modal from flashing empty before content renders

### DIFF
--- a/packages/core/src/dialog.ts
+++ b/packages/core/src/dialog.ts
@@ -70,12 +70,12 @@ export default {
       dialog.remove()
     })
 
+    iframe.srcdoc = page.outerHTML
+
     dialog.appendChild(iframe)
     document.body.prepend(dialog)
     dialog.showModal()
 
     dialog.focus()
-
-    iframe.srcdoc = page.outerHTML
   },
 }


### PR DESCRIPTION
## Problem

Fixes #3130

The development error modal briefly shows as an empty dialog before the iframe error page content renders. This happens because `dialog.showModal()` is called before `iframe.srcdoc` is set.

## Current code (dialog.ts)

```ts
dialog.appendChild(iframe)
document.body.prepend(dialog)
dialog.showModal()          // ← dialog visible, but iframe is empty

dialog.focus()

iframe.srcdoc = page.outerHTML  // ← content set after dialog is already shown
```

## Fix

Move `srcdoc` assignment before `showModal()` so content is ready before the dialog becomes visible:

```ts
iframe.srcdoc = page.outerHTML   // ← content set first

dialog.appendChild(iframe)
document.body.prepend(dialog)
dialog.showModal()               // ← dialog shown with content ready
```

## Testing

Tested by triggering server errors in a Laravel + Inertia app with rich error pages (Ignition). The empty flash no longer occurs.