### PR TITLE
[3.x] fix(core): add async option to FormComponentOptions

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -772,7 +772,7 @@ export type UseHttpSubmitArguments<TResponse = unknown, TForm = unknown> =
 
 export type FormComponentOptions = Pick<
   VisitOptions,
-  'preserveScroll' | 'preserveState' | 'preserveUrl' | 'replace' | 'only' | 'except' | 'reset' | 'viewTransition'
+  'preserveScroll' | 'preserveState' | 'preserveUrl' | 'replace' | 'only' | 'except' | 'reset' | 'viewTransition' | 'async'
 >
 
 export type FormComponentOptimisticCallback<


### PR DESCRIPTION
## Problem

Related to #3143 (sub-issue 3)

The `async` visit option was missing from `FormComponentOptions`, causing `<Form options={{ async: true }}>` to be silently ignored. Form submissions were always synchronous regardless of the `async` prop.

## Fix

Add `"async"` to the `Pick<VisitOptions, ...>` in `FormComponentOptions`:

```ts
// Before
"preserveScroll" | "preserveState" | "preserveUrl" | "replace" | "only" | "except" | "reset" | "viewTransition"

// After  
"preserveScroll" | "preserveState" | "preserveUrl" | "replace" | "only" | "except" | "reset" | "viewTransition" | "async"
```

Both React (`...options` spread in `Form.ts:257`) and Vue3 (`...props.options` spread in `form.ts:304`) pass options directly to `router.visit()`, so no adapter changes needed — the type fix is sufficient.

## Usage after fix

```tsx
<Form action="/endpoint" method="post" options={{ async: true }}>
  <button type="submit">Submit asynchronously</button>
</Form>
```