### PR TITLE
fix(core): preserve async requests when navigating to a different page

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -45,6 +45,10 @@ export class Request {
     return this.optimistic
   }
 
+  public isAsync(): boolean {
+    return this.requestParams.isAsync()
+  }
+
   public isPendingOptimistic(): boolean {
     return this.isOptimistic() && (!this.response || !this.response.isProcessed())
   }

--- a/packages/core/src/requestParams.ts
+++ b/packages/core/src/requestParams.ts
@@ -71,6 +71,10 @@ export class RequestParams {
     return this.params.deferredProps === true
   }
 
+  public isAsync(): boolean {
+    return this.params.async === true
+  }
+
   public onCancelToken(cb: VoidFunction) {
     this.params.onCancelToken({
       cancel: cb,

--- a/packages/core/src/requestStream.ts
+++ b/packages/core/src/requestStream.ts
@@ -24,10 +24,11 @@ export class RequestStream {
     this.cancel({ interrupted: true }, false)
   }
 
-  public cancelInFlight({ prefetch = true, optimistic = true } = {}): void {
+  public cancelInFlight({ prefetch = true, optimistic = true, async = true } = {}): void {
     this.requests
       .filter((request) => prefetch || !request.isPrefetch())
       .filter((request) => optimistic || !request.isOptimistic())
+      .filter((request) => async || !request.isAsync())
       .forEach((request) => request.cancel({ cancelled: true }))
   }
 

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -282,8 +282,9 @@ export class Router {
       : isSameUrlWithoutHash(visit.url, currentPageUrl)
 
     if (!isSamePage) {
-      // Only cancel non-prefetch requests (deferred props + partial reloads)
-      this.asyncRequestStream.cancelInFlight({ prefetch: false, optimistic: false })
+      // Cancel non-prefetch, non-optimistic, non-async in-flight requests
+      // when navigating to a different page. Preserves explicitly async requests.
+      this.asyncRequestStream.cancelInFlight({ prefetch: false, optimistic: false, async: false })
     }
 
     // Interrupt in-flight requests before taking the optimistic snapshot


### PR DESCRIPTION
## Problem

Related to #3143 (sub-issues 1 and 2)

When navigating to a different page, the router unconditionally cancelled **all** in-flight async requests via `cancelInFlight()`, including explicitly user-initiated async visits. This caused two issues:

1. **Async `<Link>` to a different endpoint**: clicking multiple times cancelled previous async requests instead of allowing concurrent requests
2. **Navigating away while async in-flight**: navigating to any different page cancelled pending async requests

Same-endpoint async requests worked because the `isSamePage` check skipped the cancellation block entirely.

## Root Cause

`router.ts:284-287` — `cancelInFlight({ prefetch: false, optimistic: false })` had no filter for `async`, so all non-prefetch, non-optimistic requests were cancelled on page change, including user-initiated async visits.

## Fix

Add an `async` filter to `cancelInFlight()` and pass `async: false` when cancelling on page navigation:

**requestParams.ts** — add `isAsync()` method
**request.ts** — add `isAsync()` delegating to requestParams  
**requestStream.ts** — add `async` filter to `cancelInFlight()`
**router.ts** — pass `{ prefetch: false, optimistic: false, async: false }` to preserve explicitly async requests

### Before
```ts
this.asyncRequestStream.cancelInFlight({ prefetch: false, optimistic: false })
// ↑ cancels ALL async requests including user-initiated async visits
```

### After
```ts
this.asyncRequestStream.cancelInFlight({ prefetch: false, optimistic: false, async: false })
// ↑ only cancels internal async requests (deferred props, partial reloads)
//   preserves explicitly async visits
```

## Note

This does not address sub-issue 3 (`<Form>` ignoring `async` prop) — that is a separate type-only fix in #3157.

Also, `response.ts` `shouldSetPage()` still discards async responses when the user has navigated to a different component/pathname. This is an intentional staleness guard but may need revisiting as a design decision (should async responses still update props in the background after navigation?).