### PR TITLE
[3.x] Support anchor target attribute

### DIFF
--- a/packages/core/src/navigationEvents.ts
+++ b/packages/core/src/navigationEvents.ts
@@ -11,11 +11,12 @@ function isContentEditableOrPrevented(event: KeyboardNavigationEvent | MouseNavi
 
 /**
  * Determine if this mouse event should be intercepted for navigation purposes.
- * Links with modifier keys or non-left clicks should not be intercepted.
+ * Links with modifier keys or non-left clicks or same browsing context targets should not be intercepted.
  * Content editable elements and prevented events are ignored.
  */
 export function shouldIntercept(event: MouseNavigationEvent): boolean {
   const isLink = (event.currentTarget as HTMLElement).tagName.toLowerCase() === 'a'
+  const target = isLink ? (event.currentTarget as HTMLAnchorElement).target : ''
 
   return !(
     isContentEditableOrPrevented(event) ||
@@ -23,6 +24,7 @@ export function shouldIntercept(event: MouseNavigationEvent): boolean {
     (isLink && event.ctrlKey) ||
     (isLink && event.metaKey) ||
     (isLink && event.shiftKey) ||
+    (isLink && target !== '' && target !== '_self') ||
     (isLink && 'button' in event && event.button !== 0)
   )
 }

--- a/packages/core/src/navigationEvents.ts
+++ b/packages/core/src/navigationEvents.ts
@@ -11,7 +11,7 @@ function isContentEditableOrPrevented(event: KeyboardNavigationEvent | MouseNavi
 
 /**
  * Determine if this mouse event should be intercepted for navigation purposes.
- * Links with modifier keys or non-left clicks or same browsing context targets should not be intercepted.
+ * Links with modifier keys or non-left clicks or different browsing context targets should not be intercepted.
  * Content editable elements and prevented events are ignored.
  */
 export function shouldIntercept(event: MouseNavigationEvent): boolean {

--- a/packages/react/test-app/Pages/Home.tsx
+++ b/packages/react/test-app/Pages/Home.tsx
@@ -92,6 +92,13 @@ export default (props: { example: string }) => {
         <Link id="navigate-back" href="/head/mixed">
           Go to Mixed Head
         </Link>
+
+        <Link href="/links/as-element" className="link-targets-self" target="_self">
+          Target _self
+        </Link>
+        <Link href="/links/as-element" className="link-targets-blank" target="_blank">
+          Target _blank
+        </Link>
       </div>
     </>
   )

--- a/packages/svelte/test-app/Pages/Home.svelte
+++ b/packages/svelte/test-app/Pages/Home.svelte
@@ -52,4 +52,7 @@
 
   <a href={'#'} onclick={redirectHash} class="visits-redirect-hash">Manual Hash Redirect visit</a>
   <a href={'#'} onclick={redirectHashPost} class="visits-redirect-hash-post">Manual Hash Redirect POST visit</a>
+
+  <a href="/links/as-element" use:inertia class="link-targets-self" target="_self">Target _self</a>
+  <a href="/links/as-element" use:inertia class="link-targets-blank" target="_blank">Target _blank</a>
 </div>

--- a/packages/vue3/test-app/Pages/Home.vue
+++ b/packages/vue3/test-app/Pages/Home.vue
@@ -58,5 +58,12 @@ window._plugin_global_props = getCurrentInstance()?.appContext.config.globalProp
     <a href="#" @click.prevent="redirectHashPost" class="visits-redirect-hash-post">Manual Hash Redirect POST visit</a>
 
     <Link id="navigate-back" href="/head/mixed">Go to Mixed Head</Link>
+
+    <Link href="/links/as-element" className="link-targets-self" target="_self">
+      Target _self
+    </Link>
+    <Link href="/links/as-element" className="link-targets-blank" target="_blank">
+      Target _blank
+    </Link>
   </div>
 </template>

--- a/packages/vue3/test-app/Pages/Home.vue
+++ b/packages/vue3/test-app/Pages/Home.vue
@@ -59,11 +59,7 @@ window._plugin_global_props = getCurrentInstance()?.appContext.config.globalProp
 
     <Link id="navigate-back" href="/head/mixed">Go to Mixed Head</Link>
 
-    <Link href="/links/as-element" className="link-targets-self" target="_self">
-      Target _self
-    </Link>
-    <Link href="/links/as-element" className="link-targets-blank" target="_blank">
-      Target _blank
-    </Link>
+    <Link href="/links/as-element" className="link-targets-self" target="_self">Target _self</Link>
+    <Link href="/links/as-element" className="link-targets-blank" target="_blank">Target _blank</Link>
   </div>
 </template>

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -1334,3 +1334,29 @@ test.describe('path traversal', () => {
     await expect(page).toHaveURL('/')
   })
 })
+
+test.describe('link targets', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+  })
+
+  test('_self opens in same tab', async ({ page }) => {
+    await page.getByRole('link', { name: 'Target _self' }).click()
+
+    await expect(page).toHaveURL('/links/as-element')
+  })
+
+  test('_blank opens in new tab', async ({ page, context }) => {
+    const newTabPromise = context.waitForEvent('page');
+
+    await page.getByRole('link', { name: 'Target _blank' }).click()
+
+    const newTab = await newTabPromise;
+
+    await newTab.waitForLoadState();
+
+    await expect(page).toHaveURL('/');
+
+    await expect(newTab).toHaveURL('/links/as-element')
+  })
+})

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -1347,15 +1347,15 @@ test.describe('link targets', () => {
   })
 
   test('_blank opens in new tab', async ({ page, context }) => {
-    const newTabPromise = context.waitForEvent('page');
+    const newTabPromise = context.waitForEvent('page')
 
     await page.getByRole('link', { name: 'Target _blank' }).click()
 
-    const newTab = await newTabPromise;
+    const newTab = await newTabPromise
 
-    await newTab.waitForLoadState();
+    await newTab.waitForLoadState()
 
-    await expect(page).toHaveURL('/');
+    await expect(page).toHaveURL('/')
 
     await expect(newTab).toHaveURL('/links/as-element')
   })


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

First of all,  thanks for the work on Inertia!

The reason for this pull request is that I was working on a navigation link in my company's project, and some of the links require opening in a new tab. Of course, I added `target="_blank"` to the `Link` component as a concept I'm used to in libraries like React Router, Nuxt, and the like, but I was surprised that this isn't supported, judging from the comments in https://github.com/inertiajs/inertia/issues/1096 and after diving into the source code myself.

I will be open to backporting this to 2.x if it is merged.