### PR TITLE
[3.x] Prevent unhandled rejection when a view transition is superseded

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -251,6 +251,13 @@ class CurrentPage {
     return new Promise((resolve) => {
       const transitionResult = document.startViewTransition(() => doSwap().then(resolve))
 
+      // Starting a new view transition before this one finishes (e.g. rapid
+      // navigation or an interrupted visit) causes the browser to skip the active
+      // transition, rejecting its `ready` promise with an `AbortError`. That's
+      // expected, so swallow it to avoid an unhandled promise rejection.
+      // See https://www.w3.org/TR/css-view-transitions-1/#ViewTransition-prepare
+      transitionResult.ready.catch(() => {})
+
       viewTransitionCallback(transitionResult)
     })
   }

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -251,11 +251,8 @@ class CurrentPage {
     return new Promise((resolve) => {
       const transitionResult = document.startViewTransition(() => doSwap().then(resolve))
 
-      // Starting a new view transition before this one finishes (e.g. rapid
-      // navigation or an interrupted visit) causes the browser to skip the active
-      // transition, rejecting its `ready` promise with an `AbortError`. That's
-      // expected, so swallow it to avoid an unhandled promise rejection.
-      // See https://www.w3.org/TR/css-view-transitions-1/#ViewTransition-prepare
+      // A newer transition aborts this one, rejecting `ready` with an AbortError.
+      // That's expected, so swallow it to avoid an unhandled rejection.
       transitionResult.ready.catch(() => {})
 
       viewTransitionCallback(transitionResult)

--- a/packages/react/test-app/Pages/ViewTransition/PageA.tsx
+++ b/packages/react/test-app/Pages/ViewTransition/PageA.tsx
@@ -17,6 +17,16 @@ export default () => {
     })
   }
 
+  const supersedeTransition = () => {
+    router.visit('/view-transition/page-b', {
+      viewTransition: () => {
+        // While the transition is still in flight, start another one. The browser
+        // aborts the first, rejecting its `ready` promise with an AbortError.
+        document.startViewTransition(() => {})
+      },
+    })
+  }
+
   const clientSideReplace = () => {
     router.replace({
       url: '/view-transition/page-b',
@@ -37,6 +47,7 @@ export default () => {
       <button onClick={transitionWithBoolean}>Transition with boolean</button>
       <button onClick={transitionWithCallback}>Transition with callback</button>
       <button onClick={clientSideReplace}>Client-side replace</button>
+      <button onClick={supersedeTransition}>Supersede transition</button>
       <Link
         href="/view-transition/page-b"
         viewTransition={(viewTransition) => {

--- a/packages/react/test-app/Pages/ViewTransition/PageA.tsx
+++ b/packages/react/test-app/Pages/ViewTransition/PageA.tsx
@@ -20,8 +20,7 @@ export default () => {
   const supersedeTransition = () => {
     router.visit('/view-transition/page-b', {
       viewTransition: () => {
-        // While the transition is still in flight, start another one. The browser
-        // aborts the first, rejecting its `ready` promise with an AbortError.
+        // Simulate a rapid second navigation that aborts this in-flight transition.
         document.startViewTransition(() => {})
       },
     })

--- a/packages/react/test-app/Pages/ViewTransition/PageA.tsx
+++ b/packages/react/test-app/Pages/ViewTransition/PageA.tsx
@@ -17,12 +17,19 @@ export default () => {
     })
   }
 
-  const supersedeTransition = () => {
-    router.visit('/view-transition/page-b', {
-      viewTransition: () => {
-        // Simulate a rapid second navigation that aborts this in-flight transition.
-        document.startViewTransition(() => {})
-      },
+  const rapidNavigation = () => {
+    router.replace({
+      url: '/view-transition/page-b',
+      component: 'ViewTransition/PageB',
+      props: {},
+      viewTransition: true,
+    })
+
+    router.replace({
+      url: '/view-transition/page-a',
+      component: 'ViewTransition/PageA',
+      props: {},
+      viewTransition: true,
     })
   }
 
@@ -46,7 +53,7 @@ export default () => {
       <button onClick={transitionWithBoolean}>Transition with boolean</button>
       <button onClick={transitionWithCallback}>Transition with callback</button>
       <button onClick={clientSideReplace}>Client-side replace</button>
-      <button onClick={supersedeTransition}>Supersede transition</button>
+      <button onClick={rapidNavigation}>Rapid navigation</button>
       <Link
         href="/view-transition/page-b"
         viewTransition={(viewTransition) => {

--- a/packages/svelte/test-app/Pages/ViewTransition/PageA.svelte
+++ b/packages/svelte/test-app/Pages/ViewTransition/PageA.svelte
@@ -17,12 +17,19 @@
     })
   }
 
-  const supersedeTransition = () => {
-    router.visit('/view-transition/page-b', {
-      viewTransition: () => {
-        // Simulate a rapid second navigation that aborts this in-flight transition.
-        document.startViewTransition(() => {})
-      },
+  const rapidNavigation = () => {
+    router.replace({
+      url: '/view-transition/page-b',
+      component: 'ViewTransition/PageB',
+      props: {},
+      viewTransition: true,
+    })
+
+    router.replace({
+      url: '/view-transition/page-a',
+      component: 'ViewTransition/PageA',
+      props: {},
+      viewTransition: true,
     })
   }
 
@@ -45,7 +52,7 @@
 <button onclick={transitionWithBoolean}>Transition with boolean</button>
 <button onclick={transitionWithCallback}>Transition with callback</button>
 <button onclick={clientSideReplace}>Client-side replace</button>
-<button onclick={supersedeTransition}>Supersede transition</button>
+<button onclick={rapidNavigation}>Rapid navigation</button>
 <Link
   href="/view-transition/page-b"
   viewTransition={(viewTransition) => {

--- a/packages/svelte/test-app/Pages/ViewTransition/PageA.svelte
+++ b/packages/svelte/test-app/Pages/ViewTransition/PageA.svelte
@@ -20,8 +20,7 @@
   const supersedeTransition = () => {
     router.visit('/view-transition/page-b', {
       viewTransition: () => {
-        // While the transition is still in flight, start another one. The browser
-        // aborts the first, rejecting its `ready` promise with an AbortError.
+        // Simulate a rapid second navigation that aborts this in-flight transition.
         document.startViewTransition(() => {})
       },
     })

--- a/packages/svelte/test-app/Pages/ViewTransition/PageA.svelte
+++ b/packages/svelte/test-app/Pages/ViewTransition/PageA.svelte
@@ -17,6 +17,16 @@
     })
   }
 
+  const supersedeTransition = () => {
+    router.visit('/view-transition/page-b', {
+      viewTransition: () => {
+        // While the transition is still in flight, start another one. The browser
+        // aborts the first, rejecting its `ready` promise with an AbortError.
+        document.startViewTransition(() => {})
+      },
+    })
+  }
+
   const clientSideReplace = () => {
     router.replace({
       url: '/view-transition/page-b',
@@ -36,6 +46,7 @@
 <button onclick={transitionWithBoolean}>Transition with boolean</button>
 <button onclick={transitionWithCallback}>Transition with callback</button>
 <button onclick={clientSideReplace}>Client-side replace</button>
+<button onclick={supersedeTransition}>Supersede transition</button>
 <Link
   href="/view-transition/page-b"
   viewTransition={(viewTransition) => {

--- a/packages/vue3/test-app/Pages/ViewTransition/PageA.vue
+++ b/packages/vue3/test-app/Pages/ViewTransition/PageA.vue
@@ -17,6 +17,16 @@ const transitionWithCallback = () => {
   })
 }
 
+const supersedeTransition = () => {
+  router.visit('/view-transition/page-b', {
+    viewTransition: () => {
+      // While the transition is still in flight, start another one. The browser
+      // aborts the first, rejecting its `ready` promise with an AbortError.
+      document.startViewTransition(() => {})
+    },
+  })
+}
+
 const clientSideReplace = () => {
   router.replace({
     url: '/view-transition/page-b',
@@ -37,6 +47,7 @@ const clientSideReplace = () => {
   <button @click="transitionWithBoolean">Transition with boolean</button>
   <button @click="transitionWithCallback">Transition with callback</button>
   <button @click="clientSideReplace">Client-side replace</button>
+  <button @click="supersedeTransition">Supersede transition</button>
   <Link
     href="/view-transition/page-b"
     :view-transition="

--- a/packages/vue3/test-app/Pages/ViewTransition/PageA.vue
+++ b/packages/vue3/test-app/Pages/ViewTransition/PageA.vue
@@ -20,8 +20,7 @@ const transitionWithCallback = () => {
 const supersedeTransition = () => {
   router.visit('/view-transition/page-b', {
     viewTransition: () => {
-      // While the transition is still in flight, start another one. The browser
-      // aborts the first, rejecting its `ready` promise with an AbortError.
+      // Simulate a rapid second navigation that aborts this in-flight transition.
       document.startViewTransition(() => {})
     },
   })

--- a/packages/vue3/test-app/Pages/ViewTransition/PageA.vue
+++ b/packages/vue3/test-app/Pages/ViewTransition/PageA.vue
@@ -17,12 +17,19 @@ const transitionWithCallback = () => {
   })
 }
 
-const supersedeTransition = () => {
-  router.visit('/view-transition/page-b', {
-    viewTransition: () => {
-      // Simulate a rapid second navigation that aborts this in-flight transition.
-      document.startViewTransition(() => {})
-    },
+const rapidNavigation = () => {
+  router.replace({
+    url: '/view-transition/page-b',
+    component: 'ViewTransition/PageB',
+    props: {},
+    viewTransition: true,
+  })
+
+  router.replace({
+    url: '/view-transition/page-a',
+    component: 'ViewTransition/PageA',
+    props: {},
+    viewTransition: true,
   })
 }
 
@@ -46,7 +53,7 @@ const clientSideReplace = () => {
   <button @click="transitionWithBoolean">Transition with boolean</button>
   <button @click="transitionWithCallback">Transition with callback</button>
   <button @click="clientSideReplace">Client-side replace</button>
-  <button @click="supersedeTransition">Supersede transition</button>
+  <button @click="rapidNavigation">Rapid navigation</button>
   <Link
     href="/view-transition/page-b"
     :view-transition="

--- a/tests/view-transitions.spec.ts
+++ b/tests/view-transitions.spec.ts
@@ -90,4 +90,21 @@ test.describe('View Transitions', () => {
     await expect(page.getByText('Page B - View Transition Test')).toBeVisible()
     await expect(consoleMessages.errors).toEqual([])
   })
+
+  test('does not throw when a view transition is superseded by a new one', async ({ page }) => {
+    consoleMessages.listen(page)
+
+    await page.goto('/view-transition/page-a')
+    await expect(page.getByText('Page A - View Transition Test')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Supersede transition' }).click()
+
+    await expect(page).toHaveURL('/view-transition/page-b')
+    await expect(page.getByText('Page B - View Transition Test')).toBeVisible()
+
+    // Superseding a transition rejects the old transition's `ready` promise with an
+    // AbortError. It must be handled internally so it never surfaces as an unhandled rejection.
+    await page.waitForTimeout(500)
+    await expect(consoleMessages.errors).toEqual([])
+  })
 })

--- a/tests/view-transitions.spec.ts
+++ b/tests/view-transitions.spec.ts
@@ -97,13 +97,13 @@ test.describe('View Transitions', () => {
     await page.goto('/view-transition/page-a')
     await expect(page.getByText('Page A - View Transition Test')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Supersede transition' }).click()
+    await page.getByRole('button', { name: 'Rapid navigation' }).click()
 
-    await expect(page).toHaveURL('/view-transition/page-b')
-    await expect(page.getByText('Page B - View Transition Test')).toBeVisible()
+    await expect(page).toHaveURL('/view-transition/page-a')
+    await expect(page.getByText('Page A - View Transition Test')).toBeVisible()
 
-    // The aborted transition rejects its `ready` promise, handled internally so it
-    // never surfaces as an unhandled rejection.
+    // The second navigation aborts the first transition, rejecting its `ready` promise.
+    // It must be handled internally so it never surfaces as an unhandled rejection.
     await page.waitForTimeout(500)
     await expect(consoleMessages.errors).toEqual([])
   })

--- a/tests/view-transitions.spec.ts
+++ b/tests/view-transitions.spec.ts
@@ -91,7 +91,7 @@ test.describe('View Transitions', () => {
     await expect(consoleMessages.errors).toEqual([])
   })
 
-  test('does not throw when a view transition is superseded by a new one', async ({ page }) => {
+  test('does not throw when a rapid navigation aborts an in-flight view transition', async ({ page }) => {
     consoleMessages.listen(page)
 
     await page.goto('/view-transition/page-a')
@@ -102,8 +102,8 @@ test.describe('View Transitions', () => {
     await expect(page).toHaveURL('/view-transition/page-b')
     await expect(page.getByText('Page B - View Transition Test')).toBeVisible()
 
-    // Superseding a transition rejects the old transition's `ready` promise with an
-    // AbortError. It must be handled internally so it never surfaces as an unhandled rejection.
+    // The aborted transition rejects its `ready` promise, handled internally so it
+    // never surfaces as an unhandled rejection.
     await page.waitForTimeout(500)
     await expect(consoleMessages.errors).toEqual([])
   })


### PR DESCRIPTION
When a new view transition starts before an in-flight one finishes (rapid navigation or an interrupted visit), the browser skips the active transition and rejects its `ViewTransition.ready` promise with an `AbortError`. Inertia never attached a handler to that promise, so the rejection surfaced as an `unhandledrejection` event and was reported to error trackers (e.g. Sentry).

This is distinct from the visibility guard added in #2957: that only prevents starting a transition while the document is hidden, it cannot catch a running transition being aborted by a newer one. Attach a no-op `.catch()` to `ready`, since being superseded is expected behaviour, not an error.

Note the rejection only surfaces as an unhandled rejection in WebKit (Safari); Chromium does not emit the event for a bare `ready` rejection, which is why the regression test asserts under WebKit.

[Spec](https://www.w3.org/TR/css-view-transitions-1/#ViewTransition-prepare):
> If document's active view transition is not null, then skip that view transition with an 'AbortError' DOMException.

As in #2957, Claude helped me write this fix.