### PR TITLE
[3.x] Fix Svelte build failure from optional TypeScript parameters

### DIFF
--- a/packages/svelte/svelte.config.js
+++ b/packages/svelte/svelte.config.js
@@ -3,7 +3,7 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  preprocess: vitePreprocess(),
+  preprocess: vitePreprocess({ script: true }),
   kit: {
     adapter: adapter(),
   },


### PR DESCRIPTION
The Svelte adapter ships raw `.svelte` files with TypeScript still in their `<script>` blocks. This always used to work, but a recent change upstream (https://github.com/sveltejs/vite-plugin-svelte/issues/1360#issuecomment-4787364883) means Svelte's built-in type stripping now leaves a dangling `?` on optional parameters, producing invalid JavaScript that crashes Vite during dependency optimization.

Enabling `vitePreprocess({ script: true })` runs the script blocks through esbuild during packaging, so the published files ship plain JavaScript with types already stripped.

This is an alternative to #3171. Related to #3166.