### PR TITLE
[2.x] Prevent unhandled rejection when a view transition is superseded

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -234,6 +234,10 @@ class CurrentPage {
     return new Promise((resolve) => {
       const transitionResult = document.startViewTransition(() => doSwap().then(resolve))
 
+      // A newer transition aborts this one, rejecting `ready` with an AbortError.
+      // That's expected, so swallow it to avoid an unhandled rejection.
+      transitionResult.ready.catch(() => {})
+
       viewTransitionCallback(transitionResult)
     })
   }

--- a/packages/react/test-app/Pages/ViewTransition/PageA.tsx
+++ b/packages/react/test-app/Pages/ViewTransition/PageA.tsx
@@ -17,6 +17,22 @@ export default () => {
     })
   }
 
+  const rapidNavigation = () => {
+    router.replace({
+      url: '/view-transition/page-b',
+      component: 'ViewTransition/PageB',
+      props: {},
+      viewTransition: true,
+    })
+
+    router.replace({
+      url: '/view-transition/page-a',
+      component: 'ViewTransition/PageA',
+      props: {},
+      viewTransition: true,
+    })
+  }
+
   const clientSideReplace = () => {
     router.replace({
       url: '/view-transition/page-b',
@@ -37,6 +53,7 @@ export default () => {
       <button onClick={transitionWithBoolean}>Transition with boolean</button>
       <button onClick={transitionWithCallback}>Transition with callback</button>
       <button onClick={clientSideReplace}>Client-side replace</button>
+      <button onClick={rapidNavigation}>Rapid navigation</button>
       <Link
         href="/view-transition/page-b"
         viewTransition={(viewTransition) => {

--- a/packages/svelte/test-app/Pages/ViewTransition/PageA.svelte
+++ b/packages/svelte/test-app/Pages/ViewTransition/PageA.svelte
@@ -17,6 +17,22 @@
     })
   }
 
+  const rapidNavigation = () => {
+    router.replace({
+      url: '/view-transition/page-b',
+      component: 'ViewTransition/PageB',
+      props: {},
+      viewTransition: true,
+    })
+
+    router.replace({
+      url: '/view-transition/page-a',
+      component: 'ViewTransition/PageA',
+      props: {},
+      viewTransition: true,
+    })
+  }
+
   const clientSideReplace = () => {
     router.replace({
       url: '/view-transition/page-b',
@@ -36,6 +52,7 @@
 <button on:click={transitionWithBoolean}>Transition with boolean</button>
 <button on:click={transitionWithCallback}>Transition with callback</button>
 <button on:click={clientSideReplace}>Client-side replace</button>
+<button on:click={rapidNavigation}>Rapid navigation</button>
 <Link
   href="/view-transition/page-b"
   viewTransition={(viewTransition) => {

--- a/packages/vue3/test-app/Pages/ViewTransition/PageA.vue
+++ b/packages/vue3/test-app/Pages/ViewTransition/PageA.vue
@@ -17,6 +17,22 @@ const transitionWithCallback = () => {
   })
 }
 
+const rapidNavigation = () => {
+  router.replace({
+    url: '/view-transition/page-b',
+    component: 'ViewTransition/PageB',
+    props: {},
+    viewTransition: true,
+  })
+
+  router.replace({
+    url: '/view-transition/page-a',
+    component: 'ViewTransition/PageA',
+    props: {},
+    viewTransition: true,
+  })
+}
+
 const clientSideReplace = () => {
   router.replace({
     url: '/view-transition/page-b',
@@ -37,6 +53,7 @@ const clientSideReplace = () => {
   <button @click="transitionWithBoolean">Transition with boolean</button>
   <button @click="transitionWithCallback">Transition with callback</button>
   <button @click="clientSideReplace">Client-side replace</button>
+  <button @click="rapidNavigation">Rapid navigation</button>
   <Link
     href="/view-transition/page-b"
     :view-transition="

--- a/tests/view-transitions.spec.ts
+++ b/tests/view-transitions.spec.ts
@@ -90,4 +90,21 @@ test.describe('View Transitions', () => {
     await expect(page.getByText('Page B - View Transition Test')).toBeVisible()
     await expect(consoleMessages.errors).toEqual([])
   })
+
+  test('does not throw when a rapid navigation aborts an in-flight view transition', async ({ page }) => {
+    consoleMessages.listen(page)
+
+    await page.goto('/view-transition/page-a')
+    await expect(page.getByText('Page A - View Transition Test')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Rapid navigation' }).click()
+
+    await expect(page).toHaveURL('/view-transition/page-a')
+    await expect(page.getByText('Page A - View Transition Test')).toBeVisible()
+
+    // The second navigation aborts the first transition, rejecting its `ready` promise.
+    // It must be handled internally so it never surfaces as an unhandled rejection.
+    await page.waitForTimeout(500)
+    await expect(consoleMessages.errors).toEqual([])
+  })
 })


### PR DESCRIPTION
Backport #3165 