### PR TITLE
[3.x] Defer forced reloads to a cancelable `location` event

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -62,3 +62,7 @@ export const firePrefetchingEvent: GlobalEventTrigger<'prefetching'> = (visit) =
 export const fireFlashEvent: GlobalEventTrigger<'flash'> = (flash) => {
   return fireEvent('flash', { detail: { flash } })
 }
+
+export const fireLocationEvent: GlobalEventTrigger<'location'> = (url, versionChange) => {
+  return fireEvent('location', { cancelable: true, detail: { url, versionChange } })
+}

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -7,6 +7,7 @@ import {
   fireErrorEvent,
   fireFlashEvent,
   fireHttpExceptionEvent,
+  fireLocationEvent,
   firePrefetchedEvent,
   fireSuccessEvent,
 } from './events'
@@ -206,8 +207,17 @@ export class Response {
         return
       }
 
-      // Skip background (async) requests so we don't force a full-page navigation the user never initiated
-      if (this.requestParams.all().async) {
+      const responseVersion = this.getHeader('x-inertia-version')
+      const versionChange = !!responseVersion && responseVersion !== currentPage.get().version
+
+      if (!fireLocationEvent(url, versionChange)) {
+        return
+      }
+
+      // A version change on a background request only needs to pick up new assets, so we don't
+      // force a full-page navigation the user never initiated. The next user-initiated visit
+      // hits the same location response and reloads then.
+      if (versionChange && this.requestParams.all().async) {
         return
       }
 

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -202,13 +202,18 @@ export class Response {
    */
   protected locationVisit(url: URL): boolean | void {
     try {
-      SessionStorage.set(SessionStorage.locationVisitKey, {
-        preserveScroll: this.requestParams.all().preserveScroll === true,
-      })
-
       if (typeof window === 'undefined') {
         return
       }
+
+      // Skip background (async) requests so we don't force a full-page navigation the user never initiated
+      if (this.requestParams.all().async) {
+        return
+      }
+
+      SessionStorage.set(SessionStorage.locationVisitKey, {
+        preserveScroll: this.requestParams.all().preserveScroll === true,
+      })
 
       if (isSameUrlWithoutHash(window.location, url)) {
         window.location.reload()

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -454,6 +454,14 @@ export type GlobalEventsMap<T extends RequestPayload = RequestPayload> = {
     }
     result: void
   }
+  location: {
+    parameters: [URL, boolean]
+    details: {
+      url: URL
+      versionChange: boolean
+    }
+    result: boolean | void
+  }
 }
 
 export type PageEvent = 'newComponent' | 'firstLoad'
@@ -980,5 +988,6 @@ declare global {
     'inertia:navigate': GlobalEvent<'navigate'>
     'inertia:clientVisit': GlobalEvent<'clientVisit'>
     'inertia:flash': GlobalEvent<'flash'>
+    'inertia:location': GlobalEvent<'location'>
   }
 }

--- a/packages/react/test-app/Pages/Visits/AsyncLocationVisit.tsx
+++ b/packages/react/test-app/Pages/Visits/AsyncLocationVisit.tsx
@@ -1,14 +1,35 @@
 import { router } from '@inertiajs/react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export default () => {
   const [draft, setDraft] = useState('')
+  const [banner, setBanner] = useState('')
+  const [lastVersionChange, setLastVersionChange] = useState('')
+  const bannerMode = useRef(false)
+  const [bannerModeLabel, setBannerModeLabel] = useState(false)
+
+  useEffect(() => {
+    return router.on('location', (event) => {
+      setLastVersionChange(String(event.detail.versionChange))
+
+      if (bannerMode.current && event.detail.versionChange) {
+        event.preventDefault()
+        setBanner('A new version is available')
+      }
+    })
+  }, [])
 
   const backgroundReload = () => {
-    router.reload({
-      data: { foo: 'bar' },
-      headers: { 'X-Simulate-Version-Change': '1' },
-    })
+    router.reload({ headers: { 'X-Simulate-Version-Change': '1' } })
+  }
+
+  const backgroundManualLocation = () => {
+    router.reload({ headers: { 'X-Simulate-Manual-Location': '1' } })
+  }
+
+  const toggleBannerMode = () => {
+    bannerMode.current = !bannerMode.current
+    setBannerModeLabel(bannerMode.current)
   }
 
   return (
@@ -20,6 +41,15 @@ export default () => {
       <button onClick={backgroundReload} className="reload">
         Background reload
       </button>
+      <button onClick={backgroundManualLocation} className="manual-location">
+        Background manual location
+      </button>
+      <button onClick={toggleBannerMode} className="banner-mode">
+        Banner mode: {String(bannerModeLabel)}
+      </button>
+
+      <span id="version-change">{lastVersionChange}</span>
+      <span id="banner">{banner}</span>
     </div>
   )
 }

--- a/packages/react/test-app/Pages/Visits/AsyncLocationVisit.tsx
+++ b/packages/react/test-app/Pages/Visits/AsyncLocationVisit.tsx
@@ -1,0 +1,25 @@
+import { router } from '@inertiajs/react'
+import { useState } from 'react'
+
+export default () => {
+  const [draft, setDraft] = useState('')
+
+  const backgroundReload = () => {
+    router.reload({
+      data: { foo: 'bar' },
+      headers: { 'X-Simulate-Version-Change': '1' },
+    })
+  }
+
+  return (
+    <div>
+      <span className="text">This is the page that demonstrates async location visits</span>
+
+      <input id="draft" value={draft} onChange={(e) => setDraft(e.target.value)} />
+
+      <button onClick={backgroundReload} className="reload">
+        Background reload
+      </button>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/Visits/AsyncLocationVisit.svelte
+++ b/packages/svelte/test-app/Pages/Visits/AsyncLocationVisit.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { router } from '@inertiajs/svelte'
+
+  let draft = $state('')
+
+  const backgroundReload = () => {
+    router.reload({
+      data: { foo: 'bar' },
+      headers: { 'X-Simulate-Version-Change': '1' },
+    })
+  }
+</script>
+
+<div>
+  <span class="text">This is the page that demonstrates async location visits</span>
+
+  <input id="draft" bind:value={draft} />
+
+  <button onclick={backgroundReload} class="reload">Background reload</button>
+</div>

--- a/packages/svelte/test-app/Pages/Visits/AsyncLocationVisit.svelte
+++ b/packages/svelte/test-app/Pages/Visits/AsyncLocationVisit.svelte
@@ -1,13 +1,29 @@
 <script lang="ts">
   import { router } from '@inertiajs/svelte'
+  import { onMount } from 'svelte'
 
   let draft = $state('')
+  let banner = $state('')
+  let bannerMode = $state(false)
+  let lastVersionChange = $state('')
+
+  onMount(() => {
+    return router.on('location', (event) => {
+      lastVersionChange = String(event.detail.versionChange)
+
+      if (bannerMode && event.detail.versionChange) {
+        event.preventDefault()
+        banner = 'A new version is available'
+      }
+    })
+  })
 
   const backgroundReload = () => {
-    router.reload({
-      data: { foo: 'bar' },
-      headers: { 'X-Simulate-Version-Change': '1' },
-    })
+    router.reload({ headers: { 'X-Simulate-Version-Change': '1' } })
+  }
+
+  const backgroundManualLocation = () => {
+    router.reload({ headers: { 'X-Simulate-Manual-Location': '1' } })
   }
 </script>
 
@@ -17,4 +33,9 @@
   <input id="draft" bind:value={draft} />
 
   <button onclick={backgroundReload} class="reload">Background reload</button>
+  <button onclick={backgroundManualLocation} class="manual-location">Background manual location</button>
+  <button onclick={() => (bannerMode = !bannerMode)} class="banner-mode">Banner mode: {bannerMode}</button>
+
+  <span id="version-change">{lastVersionChange}</span>
+  <span id="banner">{banner}</span>
 </div>

--- a/packages/vue3/test-app/Pages/Visits/AsyncLocationVisit.vue
+++ b/packages/vue3/test-app/Pages/Visits/AsyncLocationVisit.vue
@@ -1,14 +1,33 @@
 <script setup lang="ts">
 import { router } from '@inertiajs/vue3'
-import { ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 
 const draft = ref('')
+const banner = ref('')
+const bannerMode = ref(false)
+const lastVersionChange = ref('')
+
+let stopListening: VoidFunction
+
+onMounted(() => {
+  stopListening = router.on('location', (event) => {
+    lastVersionChange.value = String(event.detail.versionChange)
+
+    if (bannerMode.value && event.detail.versionChange) {
+      event.preventDefault()
+      banner.value = 'A new version is available'
+    }
+  })
+})
+
+onUnmounted(() => stopListening?.())
 
 const backgroundReload = () => {
-  router.reload({
-    data: { foo: 'bar' },
-    headers: { 'X-Simulate-Version-Change': '1' },
-  })
+  router.reload({ headers: { 'X-Simulate-Version-Change': '1' } })
+}
+
+const backgroundManualLocation = () => {
+  router.reload({ headers: { 'X-Simulate-Manual-Location': '1' } })
 }
 </script>
 
@@ -19,5 +38,10 @@ const backgroundReload = () => {
     <input id="draft" v-model="draft" />
 
     <button @click="backgroundReload" class="reload">Background reload</button>
+    <button @click="backgroundManualLocation" class="manual-location">Background manual location</button>
+    <button @click="bannerMode = !bannerMode" class="banner-mode">Banner mode: {{ bannerMode }}</button>
+
+    <span id="version-change">{{ lastVersionChange }}</span>
+    <span id="banner">{{ banner }}</span>
   </div>
 </template>

--- a/packages/vue3/test-app/Pages/Visits/AsyncLocationVisit.vue
+++ b/packages/vue3/test-app/Pages/Visits/AsyncLocationVisit.vue
@@ -1,26 +1,22 @@
 <script setup lang="ts">
 import { router } from '@inertiajs/vue3'
-import { onMounted, onUnmounted, ref } from 'vue'
+import { onUnmounted, ref } from 'vue'
 
 const draft = ref('')
 const banner = ref('')
 const bannerMode = ref(false)
 const lastVersionChange = ref('')
 
-let stopListening: VoidFunction
-
-onMounted(() => {
-  stopListening = router.on('location', (event) => {
+onUnmounted(
+  router.on('location', (event) => {
     lastVersionChange.value = String(event.detail.versionChange)
 
     if (bannerMode.value && event.detail.versionChange) {
       event.preventDefault()
       banner.value = 'A new version is available'
     }
-  })
-})
-
-onUnmounted(() => stopListening?.())
+  }),
+)
 
 const backgroundReload = () => {
   router.reload({ headers: { 'X-Simulate-Version-Change': '1' } })

--- a/packages/vue3/test-app/Pages/Visits/AsyncLocationVisit.vue
+++ b/packages/vue3/test-app/Pages/Visits/AsyncLocationVisit.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3'
+import { ref } from 'vue'
+
+const draft = ref('')
+
+const backgroundReload = () => {
+  router.reload({
+    data: { foo: 'bar' },
+    headers: { 'X-Simulate-Version-Change': '1' },
+  })
+}
+</script>
+
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates async location visits</span>
+
+    <input id="draft" v-model="draft" />
+
+    <button @click="backgroundReload" class="reload">Background reload</button>
+  </div>
+</template>

--- a/tests/app/helpers.js
+++ b/tests/app/helpers.js
@@ -198,6 +198,14 @@ module.exports = {
 
     return res.status(200).send(applyDefaultNonce(req, html))
   },
-  location: (res, href) => res.status(409).header('X-Inertia-Location', href).send(''),
+  location: (res, href, version) => {
+    res.status(409).header('X-Inertia-Location', href)
+
+    if (version) {
+      res.header('X-Inertia-Version', version)
+    }
+
+    return res.send('')
+  },
   redirect: (res, href) => res.status(409).header('X-Inertia-Redirect', href).send(''),
 }

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -1925,7 +1925,11 @@ app.post('/redirect-hash', (req, res) => {
 app.get('/location', ({ res }) => inertia.location(res, '/dump/get'))
 app.get('/visits/async-location-visit', (req, res) => {
   if (req.headers['x-simulate-version-change']) {
-    return inertia.location(res, req.originalUrl)
+    return inertia.location(res, req.originalUrl, 'updated-version')
+  }
+
+  if (req.headers['x-simulate-manual-location']) {
+    return inertia.location(res, '/dump/get')
   }
 
   inertia.render(req, res, { component: 'Visits/AsyncLocationVisit' })

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -1923,6 +1923,13 @@ app.post('/redirect-hash', (req, res) => {
 })
 
 app.get('/location', ({ res }) => inertia.location(res, '/dump/get'))
+app.get('/visits/async-location-visit', (req, res) => {
+  if (req.headers['x-simulate-version-change']) {
+    return inertia.location(res, req.originalUrl)
+  }
+
+  inertia.render(req, res, { component: 'Visits/AsyncLocationVisit' })
+})
 app.post('/redirect-external', (req, res) => inertia.location(res, '/non-inertia'))
 app.post('/disconnect', (req, res) => res.socket.destroy())
 app.post('/json', (req, res) => res.status(200).json({ foo: 'bar' }))

--- a/tests/manual-visits.spec.ts
+++ b/tests/manual-visits.spec.ts
@@ -29,6 +29,19 @@ test('can make a location visit', async ({ page }) => {
   await expect(dump.headers).not.toHaveProperty('x-inertia')
 })
 
+test('does not force a hard refresh when a location visit is triggered by a background request', async ({ page }) => {
+  pageLoads.watch(page)
+  await page.goto('/visits/async-location-visit')
+
+  await page.fill('#draft', 'unsaved work')
+
+  const response = page.waitForResponse('**/visits/async-location-visit?**')
+  await page.getByRole('button', { name: 'Background reload' }).click()
+  await response
+
+  await expect(page.locator('#draft')).toHaveValue('unsaved work')
+})
+
 test.describe('Auto-cancellation', () => {
   test('will automatically cancel a pending visits when a new request is made', async ({ page }) => {
     pageLoads.watch(page)

--- a/tests/manual-visits.spec.ts
+++ b/tests/manual-visits.spec.ts
@@ -29,17 +29,43 @@ test('can make a location visit', async ({ page }) => {
   await expect(dump.headers).not.toHaveProperty('x-inertia')
 })
 
-test('does not force a hard refresh when a location visit is triggered by a background request', async ({ page }) => {
+test('does not force a hard refresh when an asset version change lands on a background request', async ({ page }) => {
   pageLoads.watch(page)
   await page.goto('/visits/async-location-visit')
 
   await page.fill('#draft', 'unsaved work')
 
-  const response = page.waitForResponse('**/visits/async-location-visit?**')
+  const response = page.waitForResponse('**/visits/async-location-visit**')
   await page.getByRole('button', { name: 'Background reload' }).click()
   await response
 
+  await expect(page.locator('#version-change')).toHaveText('true')
   await expect(page.locator('#draft')).toHaveValue('unsaved work')
+})
+
+test('lets you handle a background asset version change yourself', async ({ page }) => {
+  pageLoads.watch(page)
+  await page.goto('/visits/async-location-visit')
+
+  await page.fill('#draft', 'unsaved work')
+  await page.getByRole('button', { name: 'Banner mode' }).click()
+
+  const response = page.waitForResponse('**/visits/async-location-visit**')
+  await page.getByRole('button', { name: 'Background reload' }).click()
+  await response
+
+  await expect(page.locator('#banner')).toHaveText('A new version is available')
+  await expect(page.locator('#draft')).toHaveValue('unsaved work')
+})
+
+test('still honors a manual location visit made from a background request', async ({ page }) => {
+  await page.goto('/visits/async-location-visit')
+
+  await page.getByRole('button', { name: 'Background manual location' }).click()
+
+  const dump = await shouldBeDumpPage(page, 'get')
+
+  await expect(dump.headers).not.toHaveProperty('x-inertia')
 })
 
 test.describe('Auto-cancellation', () => {


### PR DESCRIPTION
When the asset version changes, the server responds with a location visit so the client performs a full-page reload and picks up the new assets. This also happened on background requests such as polling or a websocket-driven `router.reload()`, which meant a deploy could wipe out unsaved state, like a form being edited, on a request the user never initiated.

This PR introduces a cancelable `location` global event that fires whenever a location visit is about to force a full-page navigation. The event detail includes a `versionChange` boolean so you know whether the navigation was triggered by an asset version change or an explicit `Inertia::location()` redirect. 

By default a version change on a background request no longer forces a reload. The current page stays untouched and the next user-initiated visit picks up the new assets at a safe moment. Explicit `Inertia::location()` redirects are still honored, even on background requests. You may listen for the event and call `preventDefault()` to take over, for example to show a "new version available" banner instead of reloading.

To tell an automatic version change apart from a manual redirect, the Laravel adapter now echoes the new asset version in the `X-Inertia-Version` header on the 409 location response. The client compares it against the current page version to set `versionChange`, so a genuine version bump defers while a manual `Inertia::location()` (which carries no version header) always navigates.

```js
router.on('location', (event) => {
    if (event.detail.versionChange) {
        event.preventDefault()
        showBanner('A new version is available.')
    }
})
```

See also inertiajs/inertia-laravel#884.