### PR TITLE
[3.x]  Improve HTTPS Vite SSR performance on Linux with small response sizes

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -164,6 +164,7 @@ export default function inertia(options: InertiaPluginOptions = {}): Plugin {
 
     configureServer(server) {
       devServer = server
+      server.httpServer?.on('connection', (socket) => socket.setNoDelay(true))
 
       if (!entry) {
         return

--- a/packages/vite/tests/ssr.test.ts
+++ b/packages/vite/tests/ssr.test.ts
@@ -118,6 +118,29 @@ describe('SSR', () => {
       expect(logger.info).toHaveBeenCalledWith('Inertia SSR dev endpoint: /__inertia_ssr')
     })
 
+    it('disables Nagle on accepted HTTP server sockets', () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('resources/js/ssr.ts'))
+
+      const plugin = inertia()
+      const logger = createMockLogger()
+      const server = createMockServer(logger)
+      const httpServer = { on: vi.fn(), once: vi.fn() }
+
+      ;(server as any).httpServer = httpServer
+
+      plugin.configResolved!(createMockConfig(logger, false))
+      plugin.configureServer!(server)
+
+      expect(httpServer.on).toHaveBeenCalledWith('connection', expect.any(Function))
+
+      const connectionHandler = httpServer.on.mock.calls[0][1]
+      const socket = { setNoDelay: vi.fn() }
+
+      connectionHandler(socket)
+
+      expect(socket.setNoDelay).toHaveBeenCalledWith(true)
+    })
+
     it('does not add middleware when no entry exists', () => {
       mockExistsSync.mockReturnValue(false)
 


### PR DESCRIPTION
On Linux, I noticed Inertia SSR through Vite's dev server can be much slower than expected when Vite runs over HTTPS. In my tests, a small SSR response (~1.8KB) took a median of 43ms.

After some digging it seems that the cause is [Nagle's algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm), a TCP optimization that batches small writes before sending them. Disabling it on Vite's dev-server sockets with Node's [`socket.setNoDelay()`](https://nodejs.org/api/net.html#socketsetnodelaynodelay) drops the same request to 3-4ms.

The delay is easiest to see with small responses, because of the well-known interaction between [Nagle's algorithm](https://www.rfc-editor.org/rfc/rfc896.html) and TCP's [delayed ACK](https://brooker.co.za/blog/2024/05/09/nagle.html) behavior. In my tests 1.8KB and a 34KB response both measured around 43ms, while a 132KB response measured around 3.7ms. It seems to be an issue on Linux specifically, as I couldn't reproduce it on macOS. On macOS it seems to be handled through `net.inet.tcp.delayed_ack: 3` [link](https://rolande.wordpress.com/2020/04/16/performance-tuning-the-network-stack-on-macos-high-sierra-10-13-and-mojave-10-14/)

> Apple is now defaulting the setting for Delayed ACK (net.inet.tcp.delayed_ack) to 3 which is for Auto-Detect. This effectively enables the Nagle algorithm but prevents the unacknowledged runt packet problem causing an ACK deadlock which can unnecessarily pause transfers and cause significant delays. Apple used to have an issue on higher speed interfaces but they may have overcome this problem.

## Potential fixes

By default, normal Node [HTTP/1.1](https://github.com/nodejs/node/blob/v24.13.0/lib/_http_server.js#L583-L586) servers turn off Nagle, and Node also turns it off for [HTTP/2](https://github.com/nodejs/node/blob/v24.13.0/lib/internal/http2/core.js#L1317-L1319) sessions. Vite's HTTPS dev server uses Node's HTTP/2 server with [HTTP/1.1 fallback](https://github.com/nodejs/node/blob/v24.13.0/lib/internal/http2/core.js#L3253-L3259) enabled. On that fallback path, Nagle doesn't seem to get turned off.

The evidence for this becomes stronger when you look at how inertia-laravel sends the SSR content to Vite. When Laravel renders SSR, it posts the page payload to Vite's dev SSR endpoint ([Laravel `HttpGateway.php`](https://github.com/nckrtl/inertia-laravel/blob/6b5346782458421d330d5e842b253c6382b7ed0d/src/Ssr/HttpGateway.php#L55)):

```php
$response = Http::post($url, $page);
```

The post happens via HTTP/1.1 by default ([Guzzle `version`](https://docs.guzzlephp.org/en/stable/request-options.html#version)), while Vite serves HTTP/2 over HTTPS ([Vite `server.https`](https://vite.dev/config/server-options#server-https)). This leads to the fallback mentioned earlier to be used, where Nagle likely doesn't get disabled. When I force the HTTP version to 2, the delay disappears.

```php
$options = str_starts_with($url, 'https://')
    ? ['version' => '2.0']
    : [];

$response = Http::withOptions($options)->post($url, $page);
```

Another option, I think that is better, is to explicitly disable Nagle in the Inertia Vite SSR dev server (this PR).

## Proposed change

Disable Nagle on every socket Vite's dev server accepts:

```js
configureServer(server) {
  devServer = server
  server.httpServer?.on('connection', (socket) => socket.setNoDelay(true))

  ...
}
```

This change aligns with what node already does explicitly for HTTP/1.1 and HTTP/2 sessions.

## Results

On Linux, without the fix and small SSR response sizes:

```json
{
  "vite_set_no_delay_detected": false,
  "summary": {
    "median_wall_ms": 43.07,
    "guzzle_http_protocol": "HTTP/1.1"
  }
}
```

With the fix:

```json
{
  "vite_set_no_delay_detected": true,
  "summary": {
    "median_wall_ms": 3.38,
    "guzzle_http_protocol": "HTTP/1.1"
  }
}
```

I made a repo where you could test this yourself on Linux: [nckrtl/inertia-ssr-performance](https://github.com/nckrtl/inertia-ssr-performance). The repro README and AGENTS.md cover setup, running the benchmark, and applying the package patch locally.