### PR TITLE
[3.x] Add poll marker to visit for polling requests

### DIFF
--- a/packages/core/src/requestParams.ts
+++ b/packages/core/src/requestParams.ts
@@ -71,6 +71,10 @@ export class RequestParams {
     return this.params.deferredProps === true
   }
 
+  public isPollRequest() {
+    return this.params.poll === true
+  }
+
   public onCancelToken(cb: VoidFunction) {
     this.params.onCancelToken({
       cancel: cb,

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -151,6 +151,7 @@ export class Router {
   protected doReload<T extends RequestPayload = RequestPayload>(
     options: ReloadOptions<T> & {
       deferredProps?: boolean
+      poll?: boolean
     } = {},
   ): void {
     if (typeof window === 'undefined') {
@@ -228,7 +229,8 @@ export class Router {
       ({ onStart, onFinish }) => {
         const resolved = typeof requestOptions === 'function' ? requestOptions() : requestOptions
 
-        this.reload({
+        this.doReload({
+          poll: true,
           preserveErrors: true,
           ...resolved,
           onCancelToken: (token) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -547,6 +547,7 @@ export type InternalActiveVisit = ActiveVisit & {
   onPrefetchResponse?: (response: Response) => void
   onPrefetchError?: (error: Error) => void
   deferredProps?: boolean
+  poll?: boolean
   cached?: boolean
 }
 

--- a/packages/react/test-app/Pages/Poll/Flag.tsx
+++ b/packages/react/test-app/Pages/Poll/Flag.tsx
@@ -1,0 +1,29 @@
+import { router, usePoll } from '@inertiajs/react'
+import { useState } from 'react'
+
+export default () => {
+  const [pollFlag, setPollFlag] = useState('pending')
+  const [reloadFlag, setReloadFlag] = useState('pending')
+
+  usePoll(500, {
+    onFinish(visit) {
+      setPollFlag(String((visit as any).poll === true))
+    },
+  })
+
+  const reload = () => {
+    router.reload({
+      onFinish(visit) {
+        setReloadFlag(String((visit as any).poll === true))
+      },
+    })
+  }
+
+  return (
+    <div>
+      <div id="poll-flag">poll: {pollFlag}</div>
+      <div id="reload-flag">reload: {reloadFlag}</div>
+      <button onClick={reload}>Reload</button>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/Poll/Flag.svelte
+++ b/packages/svelte/test-app/Pages/Poll/Flag.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { router, usePoll } from '@inertiajs/svelte'
+
+  let pollFlag = $state('pending')
+  let reloadFlag = $state('pending')
+
+  usePoll(500, {
+    onFinish(visit) {
+      pollFlag = String((visit as any).poll === true)
+    },
+  })
+
+  const reload = () => {
+    router.reload({
+      onFinish(visit) {
+        reloadFlag = String((visit as any).poll === true)
+      },
+    })
+  }
+</script>
+
+<div id="poll-flag">poll: {pollFlag}</div>
+<div id="reload-flag">reload: {reloadFlag}</div>
+<button onclick={reload}>Reload</button>

--- a/packages/vue3/test-app/Pages/Poll/Flag.vue
+++ b/packages/vue3/test-app/Pages/Poll/Flag.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { router, usePoll } from '@inertiajs/vue3'
+import { ref } from 'vue'
+
+const pollFlag = ref('pending')
+const reloadFlag = ref('pending')
+
+usePoll(500, {
+  onFinish(visit) {
+    pollFlag.value = String((visit as any).poll === true)
+  },
+})
+
+const reload = () => {
+  router.reload({
+    onFinish(visit) {
+      reloadFlag.value = String((visit as any).poll === true)
+    },
+  })
+}
+</script>
+
+<template>
+  <div id="poll-flag">poll: {{ pollFlag }}</div>
+  <div id="reload-flag">reload: {{ reloadFlag }}</div>
+  <button @click="reload">Reload</button>
+</template>

--- a/tests/poll.spec.ts
+++ b/tests/poll.spec.ts
@@ -344,3 +344,12 @@ test('it preserves validation errors when poll reloads data', async ({ page }) =
   await expect(page.locator('#form-error')).toBeVisible()
   await expect(page.locator('#form-error')).toHaveText('The name field is required.')
 })
+
+test('poll requests carry the poll marker while regular reloads do not', async ({ page }) => {
+  await page.goto('/poll/flag')
+
+  await expect(page.locator('#poll-flag')).toHaveText('poll: true')
+
+  await page.getByRole('button', { name: 'Reload' }).click()
+  await expect(page.locator('#reload-flag')).toHaveText('reload: false')
+})


### PR DESCRIPTION
This PR adds a `poll` flag to the visit object for requests triggered by `router.poll()` and `usePoll()`, exposed through `isPollRequest()` on the request params. This mirrors the existing `deferredProps` marker and its `isDeferredPropsRequest()` accessor, giving tooling a reliable way to distinguish polling requests from regular reloads.