### PR TITLE
[3.x] Send `X-Requested-With` header from the built-in HTTP client

### DIFF
--- a/packages/core/src/xhrHttpClient.ts
+++ b/packages/core/src/xhrHttpClient.ts
@@ -103,6 +103,14 @@ export class XhrHttpClient implements HttpClient {
         xhr.setRequestHeader(this.xsrfHeaderName, xsrfToken)
       }
 
+      const hasRequestedWithHeader = Object.keys(config.headers ?? {}).some(
+        (key) => key.toLowerCase() === 'x-requested-with',
+      )
+
+      if (!hasRequestedWithHeader) {
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
+      }
+
       let body: Document | XMLHttpRequestBodyInit | null = null
 
       if (config.data !== null && config.data !== undefined) {


### PR DESCRIPTION
The built-in XHR HTTP client did not send the `X-Requested-With: XMLHttpRequest` header, so requests made through `useHttp` were not recognized as AJAX calls by Laravel. The client now sends `X-Requested-With: XMLHttpRequest` by default, unless a caller already provides the header. This matches the behavior of regular Inertia visits, which have always sent it.

Fixes #3185.