### PR TITLE
[3.x] Change Svelte render call to be asynchronous

### DIFF
--- a/.github/workflows/playwright-chromium.yml
+++ b/.github/workflows/playwright-chromium.yml
@@ -7,13 +7,22 @@ permissions:
 jobs:
   test-chromium:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    name: Chromium (${{ matrix.adapter }}${{ matrix.http == 'axios' && ', axios' || '' }})
+    name: Chromium (${{ matrix.adapter }}${{ matrix.http == 'axios' && ', axios' || '' }}${{ matrix.svelte-async == 'true' && ', async' || '' }})
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     strategy:
       matrix:
         adapter: ['vue', 'react', 'svelte']
         http: ['default', 'axios']
+        svelte-async: ['false', 'true']
+        exclude:
+          - adapter: 'vue'
+            svelte-async: 'true'
+          - adapter: 'react'
+            svelte-async: 'true'
+          - adapter: 'svelte'
+            http: 'axios'
+            svelte-async: 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -60,23 +69,36 @@ jobs:
         run: pnpm test:${{ matrix.adapter }}
         env:
           VITE_HTTP_CLIENT: ${{ matrix.http }}
+          SVELTE_ASYNC: ${{ matrix.svelte-async }}
 
       - name: Upload failure screenshots
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-failure-screenshots-${{ matrix.adapter }}-chromium-${{ matrix.http }}
+          name: playwright-failure-screenshots-${{ matrix.adapter }}-chromium-${{ matrix.http }}${{ matrix.svelte-async == 'true' && '-async' || '' }}
           path: test-results
 
   test-chromium-ssr:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    name: Chromium SSR (${{ matrix.adapter }}, Node ${{ matrix.node-version }})
+    name: Chromium SSR (${{ matrix.adapter }}, Node ${{ matrix.node-version }}${{ matrix.svelte-async == 'true' && ', async' || '' }})
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     strategy:
       matrix:
         adapter: ['vue', 'react', 'svelte']
         node-version: ['22.x', '24.x', 'latest']
+        svelte-async: ['false', 'true']
+        exclude:
+          - adapter: 'vue'
+            svelte-async: 'true'
+          - adapter: 'react'
+            svelte-async: 'true'
+          - adapter: 'svelte'
+            node-version: '22.x'
+            svelte-async: 'true'
+          - adapter: 'svelte'
+            node-version: 'latest'
+            svelte-async: 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -121,10 +143,12 @@ jobs:
 
       - name: Run Playwright SSR Tests
         run: pnpm test:ssr:${{ matrix.adapter }} --project=chromium
+        env:
+          SVELTE_ASYNC: ${{ matrix.svelte-async }}
 
       - name: Upload failure screenshots
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-failure-screenshots-${{ matrix.adapter }}-chromium-ssr-node-${{ matrix.node-version }}
+          name: playwright-failure-screenshots-${{ matrix.adapter }}-chromium-ssr-node-${{ matrix.node-version }}${{ matrix.svelte-async == 'true' && '-async' || '' }}
           path: test-results

--- a/packages/svelte/src/components/App.svelte
+++ b/packages/svelte/src/components/App.svelte
@@ -53,6 +53,10 @@
       initialPage,
       resolveComponent,
       swapComponent: async (args) => {
+        // Explicitly sync the global page store before swapping components,
+        // ensuring the page store is up-to-date when the new component's
+        // script block runs (necessary for async: true).
+        setPage(args.page)
         component = args.component
         page = args.page
         key = args.preserveState ? key : Date.now()

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -137,7 +137,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
           withApp(context, { ssr: true, page })
         }
 
-        svelteApp = render(App, { props, context })
+        svelteApp = await render(App, { props, context })
       }
 
       const body = buildSSRBody(id, page, svelteApp.body)

--- a/packages/svelte/test-app/Pages/SSR/Async.svelte
+++ b/packages/svelte/test-app/Pages/SSR/Async.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  // Top-level await — requires the `async: true` Svelte compiler option
+  const asyncMessage = await Promise.resolve('Hello from async SSR!')
+</script>
+
+<div>
+  <h1 data-testid="async-ssr-title">Async SSR Page</h1>
+  <p data-testid="async-result">Result: {asyncMessage}</p>
+</div>

--- a/packages/svelte/test-app/tsconfig.json
+++ b/packages/svelte/test-app/tsconfig.json
@@ -17,5 +17,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["**/*.ts", "**/*.d.ts", "**/*.svelte"]
+  "include": ["**/*.ts", "**/*.d.ts", "**/*.svelte"],
+  "exclude": ["Pages/SSR/Async.svelte"]
 }

--- a/packages/svelte/test-app/vite.config.js
+++ b/packages/svelte/test-app/vite.config.js
@@ -22,5 +22,14 @@ export default defineConfig({
       '@': __dirname,
     },
   },
-  plugins: [inertia(), svelte()],
+  plugins: [
+    inertia(),
+    svelte({
+      compilerOptions: {
+        experimental: {
+          async: true,
+        },
+      },
+    }),
+  ],
 })

--- a/packages/svelte/test-app/vite.config.js
+++ b/packages/svelte/test-app/vite.config.js
@@ -4,6 +4,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { defineConfig } from 'vite'
 
 const isSSR = process.argv.includes('--ssr')
+const asyncEnabled = process.env.SVELTE_ASYNC === 'true'
 
 export default defineConfig({
   build: {
@@ -27,8 +28,13 @@ export default defineConfig({
     svelte({
       compilerOptions: {
         experimental: {
-          async: true,
+          async: asyncEnabled,
         },
+      },
+      dynamicCompileOptions({ filename }) {
+        if (filename.includes('/Pages/SSR/Async.svelte')) {
+          return { experimental: { async: true } }
+        }
       },
     }),
   ],

--- a/packages/svelte/test-app/vite.config.ssr-auto.ts
+++ b/packages/svelte/test-app/vite.config.ssr-auto.ts
@@ -2,6 +2,8 @@ import inertia from '@inertiajs/vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { defineConfig } from 'vite'
 
+const asyncEnabled = process.env.SVELTE_ASYNC === 'true'
+
 export default defineConfig({
   build: {
     minify: false,
@@ -21,8 +23,13 @@ export default defineConfig({
     svelte({
       compilerOptions: {
         experimental: {
-          async: true,
+          async: asyncEnabled,
         },
+      },
+      dynamicCompileOptions({ filename }) {
+        if (filename.includes('/Pages/SSR/Async.svelte')) {
+          return { experimental: { async: true } }
+        }
       },
     }),
   ],

--- a/packages/svelte/test-app/vite.config.ssr-auto.ts
+++ b/packages/svelte/test-app/vite.config.ssr-auto.ts
@@ -18,6 +18,12 @@ export default defineConfig({
         port: 13720,
       },
     }),
-    svelte(),
+    svelte({
+      compilerOptions: {
+        experimental: {
+          async: true,
+        },
+      },
+    }),
   ],
 })

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -162,6 +162,12 @@ app.get('/ssr-auto/with-app', (req, res) =>
   }),
 )
 
+app.get('/ssr-auto/async', (req, res) =>
+  inertia.renderSSRAuto(req, res, {
+    component: 'SSR/Async',
+  }),
+)
+
 app.get('/ssr/infinite-scroll', (req, res) => {
   const { paginated, scrollProp } = paginateUsers(1, 15, 40)
 

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -281,6 +281,8 @@ test.describe('SSR Auto Transform', () => {
     })
 
     test('it renders components with top-level await during SSR', async ({ page }) => {
+      test.skip(process.env.SVELTE_ASYNC !== 'true', 'Requires the async Svelte compiler option')
+
       const response = await page.request.get('/ssr-auto/async')
       const html = await response.text()
 
@@ -290,6 +292,8 @@ test.describe('SSR Auto Transform', () => {
     })
 
     test('it hydrates async components without mismatch after SSR', async ({ page }) => {
+      test.skip(process.env.SVELTE_ASYNC !== 'true', 'Requires the async Svelte compiler option')
+
       consoleMessages.listen(page)
 
       await page.goto('/ssr-auto/async')

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -279,5 +279,25 @@ test.describe('SSR Auto Transform', () => {
       expect(html).toMatch(/Locale:.*en-CA/)
       expect(html).toMatch(/Component:.*SSR\/WithApp/)
     })
+
+    test('it renders components with top-level await during SSR', async ({ page }) => {
+      const response = await page.request.get('/ssr-auto/async')
+      const html = await response.text()
+
+      // Verify that the top-level await resolved correctly on the server
+      expect(html).toContain('Async SSR Page')
+      expect(html).toContain('Result: Hello from async SSR!')
+    })
+
+    test('it hydrates async components without mismatch after SSR', async ({ page }) => {
+      consoleMessages.listen(page)
+
+      await page.goto('/ssr-auto/async')
+
+      await expect(page.getByTestId('async-ssr-title')).toHaveText('Async SSR Page')
+      await expect(page.getByTestId('async-result')).toHaveText('Result: Hello from async SSR!')
+
+      expect(consoleMessages.errors).toHaveLength(0)
+    })
   })
 })


### PR DESCRIPTION
fixes #3187 

this PR also enables the `async: true` compiler option, which will be the [new default in Svelte 6](https://svelte.jp/docs/svelte/runtime-errors#Client-errors-flush_sync_in_effect)