### PR TITLE
[3.x] Support raw request bodies in the built-in HTTP client

### DIFF
--- a/packages/core/src/axiosHttpClient.ts
+++ b/packages/core/src/axiosHttpClient.ts
@@ -30,6 +30,23 @@ function normalizeHeaders(headers: unknown): HttpResponseHeaders {
 }
 
 /**
+ * Axios defaults the content type to `application/x-www-form-urlencoded` for
+ * POST/PUT/PATCH requests, which mislabels raw binary payloads. The built-in
+ * XHR client leaves these untouched, so we mirror that behavior here.
+ */
+function isBinaryRequestBody(value: unknown): boolean {
+  return (
+    (typeof Blob !== 'undefined' && value instanceof Blob) ||
+    (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer) ||
+    (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(value))
+  )
+}
+
+function hasContentTypeHeader(headers: HttpRequestConfig['headers']): boolean {
+  return Object.keys(headers ?? {}).some((key) => key.toLowerCase() === 'content-type')
+}
+
+/**
  * Convert Axios progress event to framework-agnostic progress event
  */
 function toHttpProgressEvent(axiosEvent: AxiosProgressEvent): HttpProgressEvent {
@@ -94,13 +111,19 @@ export class AxiosHttpClient implements HttpClient {
   protected async doRequest(config: HttpRequestConfig): Promise<HttpResponse> {
     const axios = await this.getAxios()
 
+    const headers = { ...(config.headers ?? {}) } as Record<string, unknown>
+
+    if (isBinaryRequestBody(config.data) && !hasContentTypeHeader(config.headers)) {
+      headers['Content-Type'] = false
+    }
+
     try {
       const response = await axios({
         method: config.method,
         url: config.url,
         data: config.data,
         params: config.params,
-        headers: config.headers as Record<string, string>,
+        headers: headers as Record<string, string>,
         signal: config.signal,
         responseType: 'text',
         onUploadProgress: config.onUploadProgress

--- a/packages/core/src/xhrHttpClient.ts
+++ b/packages/core/src/xhrHttpClient.ts
@@ -33,12 +33,28 @@ function parseHeaders(xhr: XMLHttpRequest): HttpResponseHeaders {
   return headers
 }
 
+function isFormDataRequestBody(value: unknown): value is FormData {
+  return typeof FormData !== 'undefined' && value instanceof FormData
+}
+
+function isRawRequestBody(value: unknown): value is Document | XMLHttpRequestBodyInit {
+  return (
+    typeof value === 'string' ||
+    isFormDataRequestBody(value) ||
+    (typeof Blob !== 'undefined' && value instanceof Blob) ||
+    (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer) ||
+    (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(value)) ||
+    (typeof URLSearchParams !== 'undefined' && value instanceof URLSearchParams) ||
+    (typeof Document !== 'undefined' && value instanceof Document)
+  )
+}
+
 function setHeaders(xhr: XMLHttpRequest, config: HttpRequestConfig): void {
   if (!config.headers) {
     return
   }
 
-  const isFormData = config.data instanceof FormData
+  const isFormData = isFormDataRequestBody(config.data)
 
   Object.entries(config.headers).forEach(([key, value]) => {
     if (key.toLowerCase() !== 'content-type' || !isFormData) {
@@ -114,7 +130,7 @@ export class XhrHttpClient implements HttpClient {
       let body: Document | XMLHttpRequestBodyInit | null = null
 
       if (config.data !== null && config.data !== undefined) {
-        if (config.data instanceof FormData) {
+        if (isRawRequestBody(config.data)) {
           body = config.data
         } else if (typeof config.data === 'object') {
           body = JSON.stringify(config.data)

--- a/packages/core/src/xhrHttpClient.ts
+++ b/packages/core/src/xhrHttpClient.ts
@@ -37,15 +37,14 @@ function isFormDataRequestBody(value: unknown): value is FormData {
   return typeof FormData !== 'undefined' && value instanceof FormData
 }
 
-function isRawRequestBody(value: unknown): value is Document | XMLHttpRequestBodyInit {
+function isRawRequestBody(value: unknown): value is XMLHttpRequestBodyInit {
   return (
     typeof value === 'string' ||
     isFormDataRequestBody(value) ||
     (typeof Blob !== 'undefined' && value instanceof Blob) ||
     (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer) ||
     (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(value)) ||
-    (typeof URLSearchParams !== 'undefined' && value instanceof URLSearchParams) ||
-    (typeof Document !== 'undefined' && value instanceof Document)
+    (typeof URLSearchParams !== 'undefined' && value instanceof URLSearchParams)
   )
 }
 

--- a/packages/react/test-app/Pages/Visits/Data/RawBody.tsx
+++ b/packages/react/test-app/Pages/Visits/Data/RawBody.tsx
@@ -1,0 +1,77 @@
+import { http } from '@inertiajs/react'
+
+declare global {
+  interface Window {
+    _raw_body_response?: any
+  }
+}
+
+export default () => {
+  const send = async (data: unknown, headers?: Record<string, string>) => {
+    const response = await http.getClient().request({
+      method: 'post',
+      url: '/api/raw-body',
+      data,
+      headers,
+    })
+
+    window._raw_body_response = JSON.parse(response.data)
+  }
+
+  const urlSearchParamsMethod = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    const params = new URLSearchParams()
+    params.append('foo', 'bar')
+
+    await send(params)
+  }
+
+  const stringMethod = async (e: React.MouseEvent) => {
+    e.preventDefault()
+
+    await send('raw string contents', { 'Content-Type': 'text/plain' })
+  }
+
+  const blobMethod = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    const blob = new Blob(['raw blob contents'], { type: 'text/plain' })
+
+    await send(blob)
+  }
+
+  const arrayBufferMethod = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    const buffer = new TextEncoder().encode('raw array buffer contents').buffer
+
+    await send(buffer)
+  }
+
+  const arrayBufferViewMethod = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    const bytes = new TextEncoder().encode('raw array buffer view contents')
+
+    await send(bytes)
+  }
+
+  return (
+    <div>
+      <span className="text">This is the page that demonstrates HTTP client raw request bodies</span>
+
+      <a href="#" onClick={urlSearchParamsMethod} className="url-search-params">
+        URLSearchParams Link
+      </a>
+      <a href="#" onClick={stringMethod} className="string">
+        String Link
+      </a>
+      <a href="#" onClick={blobMethod} className="blob">
+        Blob Link
+      </a>
+      <a href="#" onClick={arrayBufferMethod} className="array-buffer">
+        ArrayBuffer Link
+      </a>
+      <a href="#" onClick={arrayBufferViewMethod} className="array-buffer-view">
+        ArrayBufferView Link
+      </a>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/Visits/Data/RawBody.svelte
+++ b/packages/svelte/test-app/Pages/Visits/Data/RawBody.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { http } from '@inertiajs/svelte'
+
+  const send = async (data: unknown, headers?: Record<string, string>) => {
+    const response = await http.getClient().request({
+      method: 'post',
+      url: '/api/raw-body',
+      data,
+      headers,
+    })
+
+    window._raw_body_response = JSON.parse(response.data)
+  }
+
+  const urlSearchParamsMethod = async () => {
+    const params = new URLSearchParams()
+    params.append('foo', 'bar')
+
+    await send(params)
+  }
+
+  const stringMethod = async () => {
+    await send('raw string contents', { 'Content-Type': 'text/plain' })
+  }
+
+  const blobMethod = async () => {
+    const blob = new Blob(['raw blob contents'], { type: 'text/plain' })
+
+    await send(blob)
+  }
+
+  const arrayBufferMethod = async () => {
+    const buffer = new TextEncoder().encode('raw array buffer contents').buffer
+
+    await send(buffer)
+  }
+
+  const arrayBufferViewMethod = async () => {
+    const bytes = new TextEncoder().encode('raw array buffer view contents')
+
+    await send(bytes)
+  }
+</script>
+
+<div>
+  <span class="text">This is the page that demonstrates HTTP client raw request bodies</span>
+
+  <a href={'#'} onclick={urlSearchParamsMethod} class="url-search-params">URLSearchParams Link</a>
+  <a href={'#'} onclick={stringMethod} class="string">String Link</a>
+  <a href={'#'} onclick={blobMethod} class="blob">Blob Link</a>
+  <a href={'#'} onclick={arrayBufferMethod} class="array-buffer">ArrayBuffer Link</a>
+  <a href={'#'} onclick={arrayBufferViewMethod} class="array-buffer-view">ArrayBufferView Link</a>
+</div>

--- a/packages/svelte/test-app/types.d.ts
+++ b/packages/svelte/test-app/types.d.ts
@@ -15,6 +15,7 @@ declare global {
       url: string
       page: Page
     }
+    _raw_body_response: unknown
     _inertia_page_key: string | undefined
     _inertia_props: PageProps
     _inertia_layout_id: number | string | undefined

--- a/packages/vue3/test-app/Pages/Visits/Data/RawBody.vue
+++ b/packages/vue3/test-app/Pages/Visits/Data/RawBody.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { http } from '@inertiajs/vue3'
+
+declare global {
+  interface Window {
+    _raw_body_response?: any
+  }
+}
+
+const send = async (data: unknown, headers?: Record<string, string>) => {
+  const response = await http.getClient().request({
+    method: 'post',
+    url: '/api/raw-body',
+    data,
+    headers,
+  })
+
+  window._raw_body_response = JSON.parse(response.data)
+}
+
+const urlSearchParamsMethod = async () => {
+  const params = new URLSearchParams()
+  params.append('foo', 'bar')
+
+  await send(params)
+}
+
+const stringMethod = async () => {
+  await send('raw string contents', { 'Content-Type': 'text/plain' })
+}
+
+const blobMethod = async () => {
+  const blob = new Blob(['raw blob contents'], { type: 'text/plain' })
+
+  await send(blob)
+}
+
+const arrayBufferMethod = async () => {
+  const buffer = new TextEncoder().encode('raw array buffer contents').buffer
+
+  await send(buffer)
+}
+
+const arrayBufferViewMethod = async () => {
+  const bytes = new TextEncoder().encode('raw array buffer view contents')
+
+  await send(bytes)
+}
+</script>
+
+<template>
+  <div>
+    <span class="text">This is the page that demonstrates HTTP client raw request bodies</span>
+
+    <a href="#" @click.prevent="urlSearchParamsMethod" class="url-search-params">URLSearchParams Link</a>
+    <a href="#" @click.prevent="stringMethod" class="string">String Link</a>
+    <a href="#" @click.prevent="blobMethod" class="blob">Blob Link</a>
+    <a href="#" @click.prevent="arrayBufferMethod" class="array-buffer">ArrayBuffer Link</a>
+    <a href="#" @click.prevent="arrayBufferViewMethod" class="array-buffer-view">ArrayBufferView Link</a>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -3068,6 +3068,17 @@ app.all('/api/headers', upload.none(), (req, res) => {
   })
 })
 
+app.post('/api/raw-body', express.raw({ type: () => true }), (req, res) => {
+  const isBuffer = Buffer.isBuffer(req.body)
+
+  res.json({
+    body: isBuffer ? req.body.toString('utf8') : null,
+    form: !isBuffer && typeof req.body === 'object' && req.body !== null ? req.body : {},
+    headers: req.headers,
+    method: req.method.toLowerCase(),
+  })
+})
+
 // Nested data endpoint
 app.post('/api/nested', upload.none(), (req, res) => {
   res.json({

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -1,0 +1,73 @@
+import { expect, Page, test } from '@playwright/test'
+import { pageLoads } from './support'
+
+const getRawBodyResponse = async (page: Page): Promise<any> => {
+  await page.waitForFunction(() => (window as any)._raw_body_response)
+
+  return page.evaluate(() => (window as any)._raw_body_response)
+}
+
+test.describe('HTTP client', () => {
+  test.beforeEach(async ({ page }) => {
+    pageLoads.watch(page)
+    await page.goto('/visits/data/raw-body')
+  })
+
+  test('sends URLSearchParams without JSON serialization', async ({ page }) => {
+    await page.getByRole('link', { name: 'URLSearchParams Link' }).click()
+
+    const response = await getRawBodyResponse(page)
+
+    expect(response.method).toBe('post')
+    expect(response.form).toEqual({ foo: 'bar' })
+    expect(response.headers['content-type']).toContain('application/x-www-form-urlencoded')
+  })
+
+  test('sends a string without JSON serialization', async ({ page }) => {
+    await page.getByRole('link', { name: 'String Link' }).click()
+
+    const response = await getRawBodyResponse(page)
+
+    expect(response.method).toBe('post')
+    expect(response.body).toBe('raw string contents')
+    expect(response.form).toEqual({})
+    expect(response.headers['content-type']).toContain('text/plain')
+    expect(response.headers['content-length']).toBe('19')
+  })
+
+  test('sends a Blob without JSON serialization', async ({ page }) => {
+    await page.getByRole('link', { name: 'Blob Link' }).click()
+
+    const response = await getRawBodyResponse(page)
+
+    expect(response.method).toBe('post')
+    expect(response.body).toBe('raw blob contents')
+    expect(response.form).toEqual({})
+    expect(response.headers['content-type']).toContain('text/plain')
+    expect(response.headers['content-length']).toBe('17')
+  })
+
+  test('sends an ArrayBuffer without JSON serialization', async ({ page }) => {
+    await page.getByRole('link', { name: 'ArrayBuffer Link' }).click()
+
+    const response = await getRawBodyResponse(page)
+
+    expect(response.method).toBe('post')
+    expect(response.body).toBe('raw array buffer contents')
+    expect(response.form).toEqual({})
+    expect(response.headers['content-type']).toBeUndefined()
+    expect(response.headers['content-length']).toBe('25')
+  })
+
+  test('sends an ArrayBufferView without JSON serialization', async ({ page }) => {
+    await page.getByRole('link', { name: 'ArrayBufferView Link' }).click()
+
+    const response = await getRawBodyResponse(page)
+
+    expect(response.method).toBe('post')
+    expect(response.body).toBe('raw array buffer view contents')
+    expect(response.form).toEqual({})
+    expect(response.headers['content-type']).toBeUndefined()
+    expect(response.headers['content-length']).toBe('30')
+  })
+})


### PR DESCRIPTION
This PR adds support for raw request bodies to the built-in HTTP client. Previously only `FormData` and strings were sent as-is while every other object was serialized to JSON, so passing a `URLSearchParams`, `Blob`, `ArrayBuffer`, or typed array to `http.getClient().request()` produced an empty `"{}"` body instead of the actual payload.

The client now sends these raw body types directly to the underlying request, letting the browser apply the correct encoding and content type (for example `application/x-www-form-urlencoded` for `URLSearchParams`). Plain objects and arrays are still serialized to JSON as before, so the default behavior is unchanged. This matches how libraries like Axios and ky handle request bodies.

The optional Axios client received the same treatment. Axios forces a default `application/x-www-form-urlencoded` content type on POST, PUT, and PATCH requests, which mislabels raw binary payloads, so it now leaves the content type untouched for those bodies to stay consistent with the default client.