### PR TITLE
[3.x] Preserve identity of untouched props in replaceProp

### DIFF
--- a/packages/core/src/objectUtils.ts
+++ b/packages/core/src/objectUtils.ts
@@ -63,36 +63,37 @@ const compareValues = (value1: any, value2: any): boolean => {
   }
 }
 
-// Path-aware copy-on-write "set": copies only the containers along `path` and
-// preserves the identity of everything untouched, matching how partial reloads
-// merge props ({ ...oldProps, ...newProps }). A deep clone here would hand
-// every prop a new identity and defeat consumer memoization (React memo/
-// useMemo, Svelte fine-grained reactivity).
-export const setImmutable = <T>(target: T, path: string, value: unknown): T => {
+// Immutable set at `path`: copies only the containers along the way and keeps
+// every untouched branch by reference, so consumers that memoize on other props
+// don't re-render.
+export const setPathPreservingIdentity = <T>(target: T, path: string, value: unknown): T => {
   const keys = toPath(path)
 
   if (keys.length === 0) {
     return target
   }
 
-  const cloneAlongPath = (node: unknown, depth: number): unknown => {
-    const key = keys[depth]
-    const isLast = depth === keys.length - 1
+  const copyAlongPath = (node: unknown, depth: number): unknown => {
+    if (depth === keys.length) {
+      return value
+    }
 
-    // Copy the container on the path; create one ([] for index keys, matching
-    // es-toolkit's mutable set) when the path walks through a non-object.
+    const key = keys[depth]
+
+    // Copy the container on the path; when it is missing, create an array for an
+    // integer key and an object otherwise, matching es-toolkit's mutable set().
     const copy: any = Array.isArray(node)
       ? [...node]
-      : node !== null && typeof node === 'object'
+      : node && typeof node === 'object'
         ? { ...node }
         : /^(?:0|[1-9]\d*)$/.test(key)
           ? []
           : {}
 
-    copy[key] = isLast ? value : cloneAlongPath((node as any)?.[key], depth + 1)
+    copy[key] = copyAlongPath((node as any)?.[key], depth + 1)
 
     return copy
   }
 
-  return cloneAlongPath(target, 0) as T
+  return copyAlongPath(target, 0) as T
 }

--- a/packages/core/src/objectUtils.ts
+++ b/packages/core/src/objectUtils.ts
@@ -1,3 +1,5 @@
+import { toPath } from 'es-toolkit/compat'
+
 export const stripTopLevelUndefined = <T extends Record<string, unknown>>(obj: T): T => {
   const result = {} as T
 
@@ -59,4 +61,38 @@ const compareValues = (value1: any, value2: any): boolean => {
     default:
       return value1 === value2
   }
+}
+
+// Path-aware copy-on-write "set": copies only the containers along `path` and
+// preserves the identity of everything untouched, matching how partial reloads
+// merge props ({ ...oldProps, ...newProps }). A deep clone here would hand
+// every prop a new identity and defeat consumer memoization (React memo/
+// useMemo, Svelte fine-grained reactivity).
+export const setImmutable = <T>(target: T, path: string, value: unknown): T => {
+  const keys = toPath(path)
+
+  if (keys.length === 0) {
+    return target
+  }
+
+  const cloneAlongPath = (node: unknown, depth: number): unknown => {
+    const key = keys[depth]
+    const isLast = depth === keys.length - 1
+
+    // Copy the container on the path; create one ([] for index keys, matching
+    // es-toolkit's mutable set) when the path walks through a non-object.
+    const copy: any = Array.isArray(node)
+      ? [...node]
+      : node !== null && typeof node === 'object'
+        ? { ...node }
+        : /^(?:0|[1-9]\d*)$/.test(key)
+          ? []
+          : {}
+
+    copy[key] = isLast ? value : cloneAlongPath((node as any)?.[key], depth + 1)
+
+    return copy
+  }
+
+  return cloneAlongPath(target, 0) as T
 }

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,12 +1,12 @@
 import { cloneDeep, isEqual } from 'es-toolkit'
-import { get, set } from 'es-toolkit/compat'
+import { get } from 'es-toolkit/compat'
 import { progress } from '.'
 import { config } from './config'
 import { eventHandler } from './eventHandler'
 import { fireBeforeEvent, fireClientVisitEvent, fireFlashEvent } from './events'
 import { history } from './history'
 import { InitialVisit } from './initialVisit'
-import { stripTopLevelUndefined } from './objectUtils'
+import { setImmutable, stripTopLevelUndefined } from './objectUtils'
 import { page as currentPage } from './page'
 import { polls } from './polls'
 import { prefetchedRequests } from './prefetched'
@@ -468,7 +468,7 @@ export class Router {
       props(currentProps) {
         const newValue = typeof value === 'function' ? value(get(currentProps, name), currentProps) : value
 
-        return set(cloneDeep(currentProps), name, newValue)
+        return setImmutable(currentProps, name, newValue)
       },
       ...(options || {}),
     })

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -6,7 +6,7 @@ import { eventHandler } from './eventHandler'
 import { fireBeforeEvent, fireClientVisitEvent, fireFlashEvent } from './events'
 import { history } from './history'
 import { InitialVisit } from './initialVisit'
-import { setImmutable, stripTopLevelUndefined } from './objectUtils'
+import { setPathPreservingIdentity, stripTopLevelUndefined } from './objectUtils'
 import { page as currentPage } from './page'
 import { polls } from './polls'
 import { prefetchedRequests } from './prefetched'
@@ -468,7 +468,7 @@ export class Router {
       props(currentProps) {
         const newValue = typeof value === 'function' ? value(get(currentProps, name), currentProps) : value
 
-        return setImmutable(currentProps, name, newValue)
+        return setPathPreservingIdentity(currentProps, name, newValue)
       },
       ...(options || {}),
     })

--- a/packages/core/tests/objectUtils.test.ts
+++ b/packages/core/tests/objectUtils.test.ts
@@ -1,0 +1,57 @@
+import { set } from 'es-toolkit/compat'
+import { describe, expect, it } from 'vitest'
+import { setImmutable } from '../src/objectUtils'
+
+describe('setImmutable', () => {
+  it('matches es-toolkit set() semantics for values', () => {
+    const cases: Array<[Record<string, unknown>, string, unknown]> = [
+      [{ a: 1 }, 'a', 2],
+      [{ a: 1 }, 'b', 2],
+      [{ user: { name: 'Joe', age: 3 } }, 'user.name', 'Jane'],
+      [{ items: [{ id: 1 }, { id: 2 }] }, 'items[1].id', 99],
+      [{ items: [1, 2, 3] }, 'items.1', 9],
+      [{}, 'a.b.c', 'deep'],
+      [{}, 'list[0]', 'first'],
+      [{ a: null }, 'a.b', 1],
+    ]
+
+    for (const [target, path, value] of cases) {
+      expect(setImmutable(structuredClone(target), path, value)).toEqual(
+        set(structuredClone(target), path, value),
+      )
+    }
+  })
+
+  it('does not mutate the input', () => {
+    const target = { user: { name: 'Joe' }, other: { keep: true } }
+    const snapshot = structuredClone(target)
+
+    setImmutable(target, 'user.name', 'Jane')
+
+    expect(target).toEqual(snapshot)
+  })
+
+  it('preserves the identity of untouched values (the reason it exists)', () => {
+    const other = { keep: true }
+    const sibling = { id: 1 }
+    const target = { user: { name: 'Joe', sibling }, other }
+
+    const result = setImmutable(target, 'user.name', 'Jane')
+
+    expect(result.user.name).toBe('Jane')
+    expect(result.other).toBe(other) // untouched top-level prop: same object
+    expect(result.user.sibling).toBe(sibling) // untouched sibling on the path: same object
+    expect(result).not.toBe(target)
+    expect(result.user).not.toBe(target.user) // containers on the path are copies
+  })
+
+  it('preserves identity of untouched array elements', () => {
+    const first = { id: 1 }
+    const target = { items: [first, { id: 2 }] }
+
+    const result = setImmutable(target, 'items[1].id', 99)
+
+    expect(result.items[0]).toBe(first)
+    expect(result.items[1]).toEqual({ id: 99 })
+  })
+})

--- a/packages/core/tests/objectUtils.test.ts
+++ b/packages/core/tests/objectUtils.test.ts
@@ -1,8 +1,8 @@
 import { set } from 'es-toolkit/compat'
 import { describe, expect, it } from 'vitest'
-import { setImmutable } from '../src/objectUtils'
+import { setPathPreservingIdentity } from '../src/objectUtils'
 
-describe('setImmutable', () => {
+describe('setPathPreservingIdentity', () => {
   it('matches es-toolkit set() semantics for values', () => {
     const cases: Array<[Record<string, unknown>, string, unknown]> = [
       [{ a: 1 }, 'a', 2],
@@ -16,7 +16,7 @@ describe('setImmutable', () => {
     ]
 
     for (const [target, path, value] of cases) {
-      expect(setImmutable(structuredClone(target), path, value)).toEqual(
+      expect(setPathPreservingIdentity(structuredClone(target), path, value)).toEqual(
         set(structuredClone(target), path, value),
       )
     }
@@ -26,7 +26,7 @@ describe('setImmutable', () => {
     const target = { user: { name: 'Joe' }, other: { keep: true } }
     const snapshot = structuredClone(target)
 
-    setImmutable(target, 'user.name', 'Jane')
+    setPathPreservingIdentity(target, 'user.name', 'Jane')
 
     expect(target).toEqual(snapshot)
   })
@@ -36,7 +36,7 @@ describe('setImmutable', () => {
     const sibling = { id: 1 }
     const target = { user: { name: 'Joe', sibling }, other }
 
-    const result = setImmutable(target, 'user.name', 'Jane')
+    const result = setPathPreservingIdentity(target, 'user.name', 'Jane')
 
     expect(result.user.name).toBe('Jane')
     expect(result.other).toBe(other) // untouched top-level prop: same object
@@ -45,11 +45,23 @@ describe('setImmutable', () => {
     expect(result.user).not.toBe(target.user) // containers on the path are copies
   })
 
+  it('preserves the identity of untouched siblings on a deeper path', () => {
+    const untouched = { deep: true }
+    const target = { group: { a: { keep: 1 }, b: 2, untouched } }
+
+    const result = setPathPreservingIdentity(target, 'group.b', 3)
+
+    expect(result.group.b).toBe(3)
+    expect(result.group.untouched).toBe(untouched)
+    expect(result.group.a).toBe(target.group.a) // sibling object under the touched container keeps identity
+    expect(result.group).not.toBe(target.group)
+  })
+
   it('preserves identity of untouched array elements', () => {
     const first = { id: 1 }
     const target = { items: [first, { id: 2 }] }
 
-    const result = setImmutable(target, 'items[1].id', 99)
+    const result = setPathPreservingIdentity(target, 'items[1].id', 99)
 
     expect(result.items[0]).toBe(first)
     expect(result.items[1]).toEqual({ id: 99 })

--- a/packages/react/test-app/Pages/ClientSideVisit/ReplacePropRerender.tsx
+++ b/packages/react/test-app/Pages/ClientSideVisit/ReplacePropRerender.tsx
@@ -1,28 +1,39 @@
 import { router } from '@inertiajs/react'
 import { memo, useRef } from 'react'
 
-const MemoizedOther = memo(({ other }: { other: { label: string } }) => {
+const MemoChild = memo(({ prefix, item }: { prefix: string; item: { label: string } }) => {
   const renderCount = useRef(0)
 
   renderCount.current++
 
   return (
     <div>
-      <div id="memo-render-count">Memo render count: {renderCount.current}</div>
-      <div id="memo-value">Memo value: {other.label}</div>
+      <div id={`${prefix}-render-count`}>Render count: {renderCount.current}</div>
+      <div id={`${prefix}-value`}>Value: {item.label}</div>
     </div>
   )
 })
 
-export default ({ user, other }: { user: { name: string }; other: { label: string } }) => {
+export default ({
+  user,
+  other,
+  profile,
+}: {
+  user: { name: string }
+  other: { label: string }
+  profile: { name: string; avatar: { label: string } }
+}) => {
   return (
     <div>
       <h1>replaceProp Identity Test</h1>
       <div id="current-value">Current value: {user.name}</div>
+      <div id="profile-name">Profile name: {profile.name}</div>
 
-      <MemoizedOther other={other} />
+      <MemoChild prefix="memo" item={other} />
+      <MemoChild prefix="avatar" item={profile.avatar} />
 
       <button onClick={() => router.replaceProp('user.name', 'Jane Smith')}>Replace user.name</button>
+      <button onClick={() => router.replaceProp('profile.name', 'Jane Smith')}>Replace profile.name</button>
     </div>
   )
 }

--- a/packages/react/test-app/Pages/ClientSideVisit/ReplacePropRerender.tsx
+++ b/packages/react/test-app/Pages/ClientSideVisit/ReplacePropRerender.tsx
@@ -1,0 +1,28 @@
+import { router } from '@inertiajs/react'
+import { memo, useRef } from 'react'
+
+const MemoizedOther = memo(({ other }: { other: { label: string } }) => {
+  const renderCount = useRef(0)
+
+  renderCount.current++
+
+  return (
+    <div>
+      <div id="memo-render-count">Memo render count: {renderCount.current}</div>
+      <div id="memo-value">Memo value: {other.label}</div>
+    </div>
+  )
+})
+
+export default ({ user, other }: { user: { name: string }; other: { label: string } }) => {
+  return (
+    <div>
+      <h1>replaceProp Identity Test</h1>
+      <div id="current-value">Current value: {user.name}</div>
+
+      <MemoizedOther other={other} />
+
+      <button onClick={() => router.replaceProp('user.name', 'Jane Smith')}>Replace user.name</button>
+    </div>
+  )
+}

--- a/packages/vue3/test-app/Pages/ClientSideVisit/ReplacePropRerender.vue
+++ b/packages/vue3/test-app/Pages/ClientSideVisit/ReplacePropRerender.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3'
+import ReplacePropRerenderChild from './ReplacePropRerenderChild.vue'
+
+defineProps<{
+  user: { name: string }
+  other: { label: string }
+  profile: { name: string; avatar: { label: string } }
+}>()
+</script>
+
+<template>
+  <div>
+    <h1>replaceProp Identity Test</h1>
+    <div id="current-value">Current value: {{ user.name }}</div>
+    <div id="profile-name">Profile name: {{ profile.name }}</div>
+
+    <ReplacePropRerenderChild prefix="memo" :item="other" />
+    <ReplacePropRerenderChild prefix="avatar" :item="profile.avatar" />
+
+    <button @click="router.replaceProp('user.name', 'Jane Smith')">Replace user.name</button>
+    <button @click="router.replaceProp('profile.name', 'Jane Smith')">Replace profile.name</button>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/ClientSideVisit/ReplacePropRerenderChild.vue
+++ b/packages/vue3/test-app/Pages/ClientSideVisit/ReplacePropRerenderChild.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { onUpdated, ref } from 'vue'
+
+defineProps<{ prefix: string; item: { label: string } }>()
+
+const renderCount = ref(1)
+
+onUpdated(() => {
+  renderCount.value++
+})
+</script>
+
+<template>
+  <div>
+    <div :id="`${prefix}-render-count`">Render count: {{ renderCount }}</div>
+    <div :id="`${prefix}-value`">Value: {{ item.label }}</div>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -413,6 +413,16 @@ app.get('/client-side-visit/props', (req, res) =>
   }),
 )
 
+app.get('/client-side-visit/replace-prop-rerender', (req, res) =>
+  inertia.render(req, res, {
+    component: 'ClientSideVisit/ReplacePropRerender',
+    props: {
+      user: { name: 'John Doe' },
+      other: { label: 'untouched' },
+    },
+  }),
+)
+
 app.get('/client-side-visit/sequential', (req, res) =>
   inertia.render(req, res, {
     component: 'ClientSideVisit/Sequential',

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -419,6 +419,7 @@ app.get('/client-side-visit/replace-prop-rerender', (req, res) =>
     props: {
       user: { name: 'John Doe' },
       other: { label: 'untouched' },
+      profile: { name: 'John Doe', avatar: { label: 'avatar.png' } },
     },
   }),
 )

--- a/tests/client-side-visits-props.spec.ts
+++ b/tests/client-side-visits-props.spec.ts
@@ -151,3 +151,22 @@ test.describe('Client-side visits with props manipulation', () => {
     })
   })
 })
+
+test.describe('React', () => {
+  test.skip(process.env.PACKAGE !== 'react', 'Only for React')
+
+  test('replaceProp preserves the identity of untouched props so memoized children do not re-render', async ({
+    page,
+  }) => {
+    await page.goto('/client-side-visit/replace-prop-rerender')
+
+    await expect(page.locator('#current-value')).toHaveText('Current value: John Doe')
+    await expect(page.locator('#memo-value')).toHaveText('Memo value: untouched')
+    const initialRenderCount = await page.locator('#memo-render-count').textContent()
+
+    await page.getByRole('button', { name: 'Replace user.name' }).click()
+
+    await expect(page.locator('#current-value')).toHaveText('Current value: Jane Smith')
+    await expect(page.locator('#memo-render-count')).toHaveText(initialRenderCount!)
+  })
+})

--- a/tests/client-side-visits-props.spec.ts
+++ b/tests/client-side-visits-props.spec.ts
@@ -152,21 +152,29 @@ test.describe('Client-side visits with props manipulation', () => {
   })
 })
 
-test.describe('React', () => {
-  test.skip(process.env.PACKAGE !== 'react', 'Only for React')
+test('replaceProp preserves the identity of untouched props so memoized children do not re-render', async ({
+  page,
+}) => {
+  // Svelte stores page props as a deep $state that is reassigned wholesale, so a child's
+  // object prop re-proxies on every setPage and there is no memoized-child analog to observe.
+  // The identity guarantee itself is covered by the core setPathPreservingIdentity unit tests.
+  test.skip(process.env.PACKAGE === 'svelte', 'No memoized-child analog in Svelte')
 
-  test('replaceProp preserves the identity of untouched props so memoized children do not re-render', async ({
-    page,
-  }) => {
-    await page.goto('/client-side-visit/replace-prop-rerender')
+  await page.goto('/client-side-visit/replace-prop-rerender')
 
-    await expect(page.locator('#current-value')).toHaveText('Current value: John Doe')
-    await expect(page.locator('#memo-value')).toHaveText('Memo value: untouched')
-    const initialRenderCount = await page.locator('#memo-render-count').textContent()
+  await expect(page.locator('#current-value')).toHaveText('Current value: John Doe')
+  await expect(page.locator('#memo-value')).toHaveText('Value: untouched')
+  const initialMemoRenderCount = await page.locator('#memo-render-count').textContent()
 
-    await page.getByRole('button', { name: 'Replace user.name' }).click()
+  await page.getByRole('button', { name: 'Replace user.name' }).click()
 
-    await expect(page.locator('#current-value')).toHaveText('Current value: Jane Smith')
-    await expect(page.locator('#memo-render-count')).toHaveText(initialRenderCount!)
-  })
+  await expect(page.locator('#current-value')).toHaveText('Current value: Jane Smith')
+  await expect(page.locator('#memo-render-count')).toHaveText(initialMemoRenderCount!)
+
+  const initialAvatarRenderCount = await page.locator('#avatar-render-count').textContent()
+
+  await page.getByRole('button', { name: 'Replace profile.name' }).click()
+
+  await expect(page.locator('#profile-name')).toHaveText('Profile name: Jane Smith')
+  await expect(page.locator('#avatar-render-count')).toHaveText(initialAvatarRenderCount!)
 })


### PR DESCRIPTION
`router.replaceProp()` builds the new props object with `set(cloneDeep(currentProps), name, newValue)`, deep-cloning every prop to change one. Every prop gets a new object identity on each call, so memoized components that consume unrelated props re-render on every `replaceProp`, `appendToProp`, and `prependToProp`, and the clone itself costs O(all props) per call. Partial reloads already preserve the identity of untouched props when merging the response into the current page, so `replaceProp` was the odd one out.

This PR replaces the deep clone with a path-aware immutable set: only the containers along the path are copied, and everything untouched keeps its identity. The input props object is still never mutated, and the path syntax matches the previous behavior, including dot notation, array indices, and creating missing intermediate containers.

Includes a test-app page with a memoized child component that fails on the current behavior (the memoized component re-renders when an unrelated prop is replaced) and passes with this change, plus unit tests asserting parity with the previous `set` semantics and the new identity guarantees.