### PR TITLE
[3.x] Fix React dropping the restored page on `back_forward` visits

### DIFF
--- a/packages/core/src/initialVisit.ts
+++ b/packages/core/src/initialVisit.ts
@@ -76,6 +76,7 @@ export class InitialVisit {
           .set(currentPage.get(), {
             preserveScroll: locationVisit.preserveScroll,
             preserveState: true,
+            initialRender: true,
             visitId,
           })
           .then(() => {
@@ -100,15 +101,17 @@ export class InitialVisit {
 
     const visitId = uid()
 
-    currentPage.set(currentPage.get(), { preserveScroll: true, preserveState: true, visitId }).then(() => {
-      if (navigationType.isReload()) {
-        Scroll.restore(history.getScrollRegions())
-      } else {
-        Scroll.scrollToAnchor()
-      }
+    currentPage
+      .set(currentPage.get(), { preserveScroll: true, preserveState: true, initialRender: true, visitId })
+      .then(() => {
+        if (navigationType.isReload()) {
+          Scroll.restore(history.getScrollRegions())
+        } else {
+          Scroll.scrollToAnchor()
+        }
 
-      this.fireInitialEvents(visitId)
-    })
+        this.fireInitialEvents(visitId)
+      })
   }
 
   protected static fireInitialEvents(visitId: string): void {

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -52,6 +52,7 @@ class CurrentPage {
       preserveState = false,
       viewTransition = false,
       cached = false,
+      initialRender = false,
       visitId,
     }: {
       replace?: boolean
@@ -59,6 +60,7 @@ class CurrentPage {
       preserveState?: boolean
       viewTransition?: Visit['viewTransition']
       cached?: boolean
+      initialRender?: boolean
       visitId?: string
     } = {},
   ): Promise<void> {
@@ -138,6 +140,7 @@ class CurrentPage {
           page,
           preserveState,
           viewTransition,
+          initialRender,
         }).then(() => {
           if (preserveScroll) {
             // Scroll regions must be explicitly restored since the DOM elements are destroyed
@@ -234,13 +237,15 @@ class CurrentPage {
     page,
     preserveState,
     viewTransition,
+    initialRender = false,
   }: {
     component: Component
     page: Page
     preserveState: boolean
     viewTransition: Visit['viewTransition']
+    initialRender?: boolean
   }): Promise<unknown> {
-    const doSwap = () => this.swapComponent({ component, page, preserveState })
+    const doSwap = () => this.swapComponent({ component, page, preserveState, initialRender })
 
     if (!viewTransition || !document?.startViewTransition || document.visibilityState === 'hidden') {
       return doSwap()

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -287,10 +287,12 @@ export type PageHandler<ComponentType = Component> = ({
   component,
   page,
   preserveState,
+  initialRender,
 }: {
   component: ComponentType
   page: Page
   preserveState: boolean
+  initialRender: boolean
 }) => Promise<unknown>
 
 export type PreserveStateOption = boolean | 'errors' | ((page: Page) => boolean)

--- a/packages/react/src/App.ts
+++ b/packages/react/src/App.ts
@@ -50,13 +50,16 @@ function isLayoutResolver(value: unknown): boolean {
   )
 }
 
-let currentIsInitialPage = true
+let pendingInitialSwap: ReactPageHandlerArgs | null = null
 let routerIsInitialized = false
-let swapComponent: PageHandler<ReactComponent> = async () => {
+let swapComponent: PageHandler<ReactComponent> = async (args) => {
   // Dummy function so we can init the router outside of the useEffect hook. This is
   // needed so `router.reload()` works right away (on mount) in any of the user's
   // components. We swap in the real function in the useEffect hook below.
-  currentIsInitialPage = false
+  // The router can swap before that (e.g. a back_forward visit that restores a page
+  // from history), so we remember it here and replay it once the real function is in
+  // place instead of dropping the swap.
+  pendingInitialSwap = args
 }
 
 type CurrentPage = {
@@ -130,11 +133,10 @@ export default function App<SharedProps extends PageProps = PageProps>({
   }
 
   useEffect(() => {
-    swapComponent = async ({ component, page, preserveState }: ReactPageHandlerArgs) => {
-      if (currentIsInitialPage) {
+    swapComponent = async ({ component, page, preserveState, initialRender }: ReactPageHandlerArgs) => {
+      if (initialRender) {
         // We block setting the current page on the initial page to
         // prevent the initial page from being re-rendered again.
-        currentIsInitialPage = false
         return
       }
 
@@ -149,6 +151,13 @@ export default function App<SharedProps extends PageProps = PageProps>({
           key: preserveState ? current.key : Date.now(),
         })),
       )
+    }
+
+    // Replay the swap the dummy function above captured before we got here, if any.
+    if (pendingInitialSwap) {
+      const pending = pendingInitialSwap
+      pendingInitialSwap = null
+      swapComponent(pending)
     }
 
     const syncServerHead = (event: { detail: { page: Page } }) => {

--- a/packages/react/test-app/Pages/DeferredProps/TabDuplication.tsx
+++ b/packages/react/test-app/Pages/DeferredProps/TabDuplication.tsx
@@ -1,0 +1,15 @@
+import { Deferred, usePage } from '@inertiajs/react'
+
+const Message = () => {
+  const { message } = usePage<{ message?: string }>().props
+
+  return <div id="message">{message}</div>
+}
+
+export default () => {
+  return (
+    <Deferred data="message" fallback={<div id="fallback">Loading message...</div>}>
+      <Message />
+    </Deferred>
+  )
+}

--- a/packages/svelte/test-app/Pages/DeferredProps/TabDuplication.svelte
+++ b/packages/svelte/test-app/Pages/DeferredProps/TabDuplication.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { Deferred } from '@inertiajs/svelte'
+
+  interface Props {
+    message: string | undefined
+  }
+
+  let { message }: Props = $props()
+</script>
+
+<Deferred data="message">
+  {#snippet fallback()}
+    <div id="fallback">Loading message...</div>
+  {/snippet}
+  <div id="message">{message}</div>
+</Deferred>

--- a/packages/vue3/test-app/Pages/DeferredProps/TabDuplication.vue
+++ b/packages/vue3/test-app/Pages/DeferredProps/TabDuplication.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { Deferred } from '@inertiajs/vue3'
+
+defineProps<{ message?: string }>()
+</script>
+
+<template>
+  <Deferred data="message">
+    <template #fallback>
+      <div id="fallback">Loading message...</div>
+    </template>
+    <div id="message">{{ message }}</div>
+  </Deferred>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2925,6 +2925,29 @@ app.get('/deferred-props/back-button/b', (req, res) => {
   )
 })
 
+app.get('/deferred-props/tab-duplication', (req, res) => {
+  if (!req.headers['x-inertia-partial-data']) {
+    return inertia.render(req, res, {
+      component: 'DeferredProps/TabDuplication',
+      deferredProps: {
+        default: ['message'],
+      },
+      props: {},
+    })
+  }
+
+  setTimeout(
+    () =>
+      inertia.render(req, res, {
+        component: 'DeferredProps/TabDuplication',
+        props: {
+          message: req.headers['x-inertia-partial-data']?.includes('message') ? 'Message loaded!' : undefined,
+        },
+      }),
+    300,
+  )
+})
+
 app.get('/reload/concurrent', (req, res) => {
   const partialData = req.headers['x-inertia-partial-data']
 

--- a/tests/deferred-props.spec.ts
+++ b/tests/deferred-props.spec.ts
@@ -520,3 +520,40 @@ test('it does not refetch deferred props that were already loaded on a previous 
 
   expect(requests.requests).toHaveLength(0)
 })
+
+test('it restores already-resolved deferred props on a back_forward initial visit', async ({ page }) => {
+  await gotoPageAndWaitForContent(page, '/deferred-props/tab-duplication')
+
+  await expect(page.locator('#fallback')).toBeVisible()
+
+  await page.waitForResponse(page.url())
+
+  await expect(page.locator('#fallback')).not.toBeVisible()
+  await expect(page.locator('#message')).toContainText('Message loaded!')
+
+  // Duplicating a tab in Chrome or Firefox loads a fresh document that restores the
+  // original tab's history state (already holding the resolved deferred props) and is
+  // reported as a back_forward navigation. Playwright/CDP can't clone a tab, so we
+  // stand in for it: reload() keeps the real history state, and we force the reported
+  // navigation type to back_forward, which is the only signal no API exposes.
+  await page.addInitScript(() => {
+    const original = window.performance.getEntriesByType.bind(window.performance)
+
+    window.performance.getEntriesByType = (type: string) => {
+      const entries = original(type)
+
+      if (type === 'navigation') {
+        return entries.map(
+          (entry) => new Proxy(entry, { get: (t, p) => (p === 'type' ? 'back_forward' : (t as any)[p]) }),
+        )
+      }
+
+      return entries
+    }
+  })
+
+  await page.reload()
+
+  await expect(page.locator('#message')).toContainText('Message loaded!')
+  await expect(page.locator('#fallback')).not.toBeVisible()
+})


### PR DESCRIPTION
When a tab is duplicated (which Chrome and Firefox report as a `back_forward` navigation), Inertia restores the page from the browser's history state, which may already contain deferred props that resolved in the original tab. The React adapter discarded this restored page on load, assuming the first update after mount always duplicated the server-rendered page. As a result `usePage()` stayed stuck on the stale initial props, and any content waiting on those deferred props never appeared.

The adapter now skips only the initial page's own re-render and applies every other update, including a page restored from history. It also holds on to an update that arrives before the app has mounted and replays it once it has, since the restore fires before React installs its handler. Vue and Svelte were not affected.

Fixes #3195.