### PR TITLE
[3.x] Don't cancel background async visits on navigation

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -41,6 +41,10 @@ export class Request {
     return this.requestParams.isPrefetch()
   }
 
+  public getUrl(): URL {
+    return this.requestParams.all().url
+  }
+
   public isOptimistic(): boolean {
     return this.optimistic
   }

--- a/packages/core/src/requestStream.ts
+++ b/packages/core/src/requestStream.ts
@@ -24,11 +24,19 @@ export class RequestStream {
     this.cancel({ interrupted: true }, false)
   }
 
-  public cancelInFlight({ prefetch = true, optimistic = true } = {}): void {
-    this.requests
-      .filter((request) => prefetch || !request.isPrefetch())
-      .filter((request) => optimistic || !request.isOptimistic())
-      .forEach((request) => request.cancel({ cancelled: true }))
+  public cancelInFlight(
+    options: { prefetch?: boolean; optimistic?: boolean } | ((request: Request) => boolean) = {},
+  ): void {
+    const shouldCancel =
+      typeof options === 'function'
+        ? options
+        : (request: Request) => {
+            const { prefetch = true, optimistic = true } = options
+
+            return (prefetch || !request.isPrefetch()) && (optimistic || !request.isOptimistic())
+          }
+
+    this.requests.filter(shouldCancel).forEach((request) => request.cancel({ cancelled: true }))
   }
 
   protected cancel({ cancelled = false, interrupted = false } = {}, force: boolean = false): void {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -284,8 +284,15 @@ export class Router {
       : isSameUrlWithoutHash(visit.url, currentPageUrl)
 
     if (!isSamePage) {
-      // Only cancel non-prefetch requests (deferred props + partial reloads)
-      this.asyncRequestStream.cancelInFlight({ prefetch: false, optimistic: false })
+      // Cancel in-flight requests aimed at the page we're navigating away from
+      // (deferred props, partial reloads, plain reloads), but leave prefetches,
+      // optimistic requests, and background async visits to other pages untouched
+      this.asyncRequestStream.cancelInFlight(
+        (request) =>
+          !request.isPrefetch() &&
+          !request.isOptimistic() &&
+          isSameUrlWithoutQueryOrHash(request.getUrl(), currentPageUrl),
+      )
     }
 
     // Interrupt in-flight requests before taking the optimistic snapshot

--- a/packages/react/test-app/Pages/AsyncVisits/PageA.tsx
+++ b/packages/react/test-app/Pages/AsyncVisits/PageA.tsx
@@ -1,0 +1,15 @@
+import { Link } from '@inertiajs/react'
+
+export default () => (
+  <>
+    <div>Page: A</div>
+
+    <Link href="/async-visits/page-b" async>
+      Go to B async
+    </Link>
+    <Link href="/async-visits/page-a" async>
+      Go to A async
+    </Link>
+    <Link href="/async-visits/page-c">Go to C</Link>
+  </>
+)

--- a/packages/react/test-app/Pages/AsyncVisits/PageB.tsx
+++ b/packages/react/test-app/Pages/AsyncVisits/PageB.tsx
@@ -1,0 +1,9 @@
+import { Link } from '@inertiajs/react'
+
+export default () => (
+  <>
+    <div>Page: B</div>
+
+    <Link href="/async-visits/page-a">Go to A</Link>
+  </>
+)

--- a/packages/react/test-app/Pages/AsyncVisits/PageC.tsx
+++ b/packages/react/test-app/Pages/AsyncVisits/PageC.tsx
@@ -1,0 +1,9 @@
+import { Link } from '@inertiajs/react'
+
+export default () => (
+  <>
+    <div>Page: C</div>
+
+    <Link href="/async-visits/page-a">Go to A</Link>
+  </>
+)

--- a/packages/react/test-app/Pages/AsyncVisits/ReloadOrigin.tsx
+++ b/packages/react/test-app/Pages/AsyncVisits/ReloadOrigin.tsx
@@ -1,0 +1,10 @@
+import { Link, router } from '@inertiajs/react'
+
+export default () => (
+  <>
+    <div>Page: Reload Origin</div>
+
+    <button onClick={() => router.reload({ headers: { 'X-Repro-Delay': '1' } })}>Reload</button>
+    <Link href="/async-visits/page-c">Go to C</Link>
+  </>
+)

--- a/packages/svelte/test-app/Pages/AsyncVisits/PageA.svelte
+++ b/packages/svelte/test-app/Pages/AsyncVisits/PageA.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { Link } from '@inertiajs/svelte'
+</script>
+
+<div>Page: A</div>
+
+<Link href="/async-visits/page-b" async>Go to B async</Link>
+<Link href="/async-visits/page-a" async>Go to A async</Link>
+<Link href="/async-visits/page-c">Go to C</Link>

--- a/packages/svelte/test-app/Pages/AsyncVisits/PageB.svelte
+++ b/packages/svelte/test-app/Pages/AsyncVisits/PageB.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Link } from '@inertiajs/svelte'
+</script>
+
+<div>Page: B</div>
+
+<Link href="/async-visits/page-a">Go to A</Link>

--- a/packages/svelte/test-app/Pages/AsyncVisits/PageC.svelte
+++ b/packages/svelte/test-app/Pages/AsyncVisits/PageC.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Link } from '@inertiajs/svelte'
+</script>
+
+<div>Page: C</div>
+
+<Link href="/async-visits/page-a">Go to A</Link>

--- a/packages/svelte/test-app/Pages/AsyncVisits/ReloadOrigin.svelte
+++ b/packages/svelte/test-app/Pages/AsyncVisits/ReloadOrigin.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { Link, router } from '@inertiajs/svelte'
+
+  const reload = () => router.reload({ headers: { 'X-Repro-Delay': '1' } })
+</script>
+
+<div>Page: Reload Origin</div>
+
+<button onclick={reload}>Reload</button>
+<Link href="/async-visits/page-c">Go to C</Link>

--- a/packages/vue3/test-app/Pages/AsyncVisits/PageA.vue
+++ b/packages/vue3/test-app/Pages/AsyncVisits/PageA.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <div>Page: A</div>
+
+  <Link href="/async-visits/page-b" async>Go to B async</Link>
+  <Link href="/async-visits/page-a" async>Go to A async</Link>
+  <Link href="/async-visits/page-c">Go to C</Link>
+</template>

--- a/packages/vue3/test-app/Pages/AsyncVisits/PageB.vue
+++ b/packages/vue3/test-app/Pages/AsyncVisits/PageB.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <div>Page: B</div>
+
+  <Link href="/async-visits/page-a">Go to A</Link>
+</template>

--- a/packages/vue3/test-app/Pages/AsyncVisits/PageC.vue
+++ b/packages/vue3/test-app/Pages/AsyncVisits/PageC.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <div>Page: C</div>
+
+  <Link href="/async-visits/page-a">Go to A</Link>
+</template>

--- a/packages/vue3/test-app/Pages/AsyncVisits/ReloadOrigin.vue
+++ b/packages/vue3/test-app/Pages/AsyncVisits/ReloadOrigin.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { Link, router } from '@inertiajs/vue3'
+
+const reload = () => router.reload({ headers: { 'X-Repro-Delay': '1' } })
+</script>
+
+<template>
+  <div>Page: Reload Origin</div>
+
+  <button @click="reload">Reload</button>
+  <Link href="/async-visits/page-c">Go to C</Link>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -1712,6 +1712,20 @@ app.get('/deferred-props/rapid-navigation{/:id}', (req, res) => {
   )
 })
 
+app.get('/async-visits/page-a', (req, res) => inertia.render(req, res, { component: 'AsyncVisits/PageA' }))
+
+app.get('/async-visits/page-b', (req, res) => {
+  setTimeout(() => inertia.render(req, res, { component: 'AsyncVisits/PageB' }), 600)
+})
+
+app.get('/async-visits/page-c', (req, res) => inertia.render(req, res, { component: 'AsyncVisits/PageC' }))
+
+app.get('/async-visits/reload-origin', (req, res) => {
+  const delay = req.headers['x-repro-delay'] ? 600 : 0
+
+  setTimeout(() => inertia.render(req, res, { component: 'AsyncVisits/ReloadOrigin' }), delay)
+})
+
 app.get('/deferred-props/partial-reloads', (req, res) => {
   if (!req.headers['x-inertia-partial-data']) {
     return inertia.render(req, res, {

--- a/tests/async-visits.spec.ts
+++ b/tests/async-visits.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Async visits', () => {
+  test('it does not cancel repeated async visits to a different page', async ({ page }) => {
+    const cancelled: string[] = []
+
+    page.on('requestfailed', (req) => {
+      if (req.url().includes('/async-visits/page-b')) {
+        cancelled.push(req.failure()?.errorText || 'failed')
+      }
+    })
+
+    await page.goto('/async-visits/page-a')
+    await expect(page.getByText('Page: A')).toBeVisible()
+
+    const link = page.getByRole('link', { name: 'Go to B async' })
+
+    const inFlight = page.waitForRequest('**/async-visits/page-b')
+    await link.click()
+    await inFlight
+
+    await link.click()
+    await link.click()
+
+    await expect(page.getByText('Page: B')).toBeVisible()
+    expect(cancelled).toHaveLength(0)
+  })
+
+  test('it does not cancel an in-flight async visit when navigating to a different page', async ({ page }) => {
+    const cancelled: string[] = []
+    const completed: string[] = []
+
+    page.on('requestfailed', (req) => {
+      if (req.url().includes('/async-visits/page-b')) {
+        cancelled.push(req.failure()?.errorText || 'failed')
+      }
+    })
+
+    page.on('response', (res) => {
+      if (res.url().includes('/async-visits/page-b') && res.status() === 200) {
+        completed.push(res.url())
+      }
+    })
+
+    await page.goto('/async-visits/page-a')
+    await expect(page.getByText('Page: A')).toBeVisible()
+
+    const inFlight = page.waitForRequest('**/async-visits/page-b')
+    await page.getByRole('link', { name: 'Go to B async' }).click()
+    await inFlight
+
+    await page.getByRole('link', { name: 'Go to C' }).click()
+    await expect(page.getByText('Page: C')).toBeVisible()
+
+    await expect.poll(() => completed.length).toBe(1)
+    expect(cancelled).toHaveLength(0)
+  })
+
+  test('it cancels an in-flight reload of the current page when navigating away', async ({ page }) => {
+    const cancelled: string[] = []
+
+    page.on('requestfailed', (req) => {
+      if (req.url().includes('/async-visits/reload-origin') && req.headers()['x-repro-delay']) {
+        cancelled.push(req.failure()?.errorText || 'failed')
+      }
+    })
+
+    await page.goto('/async-visits/reload-origin')
+    await expect(page.getByText('Page: Reload Origin')).toBeVisible()
+
+    const inFlight = page.waitForRequest(
+      (req) => req.url().includes('/async-visits/reload-origin') && !!req.headers()['x-repro-delay'],
+    )
+    await page.getByRole('button', { name: 'Reload' }).click()
+    await inFlight
+
+    await page.getByRole('link', { name: 'Go to C' }).click()
+    await expect(page.getByText('Page: C')).toBeVisible()
+
+    await expect.poll(() => cancelled.length).toBe(1)
+  })
+})


### PR DESCRIPTION
Inertia cancels in-flight requests when you navigate to a different page, which is meant to drop stale deferred props and partial reloads for the page you're leaving. It also killed explicit async visits aimed at other pages. Clicking an async Link to another page more than once, or navigating elsewhere while an async request was in flight, cancelled the earlier request.

This PR narrows the cancellation to only the requests that actually target the page you're navigating away from, matched by origin and path. Deferred props, partial reloads, plain `router.reload()`, and polls all run against the current page and are still cancelled as before, while background async visits to other pages are left to complete.

Addresses the async visit cancellation problems (issues 1 and 2) reported in #3143.