### PR TITLE
[3.x] Guard Form getFormData against a missing form element

### DIFF
--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -128,7 +128,8 @@ const Form = forwardRef<FormComponentRef, FormProps>(
     const [isDirty, setIsDirty] = useState(false)
     const defaultData = useRef<FormData>(new FormData())
 
-    const getFormData = (submitter?: FormSubmitter): FormData => new FormData(formElement.current, submitter)
+    const getFormData = (submitter?: FormSubmitter): FormData =>
+      formElement.current ? new FormData(formElement.current, submitter) : new FormData()
 
     // Convert the FormData to an object because we can't compare two FormData
     // instances directly (which is needed for isDirty), mergeDataIntoQueryString()

--- a/packages/react/test-app/Pages/FormComponent/UnmountRace.tsx
+++ b/packages/react/test-app/Pages/FormComponent/UnmountRace.tsx
@@ -1,0 +1,22 @@
+import { Form } from '@inertiajs/react'
+import { useState } from 'react'
+
+export default function UnmountRace() {
+  const [show, setShow] = useState(true)
+
+  return (
+    <div>
+      <h1>Form Unmount Race</h1>
+
+      {show && (
+        <Form action="/dump/post" method="post">
+          <input type="text" name="name" id="name" defaultValue="John" />
+        </Form>
+      )}
+
+      <button id="hide" onClick={() => setShow(false)}>
+        Hide Form
+      </button>
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/FormComponent/UnmountRace.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/UnmountRace.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { Form } from '@inertiajs/svelte'
+
+  let show = $state(true)
+</script>
+
+<div>
+  <h1>Form Unmount Race</h1>
+
+  {#if show}
+    <Form action="/dump/post" method="post">
+      <input type="text" name="name" id="name" value="John" />
+    </Form>
+  {/if}
+
+  <button id="hide" onclick={() => (show = false)}>Hide Form</button>
+</div>

--- a/packages/vue3/test-app/Pages/FormComponent/UnmountRace.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/UnmountRace.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3'
+import { ref } from 'vue'
+
+const show = ref(true)
+</script>
+
+<template>
+  <div>
+    <h1>Form Unmount Race</h1>
+
+    <Form v-if="show" action="/dump/post" method="post">
+      <input type="text" name="name" id="name" value="John" />
+    </Form>
+
+    <button id="hide" @click="show = false">Hide Form</button>
+  </div>
+</template>

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -665,6 +665,27 @@ test.describe('Form Component', () => {
     })
   })
 
+  test('does not throw when a form event fires while the form is unmounting', async ({ page }) => {
+    consoleMessages.listen(page)
+
+    await page.goto('/form-component/unmount-race')
+
+    await page.evaluate(async () => {
+      const form = document.querySelector('form')!
+
+      ;(document.querySelector('#hide') as HTMLButtonElement).click()
+
+      // React nulls the form ref when the unmount commits (a microtask) but removes the
+      // listener in a later passive effect, so this dispatch used to hit new FormData(null)
+      await Promise.resolve()
+
+      form.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    await expect(page.locator('form')).toHaveCount(0)
+    expect(consoleMessages.errors).toEqual([])
+  })
+
   test.describe('Methods', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/form-component/methods')


### PR DESCRIPTION
Fixes #3202.

### Problem

`<Form>` can throw an uncaught `TypeError: Failed to construct 'FormData': parameter 1 is not of type 'HTMLFormElement'` when an `input`/`change`/`reset` event fires shortly before the form unmounts (e.g. the user navigates away right after typing).

`updateDirtyState` (registered for `input`/`change`/`reset`) defers its `getData()` read through `deferStateUpdate`, which is `React.startTransition`. `startTransition` callbacks are **not** cancelled on unmount, and the effect cleanup only removes the listeners. So a transition scheduled by a prior event still runs after the `<form>` has been torn down, at which point `formElement.current` is `null` and `new FormData(null)` throws.

```ts
const getFormData = (submitter?: FormSubmitter): FormData => new FormData(formElement.current, submitter)

const updateDirtyState = (event: Event) => {
  // ...
  deferStateUpdate(() =>
    setIsDirty(event.type === 'reset' ? false : !isEqual(getData(), formDataToObject(defaultData.current))),
  )
}

const deferStateUpdate = (callback: () => void) => {
  typeof React.startTransition === 'function' ? React.startTransition(callback) : setTimeout(callback, 0)
}
```

Seen in production on Chrome Mobile / Android. Source-mapped stack terminates in `getFormData` → `getData` → the `deferStateUpdate` callback in `updateDirtyState`.

### Fix

Guard `getFormData` so it returns an empty `FormData` when the form element is gone. At that point the deferred dirty-state check is cosmetic (the form has already unmounted), so a no-op is safe.

```ts
const getFormData = (submitter?: FormSubmitter): FormData =>
  formElement.current ? new FormData(formElement.current, submitter) : new FormData()
```

### Scope

React only. The Vue 3 adapter's equivalent (`onFormUpdate`) updates `isDirty` **synchronously** (no `startTransition`), so its listener cannot run after unmount and it is not affected.

### Notes

`getFormData` is unchanged in every 3.x release through 3.6.1, so the issue affects all of them.
