### PR TITLE
[3.x] Prefer server.origin when resolving SSR CSS link URLs

### DIFF
--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -83,7 +83,7 @@ function isCSSRequest(url: string): boolean {
 
 function resolveDevServerOrigin(server: ViteDevServer): string {
   if (server.config.server.origin) {
-    return new URL(server.config.server.origin).origin
+    return server.config.server.origin
   }
 
   const url = server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]

--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -82,6 +82,10 @@ function isCSSRequest(url: string): boolean {
 }
 
 function resolveDevServerOrigin(server: ViteDevServer): string {
+  if (server.config.server.origin) {
+    return new URL(server.config.server.origin).origin
+  }
+
   const url = server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]
 
   if (url) {

--- a/packages/vite/tests/ssr.test.ts
+++ b/packages/vite/tests/ssr.test.ts
@@ -691,6 +691,52 @@ describe('SSR', () => {
       ])
     })
 
+    it('prefers server.origin over resolvedUrls', async () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('resources/js/ssr.ts'))
+
+      const plugin = inertia()
+      const logger = createMockLogger()
+      const server = createMockServer(logger, {
+        origin: 'https://example.ddev.site:5173',
+        resolvedUrls: { local: ['http://localhost:5173/'], network: [] },
+      })
+
+      const cssModule = {
+        url: '/resources/css/app.css',
+        id: '/project/resources/css/app.css',
+        importedModules: new Set(),
+      }
+      const entryModule = {
+        url: '/resources/js/ssr.ts',
+        id: '/project/resources/js/ssr.ts',
+        importedModules: new Set([cssModule]),
+      }
+
+      server.environments.ssr.moduleGraph.getModuleById.mockImplementation((id: string) =>
+        id === '/project/resources/js/ssr.ts' ? entryModule : undefined,
+      )
+      server.ssrLoadModule.mockResolvedValue({
+        default: vi.fn().mockResolvedValue({
+          head: [],
+          body: '<div id="app">Hello</div>',
+        }),
+      })
+
+      plugin.configResolved!(createMockConfig(logger, false))
+      plugin.configureServer!(server)
+
+      const middleware = server.middlewares.use.mock.calls[0][1]
+      const req = createMockRequest('POST', JSON.stringify({ component: 'Test', props: {} }))
+      const res = createMockResponse()
+
+      await middleware(req, res, vi.fn())
+
+      const response = JSON.parse(res.end.mock.calls[0][0])
+      expect(response.head).toEqual([
+        '<link rel="stylesheet" href="https://example.ddev.site:5173/resources/css/app.css" data-vite-dev-id="/project/resources/css/app.css">',
+      ])
+    })
+
     it('does not duplicate base path in CSS link URLs', async () => {
       mockExistsSync.mockImplementation((path: string) => path.endsWith('resources/js/ssr.ts'))
 
@@ -930,7 +976,11 @@ function createMockConfig(
 
 function createMockServer(
   logger: ReturnType<typeof createMockLogger>,
-  { base = '/', resolvedUrls }: { base?: string; resolvedUrls?: { local: string[]; network: string[] } } = {},
+  {
+    base = '/',
+    origin,
+    resolvedUrls,
+  }: { base?: string; origin?: string; resolvedUrls?: { local: string[]; network: string[] } } = {},
 ): ViteDevServer {
   return {
     middlewares: { use: vi.fn() },
@@ -938,7 +988,7 @@ function createMockServer(
     ssrFixStacktrace: vi.fn(),
     environments: { ssr: { moduleGraph: { getModuleById: vi.fn() } } },
     resolvedUrls: resolvedUrls ?? { local: [`http://localhost:5173${base}`], network: [] },
-    config: { logger, base, root: '/project' },
+    config: { logger, base, root: '/project', server: { origin } },
   } as unknown as ViteDevServer
 }
 


### PR DESCRIPTION
## Summary
- Prefer `server.config.server.origin` in `resolveDevServerOrigin()` before falling back to `resolvedUrls`
- Fixes SSR stylesheet `<link>` tags pointing at unreachable `http://localhost:5173` in Docker/DDEV when `server.origin` is set
- Adds regression test covering `server.origin` taking precedence over local `resolvedUrls`

Fixes #3216

## Test plan
- [x] `pnpm test:vite` (111 passed)
- [x] Reproduce with DDEV: set `server.origin` to `https://*.ddev.site:5173`, confirm SSR CSS `href` uses that origin instead of `localhost`

Made with [Cursor](https://cursor.com)