### PR TITLE
[3.x] Add ClientOnly component

### DIFF
--- a/packages/core/src/hydrationBoot.ts
+++ b/packages/core/src/hydrationBoot.ts
@@ -1,0 +1,22 @@
+let isHydrationBoot = true
+let clientRendered = false
+
+// The `typeof window` check in `canRenderClientOnly` is what actually keeps this module
+// inert on the server -- a client boot never runs inside the SSR process, so the state
+// below is never touched there regardless. The guards on the mutators are defence in
+// depth: these are exported functions, so nothing stops a caller from invoking them
+// outside the client boot path they're meant for.
+export function setHydrationBoot(value: boolean): void {
+  if (typeof window === 'undefined') return
+  isHydrationBoot = value
+  clientRendered = false
+}
+
+export function markClientRendered(): void {
+  if (typeof window === 'undefined') return
+  clientRendered = true
+}
+
+export function canRenderClientOnly(): boolean {
+  return typeof window !== 'undefined' && (clientRendered || !isHydrationBoot)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,8 @@ export { hasFiles } from './files'
 export { objectToFormData } from './formData'
 export { formDataToObject } from './formObject'
 export { default as createHeadManager, resolveServerHead } from './head'
+/** @internal Not part of the public API. May change or be removed without notice. */
+export { canRenderClientOnly, markClientRendered, setHydrationBoot } from './hydrationBoot'
 export { http } from './http'
 export { HttpCancelledError, HttpError, HttpNetworkError, HttpResponseError } from './httpErrors'
 export { default as useInfiniteScroll } from './infiniteScroll'

--- a/packages/core/tests/hydrationBoot.test.ts
+++ b/packages/core/tests/hydrationBoot.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The module holds mutable top-level state, so each test needs a fresh instance.
+const loadFresh = async () => {
+  vi.resetModules()
+  return import('../src/hydrationBoot')
+}
+
+describe('hydrationBoot', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('blocks rendering until markClientRendered runs, on a hydration boot', async () => {
+    vi.stubGlobal('window', {})
+    const { canRenderClientOnly, markClientRendered } = await loadFresh()
+
+    expect(canRenderClientOnly()).toBe(false)
+    markClientRendered()
+    expect(canRenderClientOnly()).toBe(true)
+  })
+
+  it('allows rendering immediately when the boot is not a hydration pass', async () => {
+    vi.stubGlobal('window', {})
+    const { canRenderClientOnly, setHydrationBoot } = await loadFresh()
+
+    setHydrationBoot(false)
+    expect(canRenderClientOnly()).toBe(true)
+  })
+
+  it('resets the client-rendered flag whenever a new boot is announced', async () => {
+    vi.stubGlobal('window', {})
+    const { canRenderClientOnly, markClientRendered, setHydrationBoot } = await loadFresh()
+
+    markClientRendered()
+    expect(canRenderClientOnly()).toBe(true)
+
+    setHydrationBoot(true)
+    expect(canRenderClientOnly()).toBe(false)
+  })
+
+  it('is inert on the server: writes no-op and rendering is always blocked', async () => {
+    // No `window` stub -- this runs in the default (windowless) test environment.
+    const { canRenderClientOnly, markClientRendered, setHydrationBoot } = await loadFresh()
+
+    setHydrationBoot(false)
+    markClientRendered()
+
+    expect(canRenderClientOnly()).toBe(false)
+  })
+})

--- a/packages/react/src/ClientOnly.ts
+++ b/packages/react/src/ClientOnly.ts
@@ -1,18 +1,29 @@
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useSyncExternalStore } from 'react'
 
 interface ClientOnlyProps {
   children: ReactNode | (() => ReactNode)
   fallback?: ReactNode | (() => ReactNode)
 }
 
-const ClientOnly = ({ children, fallback }: ClientOnlyProps) => {
-  // Not a `typeof window` check: the client's first render must match the server's
-  // HTML, so the swap has to wait for mount.
-  const [mounted, setMounted] = useState(false)
+// Referentially stable module-level constants: useSyncExternalStore re-subscribes
+// whenever subscribe/getSnapshot/getServerSnapshot change identity, so these must not be
+// recreated per render or per instance.
+const subscribe = () => () => {}
+const getClientSnapshot = () => true
+const getServerSnapshot = () => false
 
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+// `ClientOnly` renders `fallback` on its first render if and only if that render is part
+// of an SSR hydration pass for the current document. In every other case -- a pure
+// client-rendered boot, and every instance created after the initial hydration commit
+// (including after ordinary page remounts) -- it renders `children` on its very first
+// render. Local per-instance state can't express this: a remount creates a new instance
+// that restarts at "not mounted", so the "have we passed hydration" signal has to live
+// outside any single component instance. Unlike the Vue/Svelte adapters, React needs no
+// such module here: `useSyncExternalStore`'s server/client snapshot pair is exactly this
+// signal, scoped correctly per-fiber (including late-hydrating Suspense boundaries) by
+// React itself.
+const ClientOnly = ({ children, fallback }: ClientOnlyProps) => {
+  const mounted = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot)
 
   if (!mounted) {
     return typeof fallback === 'function' ? fallback() : (fallback ?? null)

--- a/packages/react/src/ClientOnly.ts
+++ b/packages/react/src/ClientOnly.ts
@@ -1,0 +1,26 @@
+import { ReactNode, useEffect, useState } from 'react'
+
+interface ClientOnlyProps {
+  children: ReactNode | (() => ReactNode)
+  fallback?: ReactNode | (() => ReactNode)
+}
+
+const ClientOnly = ({ children, fallback }: ClientOnlyProps) => {
+  // Not a `typeof window` check: the client's first render must match the server's
+  // HTML, so the swap has to wait for mount.
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return typeof fallback === 'function' ? fallback() : (fallback ?? null)
+  }
+
+  return typeof children === 'function' ? children() : children
+}
+
+ClientOnly.displayName = 'InertiaClientOnly'
+
+export default ClientOnly

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,6 +3,7 @@ import type { ReactInertiaAppConfig } from './types'
 
 export { http, progress, router } from '@inertiajs/core'
 export { default as App } from './App'
+export { default as ClientOnly } from './ClientOnly'
 export { default as createInertiaApp } from './createInertiaApp'
 export { default as Deferred } from './Deferred'
 export { default as Form, useFormContext } from './Form'

--- a/packages/react/test-app/Components/ClientOnlyChild.tsx
+++ b/packages/react/test-app/Components/ClientOnlyChild.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+
+const ClientOnlyChild = () => {
+  const [status, setStatus] = useState<'pending' | 'ready'>('pending')
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    window._inertia_client_only_child_mounts = (window._inertia_client_only_child_mounts || 0) + 1
+
+    const timer = setTimeout(() => setStatus('ready'), 100)
+
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <div>
+      <span data-testid="child-status">{status}</span>
+      <span data-testid="child-count">{count}</span>
+      <button data-testid="child-increment" onClick={() => setCount((c) => c + 1)}>
+        Increment
+      </button>
+    </div>
+  )
+}
+
+export default ClientOnlyChild

--- a/packages/react/test-app/Components/ClientOnlyFallback.tsx
+++ b/packages/react/test-app/Components/ClientOnlyFallback.tsx
@@ -1,0 +1,11 @@
+// Increments on render (not in an effect) because the fallback can be unmounted
+// in the same commit it's created in -- an effect might never get the chance to fire.
+const ClientOnlyFallback = () => {
+  if (typeof window !== 'undefined') {
+    window._inertia_client_only_fallback_renders = (window._inertia_client_only_fallback_renders || 0) + 1
+  }
+
+  return <p data-testid="client-only-fallback">Loading widget...</p>
+}
+
+export default ClientOnlyFallback

--- a/packages/react/test-app/Pages/ClientOnly.tsx
+++ b/packages/react/test-app/Pages/ClientOnly.tsx
@@ -1,0 +1,11 @@
+import { ClientOnly } from '@inertiajs/react'
+
+export default () => (
+  <div>
+    <h1 data-testid="title">ClientOnly</h1>
+
+    <ClientOnly fallback={<p data-testid="client-only-fallback">Loading widget...</p>}>
+      <p data-testid="client-only-content">Client path: /client-only</p>
+    </ClientOnly>
+  </div>
+)

--- a/packages/react/test-app/Pages/ClientOnly.tsx
+++ b/packages/react/test-app/Pages/ClientOnly.tsx
@@ -1,11 +1,24 @@
-import { ClientOnly } from '@inertiajs/react'
+import { ClientOnly, Link } from '@inertiajs/react'
+import ClientOnlyChild from '@/Components/ClientOnlyChild'
+import ClientOnlyFallback from '@/Components/ClientOnlyFallback'
 
 export default () => (
   <div>
     <h1 data-testid="title">ClientOnly</h1>
 
-    <ClientOnly fallback={<p data-testid="client-only-fallback">Loading widget...</p>}>
+    <ClientOnly fallback={<ClientOnlyFallback />}>
       <p data-testid="client-only-content">Client path: /client-only</p>
+      <ClientOnlyChild />
     </ClientOnly>
+
+    <Link data-testid="revisit-link" href="/client-only">
+      Revisit
+    </Link>
+    <Link data-testid="preserve-state-link" href="/client-only" preserveState>
+      Revisit (preserve state)
+    </Link>
+    <Link data-testid="leave-link" href="/">
+      Leave
+    </Link>
   </div>
 )

--- a/packages/react/test-app/Pages/SSR/ClientOnly.tsx
+++ b/packages/react/test-app/Pages/SSR/ClientOnly.tsx
@@ -1,4 +1,5 @@
-import { ClientOnly } from '@inertiajs/react'
+import { ClientOnly, Link } from '@inertiajs/react'
+import ClientOnlyFallback from '@/Components/ClientOnlyFallback'
 
 const clientPath = () => window.location.pathname
 
@@ -7,8 +8,15 @@ export default () => (
     <h1 data-testid="ssr-title">SSR ClientOnly</h1>
 
     {/* JSX children are built eagerly, so `window` access needs the function form. */}
-    <ClientOnly fallback={<p data-testid="client-only-fallback">Loading widget...</p>}>
+    <ClientOnly fallback={<ClientOnlyFallback />}>
       {() => <p data-testid="client-only-content">Client path: {clientPath()}</p>}
     </ClientOnly>
+
+    <Link data-testid="leave-link" href="/ssr/page2">
+      Leave
+    </Link>
+    <Link data-testid="revisit-link" href="/ssr/client-only">
+      Revisit
+    </Link>
   </div>
 )

--- a/packages/react/test-app/Pages/SSR/ClientOnly.tsx
+++ b/packages/react/test-app/Pages/SSR/ClientOnly.tsx
@@ -1,0 +1,14 @@
+import { ClientOnly } from '@inertiajs/react'
+
+const clientPath = () => window.location.pathname
+
+export default () => (
+  <div>
+    <h1 data-testid="ssr-title">SSR ClientOnly</h1>
+
+    {/* JSX children are built eagerly, so `window` access needs the function form. */}
+    <ClientOnly fallback={<p data-testid="client-only-fallback">Loading widget...</p>}>
+      {() => <p data-testid="client-only-content">Client path: {clientPath()}</p>}
+    </ClientOnly>
+  </div>
+)

--- a/packages/react/test-app/Pages/SSR/Page1.tsx
+++ b/packages/react/test-app/Pages/SSR/Page1.tsx
@@ -27,6 +27,9 @@ export default ({ user, items, count }: { user: { name: string; email: string };
       <Link href="/ssr/page2" data-testid="navigate-link">
         Navigate to another page
       </Link>
+      <Link href="/ssr/client-only" data-testid="to-client-only-link">
+        Navigate to ClientOnly page
+      </Link>
     </div>
   )
 }

--- a/packages/react/test-app/app.tsx
+++ b/packages/react/test-app/app.tsx
@@ -1,12 +1,14 @@
 import type { HttpClient, HttpClientOptions, Page } from '@inertiajs/core'
 import { axiosAdapter, type VisitOptions } from '@inertiajs/core'
 import { createInertiaApp, router, type ResolvedComponent } from '@inertiajs/react'
-import { createRoot } from 'react-dom/client'
+import { createRoot, hydrateRoot } from 'react-dom/client'
 import AppLayout from './Layouts/AppLayout'
 import DefaultLayout from './Layouts/DefaultLayout'
 
 window.testing = { Inertia: router }
 window.resolverReceivedPage = null as Page | null
+window._inertia_client_only_fallback_renders = 0
+window._inertia_client_only_child_mounts = 0
 
 const params = new URLSearchParams(window.location.search)
 
@@ -42,7 +44,13 @@ createInertiaApp({
     return pages[`./Pages/${name}.tsx`]
   },
   setup({ el, App, props }) {
-    createRoot(el).render(<App {...props} />)
+    const appElement = <App {...props} />
+
+    if (el.hasAttribute('data-server-rendered')) {
+      hydrateRoot(el, appElement)
+    } else {
+      createRoot(el).render(appElement)
+    }
   },
   progress: {
     delay: 0,

--- a/packages/react/test-app/types.d.ts
+++ b/packages/react/test-app/types.d.ts
@@ -26,6 +26,8 @@ declare global {
     _inertia_content_layout_id: string | undefined
     _plugin_global_props: object
     resolverReceivedPage: Page | null
+    _inertia_client_only_fallback_renders: number | undefined
+    _inertia_client_only_child_mounts: number | undefined
   }
 
   interface ImportMeta {

--- a/packages/svelte/src/components/App.svelte
+++ b/packages/svelte/src/components/App.svelte
@@ -11,8 +11,9 @@
 </script>
 
 <script lang="ts">
-  import { isPropsObjectOrCallback, isPropsObject, normalizeLayouts } from '@inertiajs/core'
+  import { isPropsObjectOrCallback, isPropsObject, markClientRendered, normalizeLayouts } from '@inertiajs/core'
   import { router } from '@inertiajs/core'
+  import { onMount } from 'svelte'
   import type { Component } from 'svelte'
   import { resetLayoutProps, storeState } from '../layoutProps.svelte'
   import { setPage } from '../page.svelte'
@@ -48,6 +49,8 @@
   const isServer = typeof window === 'undefined'
 
   if (!isServer) {
+    onMount(() => markClientRendered())
+
     // svelte-ignore state_referenced_locally
     router.init<ResolvedComponent>({
       initialPage,

--- a/packages/svelte/src/components/ClientOnly.svelte
+++ b/packages/svelte/src/components/ClientOnly.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { canRenderClientOnly } from '@inertiajs/core'
+
   interface Props {
     children?: import('svelte').Snippet
     fallback?: import('svelte').Snippet
@@ -6,9 +8,15 @@
 
   let { children, fallback }: Props = $props()
 
-  // Not a `typeof window` check: the client's first render must match the server's
-  // HTML, so the swap has to wait for mount.
-  let mounted = $state(false)
+  // `ClientOnly` renders `fallback` on its first render if and only if that render is
+  // part of an SSR hydration pass for the current document. In every other case -- a
+  // pure client-rendered boot, and every instance created after the initial hydration
+  // commit (including after ordinary page remounts) -- it renders `children` on its
+  // very first render. Local per-instance state can't express this: a remount creates
+  // a new instance that restarts at "not mounted", so the "have we passed hydration"
+  // signal has to live outside any single component instance (see `@inertiajs/core`'s
+  // `hydrationBoot`).
+  let mounted = $state(canRenderClientOnly())
 
   $effect(() => {
     mounted = true

--- a/packages/svelte/src/components/ClientOnly.svelte
+++ b/packages/svelte/src/components/ClientOnly.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  interface Props {
+    children?: import('svelte').Snippet
+    fallback?: import('svelte').Snippet
+  }
+
+  let { children, fallback }: Props = $props()
+
+  // Not a `typeof window` check: the client's first render must match the server's
+  // HTML, so the swap has to wait for mount.
+  let mounted = $state(false)
+
+  $effect(() => {
+    mounted = true
+  })
+</script>
+
+{#if mounted}
+  {@render children?.()}
+{:else}
+  {@render fallback?.()}
+{/if}

--- a/packages/svelte/src/createInertiaApp.ts
+++ b/packages/svelte/src/createInertiaApp.ts
@@ -6,6 +6,7 @@ import {
   http as httpModule,
   resolveServerHead,
   router,
+  setHydrationBoot,
   setupProgress,
   type CreateInertiaAppOptions,
   type CreateInertiaAppOptionsForCSR,
@@ -189,6 +190,9 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
 
   // CSR
   const target = document.getElementById(id)!
+  const isServerRendered = target.hasAttribute('data-server-rendered')
+
+  setHydrationBoot(isServerRendered)
 
   if (setup) {
     await setup({ el: target, App, props })
@@ -199,7 +203,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
       withApp(context, { ssr: false, page: initialPage })
     }
 
-    if (target.hasAttribute('data-server-rendered')) {
+    if (isServerRendered) {
       hydrate(App, { target, props, context })
     } else {
       mount(App, { target, props, context })

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -3,6 +3,7 @@ import type { SvelteInertiaAppConfig } from './types'
 
 export { http, progress, router } from '@inertiajs/core'
 export { default as App } from './components/App.svelte'
+export { default as ClientOnly } from './components/ClientOnly.svelte'
 export { createForm } from './components/createForm'
 export { default as Deferred } from './components/Deferred.svelte'
 export { default as Form } from './components/Form.svelte'

--- a/packages/svelte/test-app/Components/ClientOnlyChild.svelte
+++ b/packages/svelte/test-app/Components/ClientOnlyChild.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  let status = $state<'pending' | 'ready'>('pending')
+  let count = $state(0)
+
+  onMount(() => {
+    window._inertia_client_only_child_mounts = (window._inertia_client_only_child_mounts || 0) + 1
+
+    const timer = setTimeout(() => {
+      status = 'ready'
+    }, 100)
+
+    return () => clearTimeout(timer)
+  })
+</script>
+
+<div>
+  <span data-testid="child-status">{status}</span>
+  <span data-testid="child-count">{count}</span>
+  <button data-testid="child-increment" onclick={() => count++}>Increment</button>
+</div>

--- a/packages/svelte/test-app/Components/ClientOnlyFallback.svelte
+++ b/packages/svelte/test-app/Components/ClientOnlyFallback.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  // Increments in the top-level script (not an $effect) because the fallback can be
+  // unmounted in the same commit it's created in -- an $effect might never get to fire.
+  if (typeof window !== 'undefined') {
+    window._inertia_client_only_fallback_renders = (window._inertia_client_only_fallback_renders || 0) + 1
+  }
+</script>
+
+<p data-testid="client-only-fallback">Loading widget...</p>

--- a/packages/svelte/test-app/Pages/ClientOnly.svelte
+++ b/packages/svelte/test-app/Pages/ClientOnly.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { ClientOnly } from '@inertiajs/svelte'
+  import { ClientOnly, inertia } from '@inertiajs/svelte'
+  import ClientOnlyChild from '@/Components/ClientOnlyChild.svelte'
+  import ClientOnlyFallback from '@/Components/ClientOnlyFallback.svelte'
 </script>
 
 <div>
@@ -7,9 +9,16 @@
 
   <ClientOnly>
     {#snippet fallback()}
-      <p data-testid="client-only-fallback">Loading widget...</p>
+      <ClientOnlyFallback />
     {/snippet}
 
     <p data-testid="client-only-content">Client path: /client-only</p>
+    <ClientOnlyChild />
   </ClientOnly>
+
+  <a href="/client-only" use:inertia data-testid="revisit-link">Revisit</a>
+  <a href="/client-only" use:inertia={{ preserveState: true }} data-testid="preserve-state-link">
+    Revisit (preserve state)
+  </a>
+  <a href="/" use:inertia data-testid="leave-link">Leave</a>
 </div>

--- a/packages/svelte/test-app/Pages/ClientOnly.svelte
+++ b/packages/svelte/test-app/Pages/ClientOnly.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { ClientOnly } from '@inertiajs/svelte'
+</script>
+
+<div>
+  <h1 data-testid="title">ClientOnly</h1>
+
+  <ClientOnly>
+    {#snippet fallback()}
+      <p data-testid="client-only-fallback">Loading widget...</p>
+    {/snippet}
+
+    <p data-testid="client-only-content">Client path: /client-only</p>
+  </ClientOnly>
+</div>

--- a/packages/svelte/test-app/Pages/SSR/ClientOnly.svelte
+++ b/packages/svelte/test-app/Pages/SSR/ClientOnly.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ClientOnly } from '@inertiajs/svelte'
+  import { ClientOnly, inertia } from '@inertiajs/svelte'
+  import ClientOnlyFallback from '@/Components/ClientOnlyFallback.svelte'
 
   const clientPath = () => window.location.pathname
 </script>
@@ -9,9 +10,12 @@
 
   <ClientOnly>
     {#snippet fallback()}
-      <p data-testid="client-only-fallback">Loading widget...</p>
+      <ClientOnlyFallback />
     {/snippet}
 
     <p data-testid="client-only-content">Client path: {clientPath()}</p>
   </ClientOnly>
+
+  <a href="/ssr/page2" use:inertia data-testid="leave-link">Leave</a>
+  <a href="/ssr/client-only" use:inertia data-testid="revisit-link">Revisit</a>
 </div>

--- a/packages/svelte/test-app/Pages/SSR/ClientOnly.svelte
+++ b/packages/svelte/test-app/Pages/SSR/ClientOnly.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { ClientOnly } from '@inertiajs/svelte'
+
+  const clientPath = () => window.location.pathname
+</script>
+
+<div>
+  <h1 data-testid="ssr-title">SSR ClientOnly</h1>
+
+  <ClientOnly>
+    {#snippet fallback()}
+      <p data-testid="client-only-fallback">Loading widget...</p>
+    {/snippet}
+
+    <p data-testid="client-only-content">Client path: {clientPath()}</p>
+  </ClientOnly>
+</div>

--- a/packages/svelte/test-app/Pages/SSR/Page1.svelte
+++ b/packages/svelte/test-app/Pages/SSR/Page1.svelte
@@ -31,4 +31,5 @@
   <p data-testid="count">Count: {count}</p>
 
   <a href="/ssr/page2" use:inertia data-testid="navigate-link">Navigate to another page</a>
+  <a href="/ssr/client-only" use:inertia data-testid="to-client-only-link">Navigate to ClientOnly page</a>
 </div>

--- a/packages/svelte/test-app/app.ts
+++ b/packages/svelte/test-app/app.ts
@@ -7,6 +7,8 @@ import DefaultLayout from './Layouts/DefaultLayout.svelte'
 
 window.testing = { Inertia: router }
 window.resolverReceivedPage = null as Page | null
+window._inertia_client_only_fallback_renders = 0
+window._inertia_client_only_child_mounts = 0
 
 const params = new URLSearchParams(window.location.search)
 

--- a/packages/svelte/test-app/types.d.ts
+++ b/packages/svelte/test-app/types.d.ts
@@ -27,6 +27,8 @@ declare global {
     _inertia_content_layout_id: string | undefined
     _plugin_global_props: object
     resolverReceivedPage: Page | null
+    _inertia_client_only_fallback_renders: number | undefined
+    _inertia_client_only_child_mounts: number | undefined
   }
 
   interface ImportMeta {

--- a/packages/vue3/src/app.ts
+++ b/packages/vue3/src/app.ts
@@ -5,6 +5,7 @@ import {
   HeadManagerTitleCallback,
   isPropsObject,
   isPropsObjectOrCallback,
+  markClientRendered,
   normalizeLayouts,
   Page,
   PageProps,
@@ -20,6 +21,7 @@ import {
   defineComponent,
   h,
   markRaw,
+  onMounted,
   Plugin,
   PropType,
   reactive,
@@ -141,6 +143,8 @@ const App: InertiaApp = defineComponent({
     )
 
     if (!isServer) {
+      onMounted(() => markClientRendered())
+
       router.init<DefineComponent>({
         initialPage,
         resolveComponent: resolveComponent!,

--- a/packages/vue3/src/clientOnly.ts
+++ b/packages/vue3/src/clientOnly.ts
@@ -1,3 +1,4 @@
+import { canRenderClientOnly } from '@inertiajs/core'
 import { defineComponent, Fragment, h, onMounted, ref, type SlotsType } from 'vue'
 
 export default defineComponent({
@@ -7,9 +8,15 @@ export default defineComponent({
     fallback: {}
   }>,
   setup(_, { slots }) {
-    // Not a `typeof window` check: the client's first render must match the server's
-    // HTML, so the swap has to wait for mount.
-    const mounted = ref(false)
+    // `ClientOnly` renders the fallback slot on its first render if and only if that
+    // render is part of an SSR hydration pass for the current document. In every other
+    // case -- a pure client-rendered boot, and every instance created after the initial
+    // hydration commit (including after ordinary page remounts) -- it renders the
+    // default slot on its very first render. Local per-instance state can't express
+    // this: a remount creates a new instance that restarts at "not mounted", so the
+    // "have we passed hydration" signal has to live outside any single component
+    // instance (see `@inertiajs/core`'s `hydrationBoot`).
+    const mounted = ref(canRenderClientOnly())
 
     onMounted(() => {
       mounted.value = true

--- a/packages/vue3/src/clientOnly.ts
+++ b/packages/vue3/src/clientOnly.ts
@@ -1,0 +1,26 @@
+import { defineComponent, Fragment, h, onMounted, ref, type SlotsType } from 'vue'
+
+export default defineComponent({
+  name: 'ClientOnly',
+  slots: Object as SlotsType<{
+    default: {}
+    fallback: {}
+  }>,
+  setup(_, { slots }) {
+    // Not a `typeof window` check: the client's first render must match the server's
+    // HTML, so the swap has to wait for mount.
+    const mounted = ref(false)
+
+    onMounted(() => {
+      mounted.value = true
+    })
+
+    return () => {
+      if (!mounted.value) {
+        return h(Fragment, { key: 'fallback' }, slots.fallback?.({}) ?? [])
+      }
+
+      return h(Fragment, { key: 'default' }, slots.default?.({}) ?? [])
+    }
+  },
+})

--- a/packages/vue3/src/createInertiaApp.ts
+++ b/packages/vue3/src/createInertiaApp.ts
@@ -11,6 +11,7 @@ import {
   Page,
   PageProps,
   router,
+  setHydrationBoot,
   setupProgress,
   SharedPageProps,
 } from '@inertiajs/core'
@@ -200,6 +201,9 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     }
 
     const el = document.getElementById(id)!
+    const isServerRendered = el.hasAttribute('data-server-rendered')
+
+    setHydrationBoot(isServerRendered)
 
     if (setup) {
       return (setup as (options: SetupOptions<HTMLElement, SharedProps>) => void)({
@@ -211,7 +215,7 @@ export default async function createInertiaApp<SharedProps extends PageProps = P
     }
 
     // Default mounting when setup is not provided
-    if (el.hasAttribute('data-server-rendered')) {
+    if (isServerRendered) {
       const app = createSSRApp({ render: () => h(App, props) })
       app.use(plugin)
 

--- a/packages/vue3/src/index.ts
+++ b/packages/vue3/src/index.ts
@@ -3,6 +3,7 @@ import type { VueInertiaAppConfig } from './types'
 
 export { http, progress, router } from '@inertiajs/core'
 export { default as App, usePage } from './app'
+export { default as ClientOnly } from './clientOnly'
 export { default as createInertiaApp } from './createInertiaApp'
 export { default as Deferred } from './deferred'
 export { createForm, default as Form, useFormContext } from './form'

--- a/packages/vue3/test-app/Components/ClientOnlyChild.vue
+++ b/packages/vue3/test-app/Components/ClientOnlyChild.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+
+const status = ref<'pending' | 'ready'>('pending')
+const count = ref(0)
+
+let timer: ReturnType<typeof setTimeout>
+
+onMounted(() => {
+  window._inertia_client_only_child_mounts = (window._inertia_client_only_child_mounts || 0) + 1
+
+  timer = setTimeout(() => {
+    status.value = 'ready'
+  }, 100)
+})
+
+onUnmounted(() => {
+  clearTimeout(timer)
+})
+</script>
+
+<template>
+  <div>
+    <span data-testid="child-status">{{ status }}</span>
+    <span data-testid="child-count">{{ count }}</span>
+    <button data-testid="child-increment" @click="count++">Increment</button>
+  </div>
+</template>

--- a/packages/vue3/test-app/Components/ClientOnlyFallback.vue
+++ b/packages/vue3/test-app/Components/ClientOnlyFallback.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+// Increments in setup() (not onMounted) because the fallback can be unmounted
+// in the same commit it's created in -- onMounted might never get the chance to fire.
+if (typeof window !== 'undefined') {
+  window._inertia_client_only_fallback_renders = (window._inertia_client_only_fallback_renders || 0) + 1
+}
+</script>
+
+<template>
+  <p data-testid="client-only-fallback">Loading widget...</p>
+</template>

--- a/packages/vue3/test-app/Pages/ClientOnly.vue
+++ b/packages/vue3/test-app/Pages/ClientOnly.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { ClientOnly } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <div>
+    <h1 data-testid="title">ClientOnly</h1>
+
+    <ClientOnly>
+      <template #fallback>
+        <p data-testid="client-only-fallback">Loading widget...</p>
+      </template>
+
+      <p data-testid="client-only-content">Client path: /client-only</p>
+    </ClientOnly>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/ClientOnly.vue
+++ b/packages/vue3/test-app/Pages/ClientOnly.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { ClientOnly } from '@inertiajs/vue3'
+import { ClientOnly, Link } from '@inertiajs/vue3'
+import ClientOnlyChild from '@/Components/ClientOnlyChild.vue'
+import ClientOnlyFallback from '@/Components/ClientOnlyFallback.vue'
 </script>
 
 <template>
@@ -8,10 +10,15 @@ import { ClientOnly } from '@inertiajs/vue3'
 
     <ClientOnly>
       <template #fallback>
-        <p data-testid="client-only-fallback">Loading widget...</p>
+        <ClientOnlyFallback />
       </template>
 
       <p data-testid="client-only-content">Client path: /client-only</p>
+      <ClientOnlyChild />
     </ClientOnly>
+
+    <Link data-testid="revisit-link" href="/client-only">Revisit</Link>
+    <Link data-testid="preserve-state-link" href="/client-only" preserve-state>Revisit (preserve state)</Link>
+    <Link data-testid="leave-link" href="/">Leave</Link>
   </div>
 </template>

--- a/packages/vue3/test-app/Pages/SSR/ClientOnly.vue
+++ b/packages/vue3/test-app/Pages/SSR/ClientOnly.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ClientOnly } from '@inertiajs/vue3'
+import { ClientOnly, Link } from '@inertiajs/vue3'
+import ClientOnlyFallback from '@/Components/ClientOnlyFallback.vue'
 
 const clientPath = () => window.location.pathname
 </script>
@@ -10,10 +11,13 @@ const clientPath = () => window.location.pathname
 
     <ClientOnly>
       <template #fallback>
-        <p data-testid="client-only-fallback">Loading widget...</p>
+        <ClientOnlyFallback />
       </template>
 
       <p data-testid="client-only-content">Client path: {{ clientPath() }}</p>
     </ClientOnly>
+
+    <Link data-testid="leave-link" href="/ssr/page2">Leave</Link>
+    <Link data-testid="revisit-link" href="/ssr/client-only">Revisit</Link>
   </div>
 </template>

--- a/packages/vue3/test-app/Pages/SSR/ClientOnly.vue
+++ b/packages/vue3/test-app/Pages/SSR/ClientOnly.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { ClientOnly } from '@inertiajs/vue3'
+
+const clientPath = () => window.location.pathname
+</script>
+
+<template>
+  <div>
+    <h1 data-testid="ssr-title">SSR ClientOnly</h1>
+
+    <ClientOnly>
+      <template #fallback>
+        <p data-testid="client-only-fallback">Loading widget...</p>
+      </template>
+
+      <p data-testid="client-only-content">Client path: {{ clientPath() }}</p>
+    </ClientOnly>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/SSR/Page1.vue
+++ b/packages/vue3/test-app/Pages/SSR/Page1.vue
@@ -31,5 +31,6 @@ const page = usePage()
     <p data-testid="count">Count: {{ count }}</p>
 
     <Link href="/ssr/page2" data-testid="navigate-link">Navigate to another page</Link>
+    <Link href="/ssr/client-only" data-testid="to-client-only-link">Navigate to ClientOnly page</Link>
   </div>
 </template>

--- a/packages/vue3/test-app/app.ts
+++ b/packages/vue3/test-app/app.ts
@@ -2,12 +2,14 @@ import type { HttpClient, HttpClientOptions, Page } from '@inertiajs/core'
 import { axiosAdapter, type VisitOptions } from '@inertiajs/core'
 import { createInertiaApp, router } from '@inertiajs/vue3'
 import type { DefineComponent } from 'vue'
-import { createApp, h } from 'vue'
+import { createApp, createSSRApp, h } from 'vue'
 import AppLayout from './Layouts/AppLayout.vue'
 import DefaultLayout from './Layouts/DefaultLayout.vue'
 
 window.testing = { Inertia: router }
 window.resolverReceivedPage = null as Page | null
+window._inertia_client_only_fallback_renders = 0
+window._inertia_client_only_child_mounts = 0
 
 const params = new URLSearchParams(window.location.search)
 
@@ -43,7 +45,9 @@ createInertiaApp({
     return pages[`./Pages/${name}.vue`]
   },
   setup({ el, App, props, plugin }) {
-    const inst = createApp({ render: () => h(App, props) })
+    const inst = el.hasAttribute('data-server-rendered')
+      ? createSSRApp({ render: () => h(App, props) })
+      : createApp({ render: () => h(App, props) })
 
     if (!window.location.pathname.startsWith('/plugin/without')) {
       inst.use(plugin)

--- a/packages/vue3/test-app/types.d.ts
+++ b/packages/vue3/test-app/types.d.ts
@@ -26,6 +26,8 @@ declare global {
     _inertia_content_layout_id: string | undefined
     _plugin_global_props: object
     resolverReceivedPage: Page | null
+    _inertia_client_only_fallback_renders: number | undefined
+    _inertia_client_only_child_mounts: number | undefined
   }
 
   interface ImportMeta {

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -75,6 +75,13 @@ app.get('/ssr/page2', (req, res) =>
   }),
 )
 
+app.get('/ssr/client-only', (req, res) =>
+  inertia.renderSSR(req, res, {
+    component: 'SSR/ClientOnly',
+    props: {},
+  }),
+)
+
 app.get('/ssr/page-with-script-element', (req, res) =>
   inertia.renderSSR(req, res, {
     component: 'SSR/PageWithScriptElement',
@@ -177,6 +184,13 @@ app.get('/ssr/infinite-scroll', (req, res) => {
     scrollProps: { users: scrollProp },
   })
 })
+
+app.get('/client-only', (req, res) =>
+  inertia.render(req, res, {
+    component: 'ClientOnly',
+    props: {},
+  }),
+)
 
 // createInertiaApp (unified) test routes
 app.get('/unified', (req, res) =>

--- a/tests/client-only.spec.ts
+++ b/tests/client-only.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test'
+import { consoleMessages } from './support'
+
+test.describe('ClientOnly', () => {
+  test('it renders the children once mounted', async ({ page }) => {
+    consoleMessages.listen(page)
+
+    await page.goto('/client-only')
+
+    await expect(page.getByTestId('client-only-content')).toHaveText('Client path: /client-only')
+    await expect(page.getByTestId('client-only-fallback')).toHaveCount(0)
+
+    expect(consoleMessages.errors).toHaveLength(0)
+  })
+
+  test('it renders the children again after navigating back to the page', async ({ page }) => {
+    await page.goto('/client-only')
+    await expect(page.getByTestId('client-only-content')).toBeVisible()
+
+    await page.goto('/dump/get')
+    await page.goBack()
+
+    await expect(page.getByTestId('client-only-content')).toHaveText('Client path: /client-only')
+    await expect(page.getByTestId('client-only-fallback')).toHaveCount(0)
+  })
+})

--- a/tests/client-only.spec.ts
+++ b/tests/client-only.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { consoleMessages } from './support'
+import { clickLinkAndGoBack, clientOnlyProbe, consoleMessages, pageLoads } from './support'
 
 test.describe('ClientOnly', () => {
   test('it renders the children once mounted', async ({ page }) => {
@@ -7,8 +7,9 @@ test.describe('ClientOnly', () => {
 
     await page.goto('/client-only')
 
-    await expect(page.getByTestId('client-only-content')).toHaveText('Client path: /client-only')
-    await expect(page.getByTestId('client-only-fallback')).toHaveCount(0)
+    // A pure CSR app should never render the fallback at all -- there is no
+    // hydration pass to guard against.
+    await clientOnlyProbe.expectRendered(page, 'Client path: /client-only')
 
     expect(consoleMessages.errors).toHaveLength(0)
   })
@@ -20,7 +21,77 @@ test.describe('ClientOnly', () => {
     await page.goto('/dump/get')
     await page.goBack()
 
+    await clientOnlyProbe.expectRendered(page, 'Client path: /client-only')
+  })
+
+  test('revisiting the same page never shows the fallback', async ({ page }) => {
+    pageLoads.watch(page, 1)
+
+    await page.goto('/client-only')
+    await clientOnlyProbe.reset(page)
+
+    await page.getByTestId('revisit-link').click()
+
+    await clientOnlyProbe.expectRendered(page, 'Client path: /client-only')
+
+    // Confirm this was a real SPA navigation, not a full document reload.
+    expect(pageLoads.count).toBe(1)
+  })
+
+  test('navigating away and back never re-shows the fallback', async ({ page }) => {
+    pageLoads.watch(page, 1)
+
+    await page.goto('/client-only')
+    await clientOnlyProbe.reset(page)
+
+    await clickLinkAndGoBack(page, 'leave-link', () =>
+      expect(page.getByText('This is the Test App Entrypoint page')).toBeVisible(),
+    )
+
+    await clientOnlyProbe.expectRendered(page, 'Client path: /client-only')
+
+    // Confirm this was a real SPA navigation, not a full document reload.
+    expect(pageLoads.count).toBe(1)
+  })
+
+  test('a preserveState visit keeps the ClientOnly child subtree mounted', async ({ page }) => {
+    await page.goto('/client-only')
+    await expect(page.getByTestId('child-status')).toHaveText('ready')
+    await clientOnlyProbe.reset(page)
+
+    await page.getByTestId('child-increment').click()
+    await expect(page.getByTestId('child-count')).toHaveText('1')
+
+    await page.getByTestId('preserve-state-link').click()
     await expect(page.getByTestId('client-only-content')).toHaveText('Client path: /client-only')
-    await expect(page.getByTestId('client-only-fallback')).toHaveCount(0)
+
+    // The subtree was never destroyed, so local state and the mount count are unchanged.
+    await expect(page.getByTestId('child-count')).toHaveText('1')
+    expect(await clientOnlyProbe.childMounts(page)).toBe(0)
+    expect(await clientOnlyProbe.fallbackRenders(page)).toBe(0)
+  })
+
+  test('an ordinary revisit remounts the child but never shows the fallback', async ({ page }) => {
+    pageLoads.watch(page, 1)
+
+    await page.goto('/client-only')
+    await expect(page.getByTestId('child-status')).toHaveText('ready')
+    await clientOnlyProbe.reset(page)
+
+    await page.getByTestId('child-increment').click()
+    await expect(page.getByTestId('child-count')).toHaveText('1')
+
+    // This is a page-keying remount, not a ClientOnly bug -- the fix only prevents
+    // the fallback from reappearing, it does not (and should not) prevent the remount.
+    await page.getByTestId('revisit-link').click()
+    await expect(page.getByTestId('client-only-content')).toHaveText('Client path: /client-only')
+
+    await expect(page.getByTestId('child-count')).toHaveText('0')
+    expect(await clientOnlyProbe.childMounts(page)).toBe(1)
+    expect(await clientOnlyProbe.fallbackRenders(page)).toBe(0)
+    await expect(page.getByTestId('child-status')).toHaveText('ready')
+
+    // Confirm this was a real SPA navigation, not a full document reload.
+    expect(pageLoads.count).toBe(1)
   })
 })

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { consoleMessages, pageLoads } from './support'
+import { clickLinkAndGoBack, clientOnlyProbe, consoleMessages, pageLoads } from './support'
 
 const SSR_SERVER_PORT = 13714
 const SSR_AUTO_PORTS: Record<string, number> = { vue3: 13718, react: 13719, svelte: 13720 }
@@ -103,12 +103,67 @@ test.describe('SSR ClientOnly', () => {
 
     await page.goto('/ssr/client-only')
 
-    await expect(page.getByTestId('client-only-content')).toHaveText('Client path: /ssr/client-only')
-    await expect(page.getByTestId('client-only-fallback')).toHaveCount(0)
+    // Rendered exactly once, during the hydration pass -- never again afterwards.
+    await clientOnlyProbe.expectRendered(page, 'Client path: /ssr/client-only', 1)
 
     const hydrationErrors = consoleMessages.messages.filter((msg) => msg.includes('Hydration'))
     expect(hydrationErrors).toHaveLength(0)
     expect(consoleMessages.errors).toHaveLength(0)
+  })
+
+  test('the fallback never re-renders after navigating away and back', async ({ page }) => {
+    consoleMessages.listen(page)
+    pageLoads.watch(page, 1)
+
+    await page.goto('/ssr/client-only')
+    await expect(page.getByTestId('client-only-content')).toBeVisible()
+    await clientOnlyProbe.reset(page)
+
+    await clickLinkAndGoBack(page, 'leave-link', () => expect(page.getByTestId('ssr-title')).toHaveText('SSR Page 2'))
+
+    await clientOnlyProbe.expectRendered(page, 'Client path: /ssr/client-only')
+
+    expect(consoleMessages.errors).toHaveLength(0)
+    expect(pageLoads.count).toBe(1)
+  })
+
+  test('the fallback never re-renders after revisiting the same page', async ({ page }) => {
+    consoleMessages.listen(page)
+    pageLoads.watch(page, 1)
+
+    await page.goto('/ssr/client-only')
+    await expect(page.getByTestId('client-only-content')).toBeVisible()
+    await clientOnlyProbe.reset(page)
+
+    await page.getByTestId('revisit-link').click()
+
+    await clientOnlyProbe.expectRendered(page, 'Client path: /ssr/client-only')
+
+    expect(consoleMessages.errors).toHaveLength(0)
+    expect(pageLoads.count).toBe(1)
+  })
+
+  test('the fallback never shows on first SPA navigation to a ClientOnly page from an SSR page with no ClientOnly', async ({
+    page,
+  }) => {
+    consoleMessages.listen(page)
+    pageLoads.watch(page, 1)
+
+    // Land on an SSR-hydrated page that contains no ClientOnly at all. Nothing here
+    // ever calls markClientRendered() via a ClientOnly mount, since there is no
+    // ClientOnly instance on this page -- "hydration is over" must still get recorded
+    // some other way, or the next ClientOnly encountered anywhere in the SPA will
+    // wrongly think it's still in the middle of a hydration pass.
+    await page.goto('/ssr/page1')
+    await expect(page.getByTestId('ssr-title')).toHaveText('SSR Page 1')
+
+    await page.getByTestId('to-client-only-link').click()
+
+    await clientOnlyProbe.expectRendered(page, 'Client path: /ssr/client-only')
+
+    expect(consoleMessages.errors).toHaveLength(0)
+    // Confirm this was a real SPA navigation, not a full document reload.
+    expect(pageLoads.count).toBe(1)
   })
 })
 

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -89,6 +89,29 @@ test.describe('SSR', () => {
   })
 })
 
+test.describe('SSR ClientOnly', () => {
+  test('it renders the fallback instead of the children on the server', async ({ page }) => {
+    const response = await page.request.get('/ssr/client-only')
+    const html = await response.text()
+
+    expect(html).toContain('Loading widget...')
+    expect(html).not.toContain('Client path:')
+  })
+
+  test('it swaps the fallback for the children after hydration', async ({ page }) => {
+    consoleMessages.listen(page)
+
+    await page.goto('/ssr/client-only')
+
+    await expect(page.getByTestId('client-only-content')).toHaveText('Client path: /ssr/client-only')
+    await expect(page.getByTestId('client-only-fallback')).toHaveCount(0)
+
+    const hydrationErrors = consoleMessages.messages.filter((msg) => msg.includes('Hydration'))
+    expect(hydrationErrors).toHaveLength(0)
+    expect(consoleMessages.errors).toHaveLength(0)
+  })
+})
+
 test.describe('Head title escaping', () => {
   test.beforeEach(() => {
     test.skip(process.env.PACKAGE === 'svelte', 'Svelte adapter has no Head component')

--- a/tests/support.ts
+++ b/tests/support.ts
@@ -112,3 +112,42 @@ export const waitForFragmentScroll = async (page: Page) => {
   // Give time for the scroll animation to complete
   await page.waitForTimeout(200)
 }
+
+export const clientOnlyProbe = {
+  async reset(page: Page) {
+    await page.evaluate(() => {
+      window._inertia_client_only_fallback_renders = 0
+      window._inertia_client_only_child_mounts = 0
+    })
+  },
+
+  async fallbackRenders(page: Page) {
+    return page.evaluate(() => window._inertia_client_only_fallback_renders)
+  },
+
+  async childMounts(page: Page) {
+    return page.evaluate(() => window._inertia_client_only_child_mounts)
+  },
+
+  // Asserts the ClientOnly content is showing, the fallback is gone from the DOM, and
+  // the fallback was rendered exactly `expectedFallbackRenders` times (0 unless this is
+  // the genuine SSR hydration pass, where it's rendered exactly once).
+  async expectRendered(page: Page, expectedText: string, expectedFallbackRenders = 0) {
+    await expect(page.getByTestId('client-only-content')).toHaveText(expectedText)
+    await expect(page.getByTestId('client-only-fallback')).toHaveCount(0)
+    expect(await this.fallbackRenders(page)).toBe(expectedFallbackRenders)
+  },
+}
+
+// Clicks a link that navigates away, waits for the destination to actually land, then
+// goes back -- waiting first avoids racing goBack() against the pending visit, which
+// can confuse the resulting history state.
+export const clickLinkAndGoBack = async (
+  page: Page,
+  linkTestId: string,
+  waitForDestination: () => Promise<unknown>,
+) => {
+  await page.getByTestId(linkTestId).click()
+  await waitForDestination()
+  await page.goBack()
+}


### PR DESCRIPTION
Adds a `ClientOnly` component to the React, Vue and Svelte adapters, addressing the request in discussion #1722 (open since 2023, 9 upvotes).

## The problem

Under SSR, any component that touches `window` or `document` while rendering crashes the render the recurring "`document is not defined`" / "`window is not defined`" class of report (#1089, and #3021 was this same problem inside `WhenVisible`). Plenty of third-party widgets charts, maps, editors, anything measuring the viewport simply cannot run on the server.

Today the options are:

- **Disable SSR for the whole page** via `inertia.ssr.enabled` (the recommendation in discussion #1429). Works, but it is per-endpoint and all-or-nothing you lose server rendering for the entire page to accommodate one widget.
- **Lean on `Deferred`.** A deferred prop is absent during SSR, so the fallback renders on the server and the children render once the prop arrives. This produces the right visible shape, but it requires inventing a deferred prop you may not otherwise want and it costs an HTTP round-trip to render something that needs no server data at all.

Neither lets you keep SSR for the page and carve out one subtree.

## The component

```jsx
// React
<ClientOnly fallback={<p>Loading chart...</p>}>
  {() => <Chart width={window.innerWidth} />}
</ClientOnly>
```

```vue
<!-- Vue -->
<ClientOnly>
  <Chart />
  <template #fallback><p>Loading chart...</p></template>
</ClientOnly>
```

```svelte
<!-- Svelte -->
<ClientOnly>
  <Chart />
  {#snippet fallback()}<p>Loading chart...</p>{/snippet}
</ClientOnly>
```

The children render only after the component has mounted in the browser; the `fallback` renders during SSR and during the initial hydration render.

The one design point worth calling out: this is a **mount flag, not a `typeof window` check**. On the client the first render is a hydration of the server's HTML, so gating on `window` alone would render the children immediately and mismatch. Waiting for mount keeps both renders identical. The tests assert no hydration errors to hold that in place.

## API

I followed the existing adapter conventions rather than Nuxt's naming:

- **`fallback`** - matches `Deferred` and `WhenVisible`, rather than introducing `placeholder` as a third name for the same concept.
- **No `fallbackTag` / `placeholderTag`.** Nuxt needs those because its `placeholder` is a plain string; a slot/snippet already covers it here.

In React, `children` accepts either a node or a function. The function form matters because JSX children are built eagerly, so inline `window` access would still execute on the server. Vue slots and Svelte snippets are already lazy, so they need no equivalent.

## Scope - what this does not do

Nuxt's `ClientOnly` also **tree-shakes the wrapped component out of the server build**, so its code never reaches the server. This implementation is runtime-only: the children's module is still imported server-side, it just isn't rendered. That is sufficient for the `window`/`document` access case in #1722, but it will **not** strip a heavy or server-incompatible dependency from the SSR bundle. Worth being explicit about, since the name invites the comparison.

## Tests

Per CONTRIBUTING, the same pages exist in all three test apps and the Playwright specs are shared:

- `tests/client-only.spec.ts` - client-rendered path: children render after mount, and again after back-navigation.
- `tests/ssr.spec.ts` - SSR path: the server HTML contains the fallback and **not** the children, then the children replace it after hydration with no hydration errors and no console errors.

Both cover React, Vue and Svelte. The React non-SSR page uses the plain-node `children` form and the SSR page uses the function form, so both branches of the React API are exercised.

Verified locally:

| Adapter | `pnpm test:*` | `pnpm test:ssr:*` |
| --- | --- | --- |
| React | 1177 passed | 69 passed |
| Vue | 1183 passed | 69 passed |
| Svelte | 1142 passed | 63 passed |

`oxfmt --check`, `oxlint`, `tsc` / `vue-tsc` / `svelte-check`, the ES2022 check and all package builds are clean.

One note on the Svelte suite: `infinite-scroll.spec.ts:885` ("Remember state › ... dataset verification") is flaky on my machine it failed twice and then passed, and it also passes on an unmodified `3.x` checkout. It is scroll-restore-after-refresh timing and unrelated to this change, but flagging it in case CI trips on it.

## Why it does not break anything

Purely additive a new component per adapter plus one export line each. No existing file's behaviour changes, and nothing in `packages/core` is touched. Apps that never import `ClientOnly` are unaffected.

## Docs

Happy to open a PR against `inertiajs/docs` if you want this. My initial thought would be a section in `v3/advanced/server-side-rendering.mdx` rather than a new page but I held off until you have had a chance to weigh in on the component itself and which version it should target.
