### PR TITLE
[3.x] Return `polling` state from `usePoll`

### DIFF
--- a/packages/react/src/usePoll.ts
+++ b/packages/react/src/usePoll.ts
@@ -1,5 +1,5 @@
 import { PollOptions, ReloadOptions, router } from '@inertiajs/core'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 export default function usePoll(
   interval: number,
@@ -14,6 +14,8 @@ export default function usePoll(
 
   const pollRef = useRef<ReturnType<typeof router.poll> | null>(null)
 
+  const [polling, setPolling] = useState(options.autoStart ?? true)
+
   useEffect(() => {
     pollRef.current = router.poll(
       interval,
@@ -24,8 +26,19 @@ export default function usePoll(
     return () => pollRef.current?.destroy()
   }, [])
 
+  const stop = useCallback(() => {
+    pollRef.current?.stop()
+    setPolling(false)
+  }, [])
+
+  const start = useCallback(() => {
+    pollRef.current?.start()
+    setPolling(true)
+  }, [])
+
   return {
-    stop: () => pollRef.current?.stop(),
-    start: () => pollRef.current?.start(),
+    stop,
+    start,
+    polling,
   }
 }

--- a/packages/react/test-app/Pages/Poll/HookManual.tsx
+++ b/packages/react/test-app/Pages/Poll/HookManual.tsx
@@ -1,7 +1,7 @@
 import { usePoll } from '@inertiajs/react'
 
 export default () => {
-  const { start, stop } = usePoll(
+  const { start, stop, polling } = usePoll(
     500,
     {
       only: ['custom_prop'],
@@ -18,6 +18,7 @@ export default () => {
     <>
       <button onClick={start}>Start</button>
       <button onClick={stop}>Stop</button>
+      <div>Polling: {polling ? 'yes' : 'no'}</div>
     </>
   )
 }

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -22,7 +22,7 @@ export {
   type InertiaPrecognitiveForm,
 } from './useForm.svelte'
 export { default as useHttp } from './useHttp.svelte'
-export { default as usePoll } from './usePoll'
+export { default as usePoll } from './usePoll.svelte'
 export { default as usePrefetch } from './usePrefetch.svelte'
 export { default as useRemember } from './useRemember.svelte'
 

--- a/packages/svelte/src/usePoll.svelte.ts
+++ b/packages/svelte/src/usePoll.svelte.ts
@@ -9,13 +9,17 @@ export default function usePoll(
     autoStart: true,
   },
 ) {
+  const autoStart = options.autoStart ?? true
+
   const { stop, start, destroy } = router.poll(interval, requestOptions, {
     ...options,
     autoStart: false,
   })
 
+  let polling = $state(autoStart)
+
   onMount(() => {
-    if (options.autoStart ?? true) {
+    if (autoStart) {
       start()
     }
   })
@@ -24,5 +28,17 @@ export default function usePoll(
     destroy()
   })
 
-  return { stop, start }
+  return {
+    get polling() {
+      return polling
+    },
+    stop() {
+      stop()
+      polling = false
+    },
+    start() {
+      start()
+      polling = true
+    },
+  }
 }

--- a/packages/svelte/test-app/Pages/Poll/HookManual.svelte
+++ b/packages/svelte/test-app/Pages/Poll/HookManual.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { usePoll } from '@inertiajs/svelte'
 
-  const { start, stop } = usePoll(
+  const poll = usePoll(
     500,
     {
       only: ['custom_prop'],
@@ -15,5 +15,6 @@
   )
 </script>
 
-<button onclick={() => start()}>Start</button>
-<button onclick={() => stop()}>Stop</button>
+<button onclick={() => poll.start()}>Start</button>
+<button onclick={() => poll.stop()}>Stop</button>
+<div>Polling: {poll.polling ? 'yes' : 'no'}</div>

--- a/packages/vue3/src/usePoll.ts
+++ b/packages/vue3/src/usePoll.ts
@@ -1,5 +1,5 @@
 import { PollOptions, ReloadOptions, router } from '@inertiajs/core'
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, ref, Ref } from 'vue'
 
 export default function usePoll(
   interval: number,
@@ -11,14 +11,19 @@ export default function usePoll(
 ): {
   stop: VoidFunction
   start: VoidFunction
+  polling: Ref<boolean>
 } {
+  const autoStart = options.autoStart ?? true
+
   const { stop, start, destroy } = router.poll(interval, requestOptions, {
     ...options,
     autoStart: false,
   })
 
+  const polling = ref(autoStart)
+
   onMounted(() => {
-    if (options.autoStart ?? true) {
+    if (autoStart) {
       start()
     }
   })
@@ -28,7 +33,14 @@ export default function usePoll(
   })
 
   return {
-    stop,
-    start,
+    polling,
+    stop: () => {
+      stop()
+      polling.value = false
+    },
+    start: () => {
+      start()
+      polling.value = true
+    },
   }
 }

--- a/packages/vue3/test-app/Pages/Poll/HookManual.vue
+++ b/packages/vue3/test-app/Pages/Poll/HookManual.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { usePoll } from '@inertiajs/vue3'
 
-const { start, stop } = usePoll(
+const { start, stop, polling } = usePoll(
   500,
   {
     only: ['custom_prop'],
@@ -18,4 +18,5 @@ const { start, stop } = usePoll(
 <template>
   <button @click="start">Start</button>
   <button @click="stop">Stop</button>
+  <div>Polling: {{ polling ? 'yes' : 'no' }}</div>
 </template>

--- a/tests/poll.spec.ts
+++ b/tests/poll.spec.ts
@@ -86,6 +86,18 @@ manualData.forEach(({ method, url }) => {
   })
 })
 
+test('it exposes whether the poll is running', async ({ page }) => {
+  await page.goto('/poll/hook/manual')
+
+  await expect(page.getByText('Polling: no')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Start' }).click()
+  await expect(page.getByText('Polling: yes')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Stop' }).click()
+  await expect(page.getByText('Polling: no')).toBeVisible()
+})
+
 const setHidden = (page, hidden: boolean) =>
   page.evaluate((hidden) => {
     Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })


### PR DESCRIPTION
The `usePoll` hook now returns a reactive `polling` value next to `start` and `stop`, so you no longer have to track the start/stop state yourself.

```vue
<script setup>
import { usePoll } from '@inertiajs/vue3'

const { start, stop, polling } = usePoll(2000)
</script>

<template>
    <button v-if="polling" @click="stop">Pause updates</button>
    <button v-else @click="start">Resume updates</button>
</template>
```

It reflects whether the poll is running, not whether a request is currently in flight.