### PR TITLE
[3.x] Preserve once props during instant visits

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, isEqual } from 'es-toolkit'
-import { get } from 'es-toolkit/compat'
+import { get, set } from 'es-toolkit/compat'
 import { progress } from '.'
 import { config } from './config'
 import { eventHandler } from './eventHandler'
@@ -28,6 +28,7 @@ import {
   OptimisticCallback,
   Page,
   PageFlashData,
+  PageProps,
   PendingVisit,
   PollOptions,
   PrefetchedResponse,
@@ -639,6 +640,8 @@ export class Router {
 
     const intermediateProps = resolvedPageProps !== null ? { ...resolvedPageProps } : { ...sharedProps }
 
+    const onceProps = this.preserveOncePropsOnInstantVisit(current, intermediateProps)
+
     const intermediatePage: Page = {
       component: visit.component!,
       url: visit.url.pathname + visit.url.search + visit.url.hash,
@@ -652,6 +655,7 @@ export class Router {
       clearHistory: false,
       encryptHistory: current.encryptHistory,
       sharedProps: current.sharedProps,
+      onceProps,
       rememberedState: {},
     }
 
@@ -662,6 +666,34 @@ export class Router {
       viewTransition: visit.viewTransition,
       visitId: visit.id,
     })
+  }
+
+  /**
+   * Once props are remembered client-side, so the placeholder page must preserve their values
+   * and registry. Otherwise the swap discards the value, and an in-flight prefetch that already
+   * claimed the prop resolves with nothing to restore it from.
+   */
+  protected preserveOncePropsOnInstantVisit(current: Page, props: PageProps): Page['onceProps'] {
+    const onceProps: NonNullable<Page['onceProps']> = {}
+
+    Object.entries(current.onceProps ?? {}).forEach(([key, onceProp]) => {
+      if (get(props, onceProp.prop) !== undefined) {
+        // The visit provided its own value, so we can't claim to remember the once prop
+        return
+      }
+
+      const currentValue = get(current.props, onceProp.prop)
+
+      if (currentValue === undefined) {
+        return
+      }
+
+      set(props, onceProp.prop, currentValue)
+
+      onceProps[key] = onceProp
+    })
+
+    return onceProps
   }
 
   protected getPrefetchParams(href: string | URL | UrlMethodPair, options: VisitOptions): ActiveVisit {

--- a/packages/react/test-app/Pages/OnceProps/InstantPageA.tsx
+++ b/packages/react/test-app/Pages/OnceProps/InstantPageA.tsx
@@ -1,0 +1,19 @@
+import { router } from '@inertiajs/react'
+
+const prefetch = (url: string) => router.prefetch(url, { method: 'get' }, {})
+const instantVisit = (url: string) => router.visit(url, { component: 'OnceProps/InstantPageB' })
+
+export default ({ foo, bar }: { foo: string; bar: string }) => {
+  return (
+    <>
+      <p id="foo">Foo: {foo}</p>
+      <p id="bar">Bar: {bar}</p>
+
+      <button onClick={() => prefetch('/once-props/instant/b')}>Prefetch Page B</button>
+      <button onClick={() => instantVisit('/once-props/instant/b')}>Instant visit to Page B</button>
+
+      <button onClick={() => prefetch('/once-props/instant/b?deferred=1')}>Prefetch Deferred Page B</button>
+      <button onClick={() => instantVisit('/once-props/instant/b?deferred=1')}>Instant visit to Deferred Page B</button>
+    </>
+  )
+}

--- a/packages/react/test-app/Pages/OnceProps/InstantPageB.tsx
+++ b/packages/react/test-app/Pages/OnceProps/InstantPageB.tsx
@@ -1,0 +1,21 @@
+import { Deferred, usePage } from '@inertiajs/react'
+
+const Foo = () => {
+  const { foo } = usePage<{ foo?: string }>().props
+
+  return <>{foo}</>
+}
+
+export default ({ bar }: { bar?: string }) => {
+  return (
+    <>
+      <Deferred data="foo" fallback={<div>Loading foo...</div>}>
+        <p id="foo">
+          Foo: <Foo />
+        </p>
+      </Deferred>
+
+      <p id="bar">Bar: {bar}</p>
+    </>
+  )
+}

--- a/packages/svelte/test-app/Pages/OnceProps/InstantPageA.svelte
+++ b/packages/svelte/test-app/Pages/OnceProps/InstantPageA.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { router } from '@inertiajs/svelte'
+
+  interface Props {
+    foo: string
+    bar: string
+  }
+
+  let { foo, bar }: Props = $props()
+
+  const prefetch = (url: string) => router.prefetch(url, { method: 'get' }, {})
+  const instantVisit = (url: string) => router.visit(url, { component: 'OnceProps/InstantPageB' })
+</script>
+
+<p id="foo">Foo: {foo}</p>
+<p id="bar">Bar: {bar}</p>
+
+<button onclick={() => prefetch('/once-props/instant/b')}>Prefetch Page B</button>
+<button onclick={() => instantVisit('/once-props/instant/b')}>Instant visit to Page B</button>
+
+<button onclick={() => prefetch('/once-props/instant/b?deferred=1')}>Prefetch Deferred Page B</button>
+<button onclick={() => instantVisit('/once-props/instant/b?deferred=1')}>Instant visit to Deferred Page B</button>

--- a/packages/svelte/test-app/Pages/OnceProps/InstantPageB.svelte
+++ b/packages/svelte/test-app/Pages/OnceProps/InstantPageB.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { Deferred } from '@inertiajs/svelte'
+
+  interface Props {
+    foo: string | undefined
+    bar: string | undefined
+  }
+
+  let { foo, bar }: Props = $props()
+</script>
+
+<Deferred data="foo">
+  {#snippet fallback()}
+    <div>Loading foo...</div>
+  {/snippet}
+
+  <p id="foo">Foo: {foo}</p>
+</Deferred>
+
+<p id="bar">Bar: {bar}</p>

--- a/packages/vue3/test-app/Pages/OnceProps/InstantPageA.vue
+++ b/packages/vue3/test-app/Pages/OnceProps/InstantPageA.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3'
+
+defineProps<{ foo: string; bar: string }>()
+
+const prefetch = (url: string) => router.prefetch(url, { method: 'get' }, {})
+const instantVisit = (url: string) => router.visit(url, { component: 'OnceProps/InstantPageB' })
+</script>
+
+<template>
+  <p id="foo">Foo: {{ foo }}</p>
+  <p id="bar">Bar: {{ bar }}</p>
+
+  <button @click="prefetch('/once-props/instant/b')">Prefetch Page B</button>
+  <button @click="instantVisit('/once-props/instant/b')">Instant visit to Page B</button>
+
+  <button @click="prefetch('/once-props/instant/b?deferred=1')">Prefetch Deferred Page B</button>
+  <button @click="instantVisit('/once-props/instant/b?deferred=1')">Instant visit to Deferred Page B</button>
+</template>

--- a/packages/vue3/test-app/Pages/OnceProps/InstantPageB.vue
+++ b/packages/vue3/test-app/Pages/OnceProps/InstantPageB.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { Deferred } from '@inertiajs/vue3'
+
+defineProps<{ foo?: string; bar?: string }>()
+</script>
+
+<template>
+  <Deferred data="foo">
+    <template #fallback>
+      <div>Loading foo...</div>
+    </template>
+
+    <p id="foo">Foo: {{ foo }}</p>
+  </Deferred>
+
+  <p id="bar">Bar: {{ bar }}</p>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2900,6 +2900,25 @@ app.get('/once-props/client-side-visit', (req, res) => {
   })
 })
 
+app.get('/once-props/instant/:page', (req, res) => {
+  const { isPartialRequest, shouldResolveProp, hasPropAlready } = getOncePropsData(req)
+  const page = req.params.page
+  const deferFoo = req.query.deferred === '1' && !isPartialRequest && !hasPropAlready
+  const delay = page === 'b' && !isPartialRequest ? 500 : 0
+
+  setTimeout(() => {
+    inertia.render(req, res, {
+      component: `OnceProps/InstantPage${page.toUpperCase()}`,
+      props: {
+        foo: !deferFoo && shouldResolveProp ? `foo-${page}-` + Date.now() : undefined,
+        bar: `bar-${page}`,
+      },
+      deferredProps: deferFoo ? { default: ['foo'] } : {},
+      onceProps: { foo: { prop: 'foo', expiresAt: null } },
+    })
+  }, delay)
+})
+
 app.get('/deferred-props/back-button/a', (req, res) => {
   if (!req.headers['x-inertia-partial-data']) {
     return inertia.render(req, res, {

--- a/tests/once-props.spec.ts
+++ b/tests/once-props.spec.ts
@@ -515,3 +515,54 @@ test('it provides once props as second argument in client-side visit props callb
   await expect(page.getByText('Foo: foo-initial')).toBeVisible()
   await expect(page.getByText('Bar: bar-updated')).toBeVisible()
 })
+
+test('instant visit reuses the remembered once prop', async ({ page }) => {
+  await page.goto('/once-props/instant/a')
+
+  const fooText = await page.locator('#foo').innerText()
+  expect(fooText.startsWith('Foo: foo-a')).toBe(true)
+
+  await page.getByRole('button', { name: 'Instant visit to Page B' }).click()
+
+  await expect(page.getByText(fooText)).toBeVisible()
+
+  await page.waitForResponse((response) => response.url().includes('/once-props/instant/b'))
+
+  await expect(page.getByText('Bar: bar-b')).toBeVisible()
+  await expect(page.getByText(fooText)).toBeVisible()
+})
+
+test('instant visit adopting an in-flight prefetch preserves the once prop', async ({ page }) => {
+  await page.goto('/once-props/instant/a')
+
+  const fooText = await page.locator('#foo').innerText()
+
+  const prefetchPromise = page.waitForResponse((response) => response.url().includes('/once-props/instant/b'))
+
+  await page.getByRole('button', { name: 'Prefetch Page B' }).click()
+  await page.getByRole('button', { name: 'Instant visit to Page B' }).click()
+
+  await prefetchPromise
+
+  await expect(page.getByText('Bar: bar-b')).toBeVisible()
+  await expect(page.getByText(fooText)).toBeVisible()
+})
+
+test('instant visit adopting an in-flight prefetch preserves the deferred once prop', async ({ page }) => {
+  await page.goto('/once-props/instant/a')
+
+  const fooText = await page.locator('#foo').innerText()
+
+  const prefetchPromise = page.waitForResponse((response) =>
+    response.url().includes('/once-props/instant/b?deferred=1'),
+  )
+
+  await page.getByRole('button', { name: 'Prefetch Deferred Page B' }).click()
+  await page.getByRole('button', { name: 'Instant visit to Deferred Page B' }).click()
+
+  await prefetchPromise
+
+  await expect(page.getByText('Bar: bar-b')).toBeVisible()
+  await expect(page.getByText('Loading foo...')).not.toBeVisible()
+  await expect(page.getByText(fooText)).toBeVisible()
+})


### PR DESCRIPTION
Instant visits build their placeholder page from scratch, which dropped the once props that were being remembered client-side. Usually this went unnoticed because the real request goes out after the swap, so the server simply resolved the prop again.

With a prefetch in flight it breaks: the prefetch was sent while the previous page was still current, so it already claimed the prop and the server skipped it. By the time it lands the placeholder has discarded the value, leaving the prop undefined with nothing left to refetch it. Combined with `defer()`, the page stays in its loading state indefinitely.

The placeholder page now preserves the values along with the registry that maps them, so the prop survives the swap and the pending request advertises it correctly. Values explicitly passed through `pageProps` are left alone.

Fixes #3210.