### PR TITLE
[3.x] Expose `cancel` on the `<Form>` component

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -835,6 +835,7 @@ export type FormComponentMethods<TForm extends object = Record<string, any>> = {
   }
   reset: <K extends FormDataKeys<TForm>>(...fields: K[]) => void
   submit: () => void
+  cancel: () => void
   defaults: () => void
   getData: () => TForm
   getFormData: () => FormData

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -284,6 +284,7 @@ const Form = forwardRef<FormComponentRef, FormProps>(
       setError: form.setError,
       reset,
       submit,
+      cancel: form.cancel,
       defaults,
       getData,
       getFormData,

--- a/packages/react/test-app/Pages/FormComponent/Events.tsx
+++ b/packages/react/test-app/Pages/FormComponent/Events.tsx
@@ -58,7 +58,7 @@ export default () => {
 
   return (
     <Form action={action} method="post" {...formEvents}>
-      {({ processing, progress, wasSuccessful, recentlySuccessful }) => (
+      {({ processing, progress, wasSuccessful, recentlySuccessful, cancel }) => (
         <>
           <h1>Form Events & State</h1>
 
@@ -101,6 +101,9 @@ export default () => {
             </button>
             <button type="button" onClick={cancelVisit}>
               Cancel Visit
+            </button>
+            <button type="button" onClick={cancel}>
+              Cancel Submission
             </button>
             <button type="submit">Submit</button>
           </div>

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -246,6 +246,10 @@
     isDirty = false
   }
 
+  export function cancel() {
+    form.cancel()
+  }
+
   export function validate(field?: string | NamedInputEvent | ValidationConfig, config?: ValidationConfig) {
     return form.validate(...UseFormUtils.mergeHeadersForValidation(field, config, headers!))
   }
@@ -315,6 +319,7 @@
       setError,
       reset,
       submit,
+      cancel,
       defaults,
       getData,
       getFormData,
@@ -360,6 +365,7 @@
     setError,
     isDirty,
     submit,
+    cancel,
     defaults,
     reset,
     getData,

--- a/packages/svelte/test-app/Pages/FormComponent/Events.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/Events.svelte
@@ -83,7 +83,7 @@
   {onError}
   {onCancelToken}
 >
-  {#snippet children({ processing, progress, wasSuccessful, recentlySuccessful })}
+  {#snippet children({ processing, progress, wasSuccessful, recentlySuccessful, cancel })}
     <h1>Form Events & State</h1>
 
     <div>
@@ -117,6 +117,7 @@
       <button type="button" onclick={() => (shouldFail = true)}>Fail Request</button>
       <button type="button" onclick={() => (shouldDelay = true)}>Should Delay</button>
       <button type="button" onclick={cancelVisit}>Cancel Visit</button>
+      <button type="button" onclick={cancel}>Cancel Submission</button>
       <button type="submit">Submit</button>
     </div>
   {/snippet}

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -362,6 +362,7 @@ const Form = defineComponent({
       },
       reset,
       submit,
+      cancel: () => form.cancel(),
       defaults,
       getData,
       getFormData,

--- a/packages/vue3/test-app/Pages/FormComponent/Events.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/Events.vue
@@ -61,7 +61,7 @@ function cancelVisit() {
     :action="action"
     method="post"
     v-bind="formEvents()"
-    v-slot="{ processing, progress, wasSuccessful, recentlySuccessful }"
+    v-slot="{ processing, progress, wasSuccessful, recentlySuccessful, cancel }"
   >
     <h1>Form Events & State</h1>
 
@@ -95,6 +95,7 @@ function cancelVisit() {
       <button type="button" @click="shouldFail = true">Fail Request</button>
       <button type="button" @click="shouldDelay = true">Should Delay</button>
       <button type="button" @click="cancelVisit">Cancel Visit</button>
+      <button type="button" @click="cancel">Cancel Submission</button>
       <button type="submit">Submit</button>
     </div>
   </Form>

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -311,7 +311,7 @@ test.describe('Form Component', () => {
     })
 
     const waitForEvents = async (page: Page, events: string[]) => {
-      await page.waitForFunction(async (expected) => {
+      await page.waitForFunction((expected) => {
         return document.querySelector('#events')?.innerText === expected
       }, events.join(','))
     }
@@ -344,6 +344,17 @@ test.describe('Form Component', () => {
       await waitForEvents(page, ['onBefore', 'onCancelToken', 'onStart', 'onCancel', 'onFinish'])
     })
 
+    test('cancels the request via the exposed cancel method', async ({ page }) => {
+      await page.getByRole('button', { name: 'Should Delay' }).click()
+      await page.getByRole('button', { name: 'Submit' }).click()
+      await expect(page.locator('#processing')).toHaveText('true')
+
+      await page.getByRole('button', { name: 'Cancel Submission' }).click()
+
+      await waitForEvents(page, ['onBefore', 'onCancelToken', 'onStart', 'onCancel', 'onFinish'])
+      await expect(page.locator('#processing')).toHaveText('false')
+    })
+
     test('fires onProgress during file upload', async ({ page }) => {
       const file = {
         name: 'test.jpg',
@@ -354,7 +365,8 @@ test.describe('Form Component', () => {
       await page.setInputFiles('#avatar', file)
       await page.getByRole('button', { name: 'Submit' }).click()
 
-      await waitForEvents(page, ['onBefore', 'onCancelToken', 'onStart', 'onProgress'])
+      // onProgress can fire multiple times, so the event list can't be matched exactly
+      await expect(page.locator('#events')).toContainText('onBefore,onCancelToken,onStart,onProgress')
     })
 
     test('updates processing during request', async ({ page }) => {


### PR DESCRIPTION
The `<Form>` component uses `useForm()` under the hood, but never exposed its `cancel` method, so there was no clean way to abort an in-flight submission. The `cancel` method is now available through the slot props, the component ref, and the form context, in all three adapters.

See #3222