### PR TITLE
[3.x] Add `cancelOnUnmount` to the `<Form>` component

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -54,7 +54,14 @@ export class Request {
   }
 
   public async send() {
-    this.requestParams.onCancelToken(() => this.cancel({ cancelled: true }))
+    this.requestParams.onCancelToken(() => {
+      // Once the response has arrived it's too late to cancel, the page is already being updated
+      if (this.response) {
+        return
+      }
+
+      this.cancel({ cancelled: true })
+    })
 
     fireStartEvent(this.requestParams.all())
     this.requestParams.onStart()

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -818,6 +818,7 @@ export type FormComponentProps<TForm = Record<string, FormDataConvertible>> = Pa
   options?: FormComponentOptions
   onSubmitComplete?: (props: FormComponentOnSubmitCompleteArguments<TForm & object>) => void
   disableWhileProcessing?: boolean
+  cancelOnUnmount?: boolean
   resetOnSuccess?: boolean | NoInfer<FormDataKeys<TForm>>[]
   resetOnError?: boolean | NoInfer<FormDataKeys<TForm>>[]
   setDefaultsOnSuccess?: boolean

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -71,6 +71,7 @@ const Form = forwardRef<FormComponentRef, FormProps>(
       onCancelToken = noop,
       onSubmitComplete = noop,
       disableWhileProcessing = false,
+      cancelOnUnmount = false,
       resetOnError = false,
       resetOnSuccess = false,
       setDefaultsOnSuccess = false,
@@ -128,6 +129,9 @@ const Form = forwardRef<FormComponentRef, FormProps>(
     const [isDirty, setIsDirty] = useState(false)
     const defaultData = useRef<FormData>(new FormData())
 
+    const cancelOnUnmountRef = useRef(cancelOnUnmount)
+    cancelOnUnmountRef.current = cancelOnUnmount
+
     const getFormData = (submitter?: FormSubmitter): FormData =>
       formElement.current ? new FormData(formElement.current, submitter) : new FormData()
 
@@ -174,6 +178,10 @@ const Form = forwardRef<FormComponentRef, FormProps>(
 
       return () => {
         formEvents.forEach((e) => formElement.current?.removeEventListener(e, updateDirtyState))
+
+        if (cancelOnUnmountRef.current) {
+          form.cancel()
+        }
       }
     }, [])
 

--- a/packages/react/test-app/Pages/FormComponent/UnmountCancel.tsx
+++ b/packages/react/test-app/Pages/FormComponent/UnmountCancel.tsx
@@ -1,0 +1,47 @@
+import { Form } from '@inertiajs/react'
+import { useState } from 'react'
+
+export default ({ cancelOnUnmount }: { cancelOnUnmount: boolean }) => {
+  const [events, setEvents] = useState<string[]>([])
+  const [showModal, setShowModal] = useState(true)
+
+  function log(eventName: string) {
+    setEvents((previousEvents) => [...previousEvents, eventName])
+  }
+
+  const formEvents = {
+    onBefore: () => log('onBefore'),
+    onStart: () => log('onStart'),
+    onFinish: () => log('onFinish'),
+    onCancel: () => log('onCancel'),
+    onSuccess: () => log('onSuccess'),
+    onCancelToken: () => log('onCancelToken'),
+  }
+
+  return (
+    <div>
+      <h1>Form Unmount Cancel</h1>
+
+      <div>
+        Events: <span id="events">{events.join(',')}</span>
+      </div>
+
+      {showModal && (
+        <Form
+          action={`/form-component/unmount-cancel/${cancelOnUnmount ? 'yes' : 'no'}`}
+          method="post"
+          cancelOnUnmount={cancelOnUnmount}
+          {...formEvents}
+        >
+          <input type="text" name="name" defaultValue="John" />
+
+          <button type="submit">Submit</button>
+        </Form>
+      )}
+
+      <button type="button" onClick={() => setShowModal(false)}>
+        Close Modal
+      </button>
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/FormComponent/UnmountCancel.tsx
+++ b/packages/react/test-app/Pages/FormComponent/UnmountCancel.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 export default ({ cancelOnUnmount }: { cancelOnUnmount: boolean }) => {
   const [events, setEvents] = useState<string[]>([])
   const [showModal, setShowModal] = useState(true)
+  const [closeOnSuccess, setCloseOnSuccess] = useState(false)
 
   function log(eventName: string) {
     setEvents((previousEvents) => [...previousEvents, eventName])
@@ -14,8 +15,16 @@ export default ({ cancelOnUnmount }: { cancelOnUnmount: boolean }) => {
     onStart: () => log('onStart'),
     onFinish: () => log('onFinish'),
     onCancel: () => log('onCancel'),
-    onSuccess: () => log('onSuccess'),
     onCancelToken: () => log('onCancelToken'),
+    onSuccess: async () => {
+      log('onSuccess')
+
+      if (closeOnSuccess) {
+        setShowModal(false)
+
+        await new Promise((resolve) => setTimeout(resolve, 50))
+      }
+    },
   }
 
   return (
@@ -41,6 +50,9 @@ export default ({ cancelOnUnmount }: { cancelOnUnmount: boolean }) => {
 
       <button type="button" onClick={() => setShowModal(false)}>
         Close Modal
+      </button>
+      <button type="button" onClick={() => setCloseOnSuccess(true)}>
+        Close On Success
       </button>
     </div>
   )

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -43,6 +43,7 @@
     onError?: FormComponentProps['onError']
     onSubmitComplete?: FormComponentProps['onSubmitComplete']
     disableWhileProcessing?: boolean
+    cancelOnUnmount?: FormComponentProps['cancelOnUnmount']
     invalidateCacheTags?: FormComponentProps['invalidateCacheTags']
     resetOnError?: FormComponentProps['resetOnError']
     resetOnSuccess?: FormComponentProps['resetOnSuccess']
@@ -76,6 +77,7 @@
     onError = noop,
     onSubmitComplete = noop,
     disableWhileProcessing = false,
+    cancelOnUnmount = false,
     invalidateCacheTags = [],
     resetOnError = false,
     resetOnSuccess = false,
@@ -285,6 +287,10 @@
 
     return () => {
       formEvents.forEach((e) => formElement?.removeEventListener(e, updateDirtyState))
+
+      if (cancelOnUnmount) {
+        form.cancel()
+      }
     }
   })
 

--- a/packages/svelte/test-app/Pages/FormComponent/UnmountCancel.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/UnmountCancel.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { Form } from '@inertiajs/svelte'
+
+  let { cancelOnUnmount }: { cancelOnUnmount: boolean } = $props()
+
+  let events: string[] = $state([])
+  let showModal = $state(true)
+
+  function log(eventName: string) {
+    events = [...events, eventName]
+  }
+
+  function onBefore() {
+    log('onBefore')
+  }
+
+  function onStart() {
+    log('onStart')
+  }
+
+  function onFinish() {
+    log('onFinish')
+  }
+
+  function onCancel() {
+    log('onCancel')
+  }
+
+  function onSuccess() {
+    log('onSuccess')
+  }
+
+  function onCancelToken() {
+    log('onCancelToken')
+  }
+</script>
+
+<div>
+  <h1>Form Unmount Cancel</h1>
+
+  <div>
+    Events: <span id="events">{events.join(',')}</span>
+  </div>
+
+  {#if showModal}
+    <Form
+      action={`/form-component/unmount-cancel/${cancelOnUnmount ? 'yes' : 'no'}`}
+      method="post"
+      {cancelOnUnmount}
+      {onBefore}
+      {onStart}
+      {onFinish}
+      {onCancel}
+      {onSuccess}
+      {onCancelToken}
+    >
+      <input type="text" name="name" value="John" />
+
+      <button type="submit">Submit</button>
+    </Form>
+  {/if}
+
+  <button type="button" onclick={() => (showModal = false)}>Close Modal</button>
+</div>

--- a/packages/svelte/test-app/Pages/FormComponent/UnmountCancel.svelte
+++ b/packages/svelte/test-app/Pages/FormComponent/UnmountCancel.svelte
@@ -5,6 +5,7 @@
 
   let events: string[] = $state([])
   let showModal = $state(true)
+  let closeOnSuccess = $state(false)
 
   function log(eventName: string) {
     events = [...events, eventName]
@@ -26,8 +27,14 @@
     log('onCancel')
   }
 
-  function onSuccess() {
+  async function onSuccess() {
     log('onSuccess')
+
+    if (closeOnSuccess) {
+      showModal = false
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
   }
 
   function onCancelToken() {
@@ -61,4 +68,5 @@
   {/if}
 
   <button type="button" onclick={() => (showModal = false)}>Close Modal</button>
+  <button type="button" onclick={() => (closeOnSuccess = true)}>Close On Success</button>
 </div>

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -130,6 +130,10 @@ const Form = defineComponent({
       type: Boolean,
       default: false,
     },
+    cancelOnUnmount: {
+      type: Boolean,
+      default: false,
+    },
     invalidateCacheTags: {
       type: [String, Array] as PropType<FormComponentProps['invalidateCacheTags']>,
       default: () => [],
@@ -232,7 +236,13 @@ const Form = defineComponent({
       (value) => form.setValidationTimeout(value),
     )
 
-    onBeforeUnmount(() => formEvents.forEach((e) => formElement.value?.removeEventListener(e, onFormUpdate)))
+    onBeforeUnmount(() => {
+      formEvents.forEach((e) => formElement.value?.removeEventListener(e, onFormUpdate))
+
+      if (props.cancelOnUnmount) {
+        form.cancel()
+      }
+    })
 
     const getFormData = (submitter?: FormSubmitter): FormData => new FormData(formElement.value, submitter)
 

--- a/packages/vue3/test-app/Pages/FormComponent/UnmountCancel.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/UnmountCancel.vue
@@ -11,13 +11,23 @@ function log(eventName: string) {
   events.value.push(eventName)
 }
 
+const closeOnSuccess = ref(false)
+
 const formEvents = {
   onBefore: () => log('onBefore'),
   onStart: () => log('onStart'),
   onFinish: () => log('onFinish'),
   onCancel: () => log('onCancel'),
-  onSuccess: () => log('onSuccess'),
   onCancelToken: () => log('onCancelToken'),
+  onSuccess: async () => {
+    log('onSuccess')
+
+    if (closeOnSuccess.value) {
+      showModal.value = false
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  },
 }
 </script>
 
@@ -43,5 +53,6 @@ const formEvents = {
     </div>
 
     <button type="button" @click="showModal = false">Close Modal</button>
+    <button type="button" @click="closeOnSuccess = true">Close On Success</button>
   </div>
 </template>

--- a/packages/vue3/test-app/Pages/FormComponent/UnmountCancel.vue
+++ b/packages/vue3/test-app/Pages/FormComponent/UnmountCancel.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3'
+import { ref } from 'vue'
+
+defineProps<{ cancelOnUnmount: boolean }>()
+
+const events = ref<string[]>([])
+const showModal = ref(true)
+
+function log(eventName: string) {
+  events.value.push(eventName)
+}
+
+const formEvents = {
+  onBefore: () => log('onBefore'),
+  onStart: () => log('onStart'),
+  onFinish: () => log('onFinish'),
+  onCancel: () => log('onCancel'),
+  onSuccess: () => log('onSuccess'),
+  onCancelToken: () => log('onCancelToken'),
+}
+</script>
+
+<template>
+  <div>
+    <h1>Form Unmount Cancel</h1>
+
+    <div>
+      Events: <span id="events">{{ events.join(',') }}</span>
+    </div>
+
+    <div v-if="showModal">
+      <Form
+        :action="`/form-component/unmount-cancel/${cancelOnUnmount ? 'yes' : 'no'}`"
+        method="post"
+        :cancel-on-unmount="cancelOnUnmount"
+        v-bind="formEvents"
+      >
+        <input type="text" name="name" value="John" />
+
+        <button type="submit">Submit</button>
+      </Form>
+    </div>
+
+    <button type="button" @click="showModal = false">Close Modal</button>
+  </div>
+</template>

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -2035,6 +2035,22 @@ app.post('/form-component/errors/bag', (req, res) =>
 app.post('/form-component/events/delay', upload.any(), async (req, res) =>
   setTimeout(() => inertia.render(req, res, { component: 'FormComponent/Events' }), 500),
 )
+app.get('/form-component/unmount-cancel/:cancelOnUnmount', (req, res) =>
+  inertia.render(req, res, {
+    component: 'FormComponent/UnmountCancel',
+    props: { cancelOnUnmount: req.params.cancelOnUnmount === 'yes' },
+  }),
+)
+app.post('/form-component/unmount-cancel/:cancelOnUnmount', upload.any(), async (req, res) =>
+  setTimeout(
+    () =>
+      inertia.render(req, res, {
+        component: 'FormComponent/UnmountCancel',
+        props: { cancelOnUnmount: req.params.cancelOnUnmount === 'yes' },
+      }),
+    500,
+  ),
+)
 app.get('/form-component/disable-while-processing/:disable', upload.any(), async (req, res) =>
   inertia.render(req, res, {
     component: 'FormComponent/DisableWhileProcessing',

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -710,6 +710,15 @@ test.describe('Form Component', () => {
       await expect(page.locator('#events')).toHaveText('onBefore,onCancelToken,onStart,onCancel,onFinish')
     })
 
+    test('does not cancel a submission that already succeeded', async ({ page }) => {
+      await page.goto('/form-component/unmount-cancel/yes')
+
+      await page.getByRole('button', { name: 'Close On Success' }).click()
+      await page.getByRole('button', { name: 'Submit' }).click()
+
+      await expect(page.locator('#events')).toHaveText('onBefore,onCancelToken,onStart,onSuccess,onFinish')
+    })
+
     test('keeps the submission running when the form unmounts without the attribute', async ({ page }) => {
       await page.goto('/form-component/unmount-cancel/no')
 

--- a/tests/form-component.spec.ts
+++ b/tests/form-component.spec.ts
@@ -698,6 +698,30 @@ test.describe('Form Component', () => {
     expect(consoleMessages.errors).toEqual([])
   })
 
+  test.describe('Cancel On Unmount', () => {
+    test('cancels an in-flight submission when the form unmounts', async ({ page }) => {
+      await page.goto('/form-component/unmount-cancel/yes')
+
+      await page.getByRole('button', { name: 'Submit' }).click()
+      await expect(page.locator('#events')).toHaveText('onBefore,onCancelToken,onStart')
+
+      await page.getByRole('button', { name: 'Close Modal' }).click()
+
+      await expect(page.locator('#events')).toHaveText('onBefore,onCancelToken,onStart,onCancel,onFinish')
+    })
+
+    test('keeps the submission running when the form unmounts without the attribute', async ({ page }) => {
+      await page.goto('/form-component/unmount-cancel/no')
+
+      await page.getByRole('button', { name: 'Submit' }).click()
+      await expect(page.locator('#events')).toHaveText('onBefore,onCancelToken,onStart')
+
+      await page.getByRole('button', { name: 'Close Modal' }).click()
+
+      await expect(page.locator('#events')).toHaveText('onBefore,onCancelToken,onStart,onSuccess,onFinish')
+    })
+  })
+
   test.describe('Methods', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/form-component/methods')


### PR DESCRIPTION
A submission keeps running when the form that started it disappears. Navigating away cancels it, but only as a side effect of the sync request stream interrupting the previous visit. Closing a modal that holds the form interrupts nothing, so an upload the user tried to abandon still completes and gets processed.

The `<Form>` component now takes a `cancelOnUnmount` attribute that cancels an in-flight submission when the form unmounts.

```vue
<Form action="/avatar" method="post" cancel-on-unmount>
    <input type="file" name="avatar" />
</Form>
```

Fixes #3222.