### PR TITLE
[3.x] Prevent unhandled rejection when a view transition is aborted mid-flight

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -256,8 +256,8 @@ class CurrentPage {
     return new Promise((resolve) => {
       const transitionResult = document.startViewTransition(() => doSwap().then(resolve))
 
-      // A newer transition aborts this one, rejecting `ready` with an AbortError.
-      // That's expected, so swallow it to avoid an unhandled rejection.
+      // A newer transition, or the tab going hidden mid-flight, aborts this one,
+      // rejecting these promises. That's expected, so swallow it to avoid an unhandled rejection.
       transitionResult.ready.catch(() => {})
       transitionResult.finished.catch(() => {})
       transitionResult.updateCallbackDone.catch(() => {})

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -253,14 +253,23 @@ class CurrentPage {
 
     const viewTransitionCallback = typeof viewTransition === 'boolean' ? () => null : viewTransition
 
+    // The browser skips this transition when a newer one supersedes it, when the tab goes hidden
+    // mid-flight, or when the swap times out, always rejecting with a DOMException. That's
+    // expected, so swallow it and let a failing swap reject as it normally would.
+    const ignoreSkippedTransition = (promise: Promise<unknown>) => {
+      promise.catch((error) => {
+        if (!(error instanceof DOMException)) {
+          throw error
+        }
+      })
+    }
+
     return new Promise((resolve) => {
       const transitionResult = document.startViewTransition(() => doSwap().then(resolve))
 
-      // A newer transition, or the tab going hidden mid-flight, aborts this one,
-      // rejecting these promises. That's expected, so swallow it to avoid an unhandled rejection.
-      transitionResult.ready.catch(() => {})
-      transitionResult.finished.catch(() => {})
-      transitionResult.updateCallbackDone.catch(() => {})
+      ignoreSkippedTransition(transitionResult.ready)
+      ignoreSkippedTransition(transitionResult.finished)
+      ignoreSkippedTransition(transitionResult.updateCallbackDone)
 
       viewTransitionCallback(transitionResult)
     })

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -259,6 +259,8 @@ class CurrentPage {
       // A newer transition aborts this one, rejecting `ready` with an AbortError.
       // That's expected, so swallow it to avoid an unhandled rejection.
       transitionResult.ready.catch(() => {})
+      transitionResult.finished.catch(() => {})
+      transitionResult.updateCallbackDone.catch(() => {})
 
       viewTransitionCallback(transitionResult)
     })

--- a/tests/view-transitions.spec.ts
+++ b/tests/view-transitions.spec.ts
@@ -108,20 +108,33 @@ test.describe('View Transitions', () => {
     await expect(consoleMessages.errors).toEqual([])
   })
 
-  test('does not throw when the tab is hidden while a view transition is in flight', async ({ page, context }) => {
+  test('does not throw when an in-flight view transition is aborted', async ({ page }) => {
     consoleMessages.listen(page)
+
+    // Chromium and Edge reject `finished` and `updateCallbackDone` when a transition is
+    // aborted, which a headless browser cannot trigger through tab switching.
+    await page.addInitScript(() => {
+      const startViewTransition = document.startViewTransition.bind(document)
+
+      document.startViewTransition = (callback) => {
+        const transition = startViewTransition(callback)
+        const aborted = () =>
+          Promise.reject(new DOMException('Transition was aborted because of invalid state', 'InvalidStateError'))
+
+        return {
+          ready: transition.ready,
+          finished: aborted(),
+          updateCallbackDone: aborted(),
+          types: transition.types,
+          skipTransition: () => transition.skipTransition(),
+        }
+      }
+    })
 
     await page.goto('/view-transition/page-a')
     await expect(page.getByText('Page A - View Transition Test')).toBeVisible()
 
     await page.getByRole('button', { name: 'Transition with boolean' }).click()
-
-    // Backgrounding the tab mid-transition aborts it, rejecting `finished` and
-    // `updateCallbackDone` on Chromium. They must be handled internally so it
-    // never surfaces as an unhandled rejection.
-    const otherPage = await context.newPage()
-    await page.waitForTimeout(500)
-    await otherPage.close()
 
     await expect(page).toHaveURL('/view-transition/page-b')
     await expect(page.getByText('Page B - View Transition Test')).toBeVisible()

--- a/tests/view-transitions.spec.ts
+++ b/tests/view-transitions.spec.ts
@@ -107,4 +107,24 @@ test.describe('View Transitions', () => {
     await page.waitForTimeout(500)
     await expect(consoleMessages.errors).toEqual([])
   })
+
+  test('does not throw when the tab is hidden while a view transition is in flight', async ({ page, context }) => {
+    consoleMessages.listen(page)
+
+    await page.goto('/view-transition/page-a')
+    await expect(page.getByText('Page A - View Transition Test')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Transition with boolean' }).click()
+
+    // Backgrounding the tab mid-transition aborts it, rejecting `finished` and
+    // `updateCallbackDone` on Chromium. They must be handled internally so it
+    // never surfaces as an unhandled rejection.
+    const otherPage = await context.newPage()
+    await page.waitForTimeout(500)
+    await otherPage.close()
+
+    await expect(page).toHaveURL('/view-transition/page-b')
+    await expect(page.getByText('Page B - View Transition Test')).toBeVisible()
+    await expect(consoleMessages.errors).toEqual([])
+  })
 })


### PR DESCRIPTION
Follow-up to #3165, which attached a no-op catch to `ready` to stop a superseded view transition from surfacing as an unhandled rejection. Chromium and Edge have the same problem with two other promises: when a transition is aborted (a newer transition supersedes it, or the tab goes hidden mid-flight), `finished` and `updateCallbackDone` also reject with an `InvalidStateError`, and neither had a handler, so it reaches `onunhandledrejection` and gets picked up by error trackers.

This attaches the same no-op catch to both, matching how `ready` is already handled in `swap()`, and adds a regression test that backgrounds the tab while a transition is in flight to trigger the abort.

Fixes #3229.