### PR TITLE
[3.x] Clear the prefetch hover timer when a link is clicked

### DIFF
--- a/packages/react/src/Link.ts
+++ b/packages/react/src/Link.ts
@@ -247,7 +247,11 @@ const Link = forwardRef<unknown, InertiaLinkProps>(
       onMouseLeave: () => {
         clearTimeout(hoverTimeout.current)
       },
-      onClick: regularEvents.onClick,
+      onClick: (event: React.MouseEvent) => {
+        clearTimeout(hoverTimeout.current)
+
+        regularEvents.onClick(event)
+      },
     }
 
     const prefetchClickEvents = {

--- a/packages/svelte/src/link.ts
+++ b/packages/svelte/src/link.ts
@@ -63,22 +63,24 @@ function link(
   let baseParams: VisitOptions
   let visitParams: VisitOptions
 
+  const handleClick = (event: MouseEvent) => {
+    if (shouldIntercept(event)) {
+      event.preventDefault()
+      router.visit(href, visitParams)
+    }
+  }
+
   const regularEvents: ActionEventHandlers = {
-    click: (event: MouseEvent) => {
-      if (shouldIntercept(event)) {
-        event.preventDefault()
-        router.visit(href, visitParams)
-      }
-    },
+    click: handleClick,
   }
 
   const prefetchHoverEvents: ActionEventHandlers = {
     mouseenter: () => (hoverTimeout = setTimeout(() => prefetch(), config.get('prefetch.hoverDelay'))),
     mouseleave: () => clearTimeout(hoverTimeout),
-    click: (event: PointerEvent) => {
+    click: (event: MouseEvent) => {
       clearTimeout(hoverTimeout)
 
-      regularEvents.click?.(event)
+      handleClick(event)
     },
   }
 

--- a/packages/svelte/src/link.ts
+++ b/packages/svelte/src/link.ts
@@ -75,7 +75,11 @@ function link(
   const prefetchHoverEvents: ActionEventHandlers = {
     mouseenter: () => (hoverTimeout = setTimeout(() => prefetch(), config.get('prefetch.hoverDelay'))),
     mouseleave: () => clearTimeout(hoverTimeout),
-    click: regularEvents.click,
+    click: (event: PointerEvent) => {
+      clearTimeout(hoverTimeout)
+
+      regularEvents.click?.(event)
+    },
   }
 
   const prefetchClickEvents: ActionEventHandlers = {

--- a/packages/vue3/src/link.ts
+++ b/packages/vue3/src/link.ts
@@ -306,7 +306,11 @@ const Link: InertiaLink = defineComponent({
       onMouseleave: () => {
         clearTimeout(hoverTimeout.value)
       },
-      onClick: regularEvents.onClick,
+      onClick: (event: MouseEvent) => {
+        clearTimeout(hoverTimeout.value)
+
+        regularEvents.onClick(event)
+      },
     }
 
     const prefetchClickEvents = {

--- a/tests/prefetch.spec.ts
+++ b/tests/prefetch.spec.ts
@@ -672,8 +672,6 @@ test('fires the navigate event with cached set to true when a prefetched respons
 })
 
 test('does not prefetch a link that was clicked before the hover delay elapsed', async ({ page }) => {
-  test.skip(process.env.PACKAGE !== 'react', 'React-only test')
-
   await page.goto('prefetch/3')
   await page.waitForLoadState('networkidle')
 

--- a/tests/prefetch.spec.ts
+++ b/tests/prefetch.spec.ts
@@ -671,6 +671,32 @@ test('fires the navigate event with cached set to true when a prefetched respons
   expect(consoleMessages.messages).toContain('false')
 })
 
+test('does not prefetch a link that was clicked before the hover delay elapsed', async ({ page }) => {
+  test.skip(process.env.PACKAGE !== 'react', 'React-only test')
+
+  await page.goto('prefetch/3')
+  await page.waitForLoadState('networkidle')
+
+  // Hold the visit back so the hover delay elapses while the old URL is still current
+  await page.route('**/prefetch/1', async (route) => {
+    if (route.request().headers().purpose !== 'prefetch') {
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+
+    await route.continue()
+  })
+
+  requests.listen(page)
+  await page.getByRole('link', { name: 'On Hover (Default)' }).click()
+  await isPrefetchPage(page, 1)
+
+  const prefetchRequests = requests.requests.filter(
+    (request) => request.url().includes('/prefetch/1') && request.headers().purpose === 'prefetch',
+  )
+
+  expect(prefetchRequests.length).toBe(0)
+})
+
 test('can use prefetched requests with preserveState', async ({ page }) => {
   await page.goto('/prefetch/preserve-state')
 


### PR DESCRIPTION
A `<Link prefetch>` clears its hover timer on mouse leave and on unmount, but not on click. Clicking within the 75ms hover delay lets the timer fire after the visit has already started. At that point `window.location` is still the old URL, so `router.prefetch` doesn't recognize the target as the current page and sends the request anyway. The response lands after the visit has swapped the page, `handlePrefetch` sees a matching URL and applies it, remounting the whole component tree and wiping any local state on the page you just navigated to.

The hover handler now clears the timer on click, the same way it already does on mouse leave. React, Vue and Svelte all had the same gap, so all three are fixed here.

Fixes #3233.