### PR TITLE
[3.x] Support big integers as native BigInt values

### DIFF
--- a/packages/core/build.js
+++ b/packages/core/build.js
@@ -30,6 +30,7 @@ const builds = [
   { entryPoints: ['src/index.ts'], format: 'esm', outfile: 'dist/index.js', platform: 'browser' },
   { entryPoints: ['src/server.ts'], format: 'esm', outfile: 'dist/server.js', platform: 'node' },
   { entryPoints: ['src/ssrErrors.ts'], format: 'esm', outfile: 'dist/ssrErrors.js', platform: 'node' },
+  { entryPoints: ['src/json.ts'], format: 'esm', outfile: 'dist/json.js', platform: 'node' },
 ]
 
 builds.forEach(async (build) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,10 @@
     "./ssrErrors": {
       "types": "./types/ssrErrors.d.ts",
       "import": "./dist/ssrErrors.js"
+    },
+    "./json": {
+      "types": "./types/json.d.ts",
+      "import": "./dist/json.js"
     }
   },
   "typesVersions": {

--- a/packages/core/src/axiosHttpClient.ts
+++ b/packages/core/src/axiosHttpClient.ts
@@ -1,7 +1,10 @@
 import type { AxiosInstance, AxiosProgressEvent } from 'axios'
+import { config as appConfig } from './config'
 import { HttpCancelledError, HttpNetworkError, HttpResponseError } from './httpErrors'
 import { httpHandlers } from './httpHandlers'
+import { containsBigInt, stringifyJson } from './json'
 import { HttpClient, HttpProgressEvent, HttpRequestConfig, HttpResponse, HttpResponseHeaders } from './types'
+import { isRawRequestBody } from './xhrHttpClient'
 
 /**
  * Normalize Axios headers to a simple string record with lowercase keys
@@ -117,11 +120,28 @@ export class AxiosHttpClient implements HttpClient {
       headers['Content-Type'] = false
     }
 
+    let data = config.data
+
+    if (
+      appConfig.get('preserveBigIntegers') &&
+      data !== null &&
+      data !== undefined &&
+      typeof data === 'object' &&
+      !isRawRequestBody(data) &&
+      containsBigInt(data)
+    ) {
+      data = stringifyJson(data)
+
+      if (!hasContentTypeHeader(config.headers)) {
+        headers['Content-Type'] = 'application/json'
+      }
+    }
+
     try {
       const response = await axios({
         method: config.method,
         url: config.url,
-        data: config.data,
+        data,
         params: config.params,
         headers: headers as Record<string, string>,
         signal: config.signal,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -80,4 +80,5 @@ export const config = new Config<InertiaAppConfig>({
     cacheFor: 30_000,
     hoverDelay: 75,
   },
+  preserveBigIntegers: false,
 })

--- a/packages/core/src/dialog.ts
+++ b/packages/core/src/dialog.ts
@@ -1,9 +1,10 @@
 import { config } from './config'
+import { stringifyJson } from './json'
 
 export default {
   createIframeAndPage(html: Record<string, unknown> | string): { iframe: HTMLIFrameElement; page: HTMLElement } {
     if (typeof html === 'object') {
-      html = `All Inertia requests must receive a valid Inertia response, however a plain JSON response was received.<hr>${JSON.stringify(
+      html = `All Inertia requests must receive a valid Inertia response, however a plain JSON response was received.<hr>${stringifyJson(
         html,
       )}`
     }

--- a/packages/core/src/domUtils.ts
+++ b/packages/core/src/domUtils.ts
@@ -1,3 +1,5 @@
+import { parseJson } from './json'
+
 const elementInViewport = (el: HTMLElement) => {
   if (el.offsetParent === null) {
     // Element is not participating in layout (e.g., display: none)
@@ -154,7 +156,7 @@ export const getInitialPageFromDOM = <T>(id: string): T | null => {
   const scriptEl = document.querySelector(`script[data-page="${id}"][type="application/json"]`)
 
   if (scriptEl?.textContent) {
-    return JSON.parse(scriptEl.textContent)
+    return parseJson(scriptEl.textContent)
   }
 
   return null

--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -1,3 +1,4 @@
+import { parseJson, stringifyJson } from './json'
 import { SessionStorage } from './sessionStorage'
 
 export const encryptHistory = async (data: any): Promise<ArrayBuffer> => {
@@ -46,7 +47,7 @@ const encryptData = async (iv: BufferSource, key: CryptoKey, data: any) => {
   }
 
   const textEncoder = new TextEncoder()
-  const str = JSON.stringify(data)
+  const str = stringifyJson(data)
   const encoded = new Uint8Array(str.length * 3)
 
   const result = textEncoder.encodeInto(str, encoded)
@@ -77,7 +78,7 @@ const decryptData = async (iv: BufferSource, key: CryptoKey, data: any) => {
     data,
   )
 
-  return JSON.parse(new TextDecoder().decode(decrypted))
+  return parseJson(new TextDecoder().decode(decrypted))
 }
 
 const getIv = (): BufferSource => {

--- a/packages/core/src/formData.ts
+++ b/packages/core/src/formData.ts
@@ -44,6 +44,8 @@ function append(form: FormData, key: string, value: FormDataConvertible, format:
     return form.append(key, value)
   } else if (typeof value === 'number') {
     return form.append(key, `${value}`)
+  } else if (typeof value === 'bigint') {
+    return form.append(key, value.toString())
   } else if (value === null || value === undefined) {
     return form.append(key, '')
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export { formDataToObject } from './formObject'
 export { default as createHeadManager, resolveServerHead } from './head'
 export { http } from './http'
 export { HttpCancelledError, HttpError, HttpNetworkError, HttpResponseError } from './httpErrors'
+export { parseJson, stringifyJson } from './json'
 export { default as useInfiniteScroll } from './infiniteScroll'
 /** @internal Not part of the public API. May change or be removed without notice. */
 export { exposeInterceptors, interceptors } from './interceptors'

--- a/packages/core/src/json.ts
+++ b/packages/core/src/json.ts
@@ -1,0 +1,86 @@
+import { config } from './config'
+
+/**
+ * BigInt values cannot be represented in JSON, so integers outside the safe
+ * range are transported as a `{ "$bigint": "<value>" }` marker and revived
+ * with a custom reviver/replacer pair.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
+ */
+const bigIntMarker = '$bigint'
+const integerPattern = /^(0|-?[1-9]\d*)$/
+
+const isEnabled = (): boolean => config.get('preserveBigIntegers')
+
+const reviveBigInt = (_key: string, value: any): any => {
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof value[bigIntMarker] === 'string' &&
+    Object.keys(value).length === 1 &&
+    integerPattern.test(value[bigIntMarker])
+  ) {
+    return BigInt(value[bigIntMarker])
+  }
+
+  return value
+}
+
+const replaceBigInt = (_key: string, value: any): any => {
+  if (typeof value === 'bigint') {
+    return { [bigIntMarker]: value.toString() }
+  }
+
+  return value
+}
+
+/**
+ * Scanning the raw text is roughly ten times cheaper than running the reviver,
+ * so payloads without markers take the plain path. Payloads the server adapter
+ * sent us are trusted, since the config is not known everywhere they arrive.
+ */
+export function parseJson(text: string, { trusted = false }: { trusted?: boolean } = {}): any {
+  if ((trusted || isEnabled()) && text.includes(`"${bigIntMarker}"`)) {
+    return JSON.parse(text, reviveBigInt)
+  }
+
+  return JSON.parse(text)
+}
+
+/**
+ * Only a BigInt makes a plain stringify throw here, so the replacer is kept off
+ * the common path. A circular structure throws again on the retry. Without the
+ * feature a BigInt keeps throwing, so nothing silently changes shape.
+ */
+export function stringifyJson(value: any, { trusted = false }: { trusted?: boolean } = {}): string {
+  if (!trusted && !isEnabled()) {
+    return JSON.stringify(value)
+  }
+
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return JSON.stringify(value, replaceBigInt)
+  }
+}
+
+export function containsBigInt(value: any, seen: WeakSet<object> = new WeakSet()): boolean {
+  if (typeof value === 'bigint') {
+    return true
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return false
+  }
+
+  if (seen.has(value)) {
+    return false
+  }
+
+  seen.add(value)
+
+  const values = Array.isArray(value) ? value : Object.values(value)
+
+  return values.some((nested) => containsBigInt(nested, seen))
+}

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -13,6 +13,7 @@ import {
 } from './events'
 import { history } from './history'
 import { interceptors } from './interceptors'
+import { parseJson } from './json'
 import { page as currentPage } from './page'
 import { partialReloadRequestsProp } from './partialReload'
 import Queue from './queue'
@@ -274,7 +275,7 @@ export class Response {
     }
 
     try {
-      return JSON.parse(response)
+      return parseJson(response)
     } catch (error) {
       return response
     }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -5,6 +5,7 @@ import { availableParallelism } from 'node:os'
 import path from 'node:path'
 import * as process from 'process'
 import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping'
+import { parseJson } from './json'
 import { classifySSRError, formatConsoleError, setSourceMapResolver } from './ssrErrors'
 import { InertiaAppResponse, Page } from './types'
 
@@ -103,7 +104,10 @@ export default (render: AppCallback, options?: Port | ServerOptions): AppCallbac
   }
 
   const handleRender = async (request: IncomingMessage, response: ServerResponse) => {
-    const page: Page = JSON.parse(await readableToString(request))
+    // The app config is set by the render callback below, so the server adapter
+    // tells us by header whether the page may contain big integer markers
+    const trusted = request.headers['x-inertia-preserve-big-integers'] === 'true'
+    const page: Page = parseJson(await readableToString(request), { trusted })
 
     // Suppress framework warnings during render (they clutter the output)
     const originalWarn = console.warn

--- a/packages/core/src/sessionStorage.ts
+++ b/packages/core/src/sessionStorage.ts
@@ -1,15 +1,17 @@
+import { parseJson, stringifyJson } from './json'
+
 export class SessionStorage {
   public static locationVisitKey = 'inertiaLocationVisit'
 
   public static set(key: string, value: any): void {
     if (typeof window !== 'undefined') {
-      window.sessionStorage.setItem(key, JSON.stringify(value))
+      window.sessionStorage.setItem(key, stringifyJson(value))
     }
   }
 
   public static get(key: string): any {
     if (typeof window !== 'undefined') {
-      return JSON.parse(window.sessionStorage.getItem(key) || 'null')
+      return parseJson(window.sessionStorage.getItem(key) || 'null')
     }
   }
 

--- a/packages/core/src/ssrUtils.ts
+++ b/packages/core/src/ssrUtils.ts
@@ -1,7 +1,8 @@
+import { stringifyJson } from './json'
 import type { Page } from './types'
 
 export function buildSSRBody(id: string, page: Page, html: string): string {
-  const json = JSON.stringify(page).replace(/\//g, '\\/')
+  const json = stringifyJson(page, { trusted: true }).replace(/\//g, '\\/')
 
   return `<script data-page="${id}" type="application/json">${json}</script><div data-server-rendered="true" id="${id}">${html}</div>`
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -106,7 +106,7 @@ export type NamedLayoutProps = InertiaConfigFor<'namedLayoutProps'>
 export type Errors = Record<string, ErrorValue>
 export type ErrorBag = Record<string, Errors>
 
-export type FormDataConvertibleValue = Blob | FormDataEntryValue | Date | boolean | number | null | undefined
+export type FormDataConvertibleValue = Blob | FormDataEntryValue | Date | boolean | number | bigint | null | undefined
 export type FormDataConvertible =
   | Array<FormDataConvertible>
   | { [key: string]: FormDataConvertible }
@@ -683,6 +683,7 @@ export type InertiaAppConfig = {
   }
   nonce?: string
   visitOptions?: (href: string, options: VisitOptions) => VisitOptions
+  preserveBigIntegers: boolean
 }
 
 export interface LinkComponentBaseProps extends Partial<

--- a/packages/core/src/xhrHttpClient.ts
+++ b/packages/core/src/xhrHttpClient.ts
@@ -1,5 +1,6 @@
 import { HttpCancelledError, HttpNetworkError, HttpResponseError } from './httpErrors'
 import { httpHandlers } from './httpHandlers'
+import { stringifyJson } from './json'
 import {
   FormDataConvertible,
   HttpClient,
@@ -37,7 +38,7 @@ function isFormDataRequestBody(value: unknown): value is FormData {
   return typeof FormData !== 'undefined' && value instanceof FormData
 }
 
-function isRawRequestBody(value: unknown): value is XMLHttpRequestBodyInit {
+export function isRawRequestBody(value: unknown): value is XMLHttpRequestBodyInit {
   return (
     typeof value === 'string' ||
     isFormDataRequestBody(value) ||
@@ -132,7 +133,7 @@ export class XhrHttpClient implements HttpClient {
         if (isRawRequestBody(config.data)) {
           body = config.data
         } else if (typeof config.data === 'object') {
-          body = JSON.stringify(config.data)
+          body = stringifyJson(config.data)
 
           if (!config.headers?.['Content-Type'] && !config.headers?.['content-type']) {
             xhr.setRequestHeader('Content-Type', 'application/json')

--- a/packages/core/tests/formData.test.ts
+++ b/packages/core/tests/formData.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { objectToFormData } from '../src/formData'
+
+describe('objectToFormData', () => {
+  it('appends big integers as their exact digits', () => {
+    const form = objectToFormData({
+      id: 900719925474099988n,
+      negative: -900719925474099988n,
+      nested: { ids: [1n, 2n] },
+    })
+
+    expect(form.get('id')).toBe('900719925474099988')
+    expect(form.get('negative')).toBe('-900719925474099988')
+    expect(form.getAll('nested[ids][]')).toEqual(['1', '2'])
+  })
+})

--- a/packages/core/tests/json.test.ts
+++ b/packages/core/tests/json.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { config } from '../src/config'
+import { containsBigInt, parseJson, stringifyJson } from '../src/json'
+
+const enable = () => config.set('preserveBigIntegers', true)
+
+afterEach(() => {
+  config.replace({})
+})
+
+describe('parseJson', () => {
+  it('leaves markers alone until the feature is enabled', () => {
+    const text = '{"props":{"id":{"$bigint":"900719925474099988"}}}'
+
+    expect(parseJson(text).props.id).toEqual({ $bigint: '900719925474099988' })
+
+    enable()
+
+    expect(parseJson(text).props.id).toBe(900719925474099988n)
+  })
+
+  it('revives markers for a trusted payload without the feature enabled', () => {
+    const text = '{"props":{"id":{"$bigint":"900719925474099988"}}}'
+
+    expect(parseJson(text, { trusted: true }).props.id).toBe(900719925474099988n)
+  })
+
+  it('only revives canonical single-key integer markers', () => {
+    enable()
+
+    const { props } = parseJson(
+      JSON.stringify({
+        props: {
+          negative: { $bigint: '-900719925474099988' },
+          fraction: { $bigint: '12.5' },
+          words: { $bigint: 'abc' },
+          padded: { $bigint: '007' },
+          negativeZero: { $bigint: '-0' },
+          zero: { $bigint: '0' },
+          extraKey: { $bigint: '1', other: 2 },
+          numeric: { $bigint: 1 },
+          note: 'the "$bigint" marker documented in a string',
+        },
+      }),
+    )
+
+    expect(props.negative).toBe(-900719925474099988n)
+    expect(props.fraction).toEqual({ $bigint: '12.5' })
+    expect(props.words).toEqual({ $bigint: 'abc' })
+    expect(props.padded).toEqual({ $bigint: '007' })
+    expect(props.negativeZero).toEqual({ $bigint: '-0' })
+    expect(props.zero).toBe(0n)
+    expect(props.extraKey).toEqual({ $bigint: '1', other: 2 })
+    expect(props.numeric).toEqual({ $bigint: 1 })
+    expect(props.note).toContain('$bigint')
+  })
+
+  it('revives markers nested in arrays and objects', () => {
+    enable()
+
+    const { props } = parseJson('{"props":{"deep":[{"id":{"$bigint":"-1234567890123456789"}}]}}')
+
+    expect(props.deep[0].id).toBe(-1234567890123456789n)
+  })
+})
+
+describe('stringifyJson', () => {
+  it('matches JSON.stringify while the feature is disabled', () => {
+    const value = { a: 1, b: [true, null], c: new Date(0), d: undefined }
+
+    expect(stringifyJson(value)).toBe(JSON.stringify(value))
+    expect(() => stringifyJson({ id: 1n })).toThrow(TypeError)
+  })
+
+  it('encodes big integers once enabled', () => {
+    enable()
+
+    expect(stringifyJson({ id: 900719925474099988n })).toBe('{"id":{"$bigint":"900719925474099988"}}')
+    expect(stringifyJson({ deep: [1n, { nested: -2n }] })).toBe(
+      '{"deep":[{"$bigint":"1"},{"nested":{"$bigint":"-2"}}]}',
+    )
+  })
+
+  it('encodes big integers for a trusted value without the feature enabled', () => {
+    expect(stringifyJson({ id: 1n }, { trusted: true })).toBe('{"id":{"$bigint":"1"}}')
+  })
+
+  it('still reports circular structures', () => {
+    enable()
+
+    const cyclic: Record<string, unknown> = { a: 1 }
+    cyclic.self = cyclic
+
+    expect(() => stringifyJson(cyclic)).toThrow(/circular/i)
+  })
+
+  it('round trips through parseJson', () => {
+    enable()
+
+    const value = { props: { id: 900719925474099988n, list: [1n, 2n] } }
+
+    expect(parseJson(stringifyJson(value))).toEqual(value)
+  })
+})
+
+describe('containsBigInt', () => {
+  it('finds big integers at any depth', () => {
+    expect(containsBigInt(1n)).toBe(true)
+    expect(containsBigInt({ a: { b: [{ c: 1n }] } })).toBe(true)
+    expect(containsBigInt({ a: 1, b: 'two', c: [null, new Date(0)] })).toBe(false)
+  })
+
+  it('does not recurse forever on circular structures', () => {
+    const cyclic: Record<string, unknown> = { a: 1 }
+    cyclic.self = cyclic
+
+    expect(containsBigInt(cyclic)).toBe(false)
+
+    cyclic.id = 1n
+
+    expect(containsBigInt(cyclic)).toBe(true)
+  })
+})

--- a/packages/react/src/useHttp.ts
+++ b/packages/react/src/useHttp.ts
@@ -15,7 +15,9 @@ import {
   mergeDataIntoQueryString,
   Method,
   objectToFormData,
+  parseJson,
   Progress,
+  stringifyJson,
   UrlMethodPair,
   UseFormArguments,
   UseFormTransformCallback,
@@ -217,7 +219,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
         if (useFormData) {
           requestData = objectToFormData(transformedData as Record<string, FormDataConvertible>)
         } else {
-          requestData = JSON.stringify(transformedData)
+          requestData = stringifyJson(transformedData)
           contentType = 'application/json'
         }
       }
@@ -242,7 +244,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
           },
         })
 
-        const responseData = (httpResponse.data ? JSON.parse(httpResponse.data) : null) as TResponse
+        const responseData = (httpResponse.data ? parseJson(httpResponse.data) : null) as TResponse
 
         if (httpResponse.status >= 200 && httpResponse.status < 300) {
           if (isMounted.current) {
@@ -270,7 +272,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
 
         if (error instanceof HttpResponseError) {
           if (error.response.status === 422) {
-            const responseData = JSON.parse(error.response.data)
+            const responseData = parseJson(error.response.data)
             const validationErrors = responseData.errors || {}
             const processedErrors = (
               withAllErrors.enabled() ? validationErrors : toSimpleValidationErrors(validationErrors)

--- a/packages/react/test-app/Pages/BigInt.tsx
+++ b/packages/react/test-app/Pages/BigInt.tsx
@@ -1,0 +1,51 @@
+import { router } from '@inertiajs/react'
+
+export default ({
+  safe,
+  big,
+  negative,
+  nested,
+  huge,
+  collision,
+}: {
+  safe: number
+  big: bigint
+  negative: bigint
+  nested: { deep: bigint[] }
+  huge: bigint
+  collision?: any
+}) => {
+  const loadReloadData = () => router.get('/bigint/reload')
+  const loadCollisionData = () => router.get('/bigint/collision')
+  const submitEcho = () => router.post('/bigint/echo', { value: 111222333444555666n })
+
+  return (
+    <div>
+      <p>
+        safe: <span id="safe">{String(safe)}</span> (<span id="safe-type">{typeof safe}</span>)
+      </p>
+      <p>
+        big: <span id="big">{String(big)}</span> (<span id="big-type">{typeof big}</span>)
+      </p>
+      <p>
+        negative: <span id="negative">{String(negative)}</span>
+      </p>
+      <p>
+        huge: <span id="huge">{String(huge)}</span>
+      </p>
+      <p>
+        nested: <span id="nested">{nested.deep.map(String).join(',')}</span>
+      </p>
+      {collision && (
+        <p>
+          collision: <span id="collision">{typeof collision === 'object' ? collision.$bigint : String(collision)}</span>{' '}
+          (<span id="collision-type">{typeof collision}</span>)
+        </p>
+      )}
+
+      <button onClick={loadReloadData}>Load reload data</button>
+      <button onClick={loadCollisionData}>Load collision data</button>
+      <button onClick={submitEcho}>Submit echo</button>
+    </div>
+  )
+}

--- a/packages/react/test-app/Pages/SSR/BigInt.tsx
+++ b/packages/react/test-app/Pages/SSR/BigInt.tsx
@@ -1,0 +1,9 @@
+export default ({ big, nested }: { big: bigint; nested: { deep: bigint[] } }) => (
+  <div>
+    <h1 data-testid="ssr-title">SSR Big Integers</h1>
+
+    <p data-testid="big">big: {String(big)}</p>
+    <p data-testid="big-type">type: {typeof big}</p>
+    <p data-testid="nested">nested: {nested.deep.map(String).join(',')}</p>
+  </div>
+)

--- a/packages/react/test-app/app.tsx
+++ b/packages/react/test-app/app.tsx
@@ -49,13 +49,14 @@ createInertiaApp({
     color: 'red',
   },
   http: getHttpConfig(),
-  ...(params.has('withAppDefaults') && {
-    defaults: {
+  defaults: {
+    preserveBigIntegers: true,
+    ...(params.has('withAppDefaults') && {
       visitOptions: (href: string, options: VisitOptions) => {
         return { headers: { ...options.headers, 'X-From-App-Defaults': 'test' } }
       },
-    },
-  }),
+    }),
+  },
   ...(params.has('withDefaultLayout') && {
     layout: () => DefaultLayout,
   }),

--- a/packages/svelte/src/useHttp.svelte.ts
+++ b/packages/svelte/src/useHttp.svelte.ts
@@ -24,6 +24,8 @@ import {
   HttpResponseError,
   mergeDataIntoQueryString,
   objectToFormData,
+  parseJson,
+  stringifyJson,
   UseFormUtils,
 } from '@inertiajs/core'
 import { cloneDeep } from 'es-toolkit'
@@ -201,7 +203,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
       if (useFormData) {
         requestData = objectToFormData(transformedData as Record<string, FormDataConvertible>)
       } else {
-        requestData = JSON.stringify(transformedData)
+        requestData = stringifyJson(transformedData)
         contentType = 'application/json'
       }
     }
@@ -223,7 +225,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
         },
       })
 
-      const responseData = (response.data ? JSON.parse(response.data) : null) as TResponse
+      const responseData = (response.data ? parseJson(response.data) : null) as TResponse
 
       if (response.status >= 200 && response.status < 300) {
         markAsSuccessful()
@@ -250,7 +252,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
 
       if (error instanceof HttpResponseError) {
         if (error.response.status === 422) {
-          const responseData = JSON.parse(error.response.data)
+          const responseData = parseJson(error.response.data)
           const validationErrors = responseData.errors || {}
           const processedErrors = (
             withAllErrors.enabled() ? validationErrors : toSimpleValidationErrors(validationErrors)

--- a/packages/svelte/test-app/Pages/BigInt.svelte
+++ b/packages/svelte/test-app/Pages/BigInt.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { router } from '@inertiajs/svelte'
+
+  let { safe, big, negative, nested, huge, collision } = $props()
+
+  const loadReloadData = () => router.get('/bigint/reload')
+  const loadCollisionData = () => router.get('/bigint/collision')
+  const submitEcho = () => router.post('/bigint/echo', { value: 111222333444555666n })
+</script>
+
+<div>
+  <p>safe: <span id="safe">{safe}</span> (<span id="safe-type">{typeof safe}</span>)</p>
+  <p>big: <span id="big">{big}</span> (<span id="big-type">{typeof big}</span>)</p>
+  <p>negative: <span id="negative">{negative}</span></p>
+  <p>huge: <span id="huge">{huge}</span></p>
+  <p>nested: <span id="nested">{nested.deep.join(',')}</span></p>
+  {#if collision}
+    <p>
+      collision: <span id="collision">{typeof collision === 'object' ? collision.$bigint : collision}</span> (<span
+        id="collision-type">{typeof collision}</span
+      >)
+    </p>
+  {/if}
+
+  <button onclick={loadReloadData}>Load reload data</button>
+  <button onclick={loadCollisionData}>Load collision data</button>
+  <button onclick={submitEcho}>Submit echo</button>
+</div>

--- a/packages/svelte/test-app/Pages/SSR/BigInt.svelte
+++ b/packages/svelte/test-app/Pages/SSR/BigInt.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  let { big, nested } = $props()
+</script>
+
+<div>
+  <h1 data-testid="ssr-title">SSR Big Integers</h1>
+
+  <p data-testid="big">big: {big}</p>
+  <p data-testid="big-type">type: {typeof big}</p>
+  <p data-testid="nested">nested: {nested.deep.join(',')}</p>
+</div>

--- a/packages/svelte/test-app/app.ts
+++ b/packages/svelte/test-app/app.ts
@@ -51,13 +51,14 @@ createInertiaApp({
     }
   },
   http: getHttpConfig(),
-  ...(params.has('withAppDefaults') && {
-    defaults: {
+  defaults: {
+    preserveBigIntegers: true,
+    ...(params.has('withAppDefaults') && {
       visitOptions: (href: string, options: VisitOptions) => {
         return { headers: { ...options.headers, 'X-From-App-Defaults': 'test' } }
       },
-    },
-  }),
+    }),
+  },
   ...(params.has('withDefaultLayout') && {
     layout: () => DefaultLayout,
   }),

--- a/packages/svelte/test-app/tsconfig.json
+++ b/packages/svelte/test-app/tsconfig.json
@@ -11,6 +11,7 @@
     "sourceMap": true,
     "strict": true,
     "module": "ESNext",
+    "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "moduleResolution": "bundler",
     "paths": {

--- a/packages/vite/src/ssr.ts
+++ b/packages/vite/src/ssr.ts
@@ -21,6 +21,7 @@
 import { existsSync } from 'node:fs'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { resolve } from 'node:path'
+import { parseJson } from '@inertiajs/core/json'
 import { classifySSRError, formatConsoleError } from '@inertiajs/core/ssrErrors'
 import type { ResolvedConfig, ViteDevServer } from 'vite'
 import { collectCSSFromModuleGraph } from './css'
@@ -169,6 +170,10 @@ function readRequestBody<T>(req: IncomingMessage): Promise<T> {
   return new Promise((resolve, reject) => {
     let data = ''
 
+    // The app config lives in the SSR entry loaded below, so the server adapter
+    // tells us by header whether the page may contain big integer markers
+    const trusted = req.headers['x-inertia-preserve-big-integers'] === 'true'
+
     req.on('data', (chunk) => (data += chunk))
 
     req.on('end', () => {
@@ -178,7 +183,7 @@ function readRequestBody<T>(req: IncomingMessage): Promise<T> {
       }
 
       try {
-        resolve(JSON.parse(data))
+        resolve(parseJson(data, { trusted }))
       } catch (error) {
         reject(new Error(`Invalid JSON in request body: ${error instanceof Error ? error.message : 'Unknown error'}`))
       }

--- a/packages/vite/tests/ssr.test.ts
+++ b/packages/vite/tests/ssr.test.ts
@@ -204,6 +204,37 @@ describe('SSR', () => {
       )
     })
 
+    it('revives big integer markers when the server adapter says the page has them', async () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('resources/js/ssr.ts'))
+
+      const plugin = inertia()
+      const logger = createMockLogger()
+      const server = createMockServer(logger)
+      const render = vi.fn().mockResolvedValue({ head: [], body: '' })
+
+      server.ssrLoadModule.mockResolvedValue({ default: render })
+
+      plugin.configResolved!(createMockConfig(logger, false))
+      plugin.configureServer!(server)
+
+      const middleware = server.middlewares.use.mock.calls[0][1]
+      const body = JSON.stringify({ component: 'Test', props: { id: { $bigint: '900719925474099988' } } })
+
+      await middleware(
+        createMockRequest('POST', body, { 'x-inertia-preserve-big-integers': 'true' }),
+        createMockResponse(),
+        vi.fn(),
+      )
+
+      expect(render).toHaveBeenCalledWith(expect.objectContaining({ props: { id: 900719925474099988n } }))
+
+      await middleware(createMockRequest('POST', body), createMockResponse(), vi.fn())
+
+      expect(render).toHaveBeenLastCalledWith(
+        expect.objectContaining({ props: { id: { $bigint: '900719925474099988' } } }),
+      )
+    })
+
     it('returns 500 when module does not export render function', async () => {
       mockExistsSync.mockImplementation((path: string) => path.endsWith('resources/js/ssr.ts'))
 
@@ -992,12 +1023,13 @@ function createMockServer(
   } as unknown as ViteDevServer
 }
 
-function createMockRequest(method: string, body: string) {
+function createMockRequest(method: string, body: string, headers: Record<string, string> = {}) {
   let dataCallback: (chunk: string) => void
   let endCallback: () => void
 
   return {
     method,
+    headers,
     on: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
       if (event === 'data') {
         dataCallback = callback

--- a/packages/vue3/src/useHttp.ts
+++ b/packages/vue3/src/useHttp.ts
@@ -15,7 +15,9 @@ import {
   mergeDataIntoQueryString,
   Method,
   objectToFormData,
+  parseJson,
   Progress,
+  stringifyJson,
   UrlMethodPair,
   UseFormArguments,
   UseFormTransformCallback,
@@ -202,7 +204,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
       if (useFormData) {
         requestData = objectToFormData(transformedData as Record<string, FormDataConvertible>)
       } else {
-        requestData = JSON.stringify(transformedData)
+        requestData = stringifyJson(transformedData)
         contentType = 'application/json'
       }
     }
@@ -224,7 +226,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
         },
       })
 
-      const responseData = (response.data ? JSON.parse(response.data) : null) as TResponse
+      const responseData = (response.data ? parseJson(response.data) : null) as TResponse
 
       if (response.status >= 200 && response.status < 300) {
         markAsSuccessful()
@@ -251,7 +253,7 @@ export default function useHttp<TForm extends FormDataType<TForm>, TResponse = u
 
       if (error instanceof HttpResponseError) {
         if (error.response.status === 422) {
-          const responseData = JSON.parse(error.response.data)
+          const responseData = parseJson(error.response.data)
           const validationErrors = responseData.errors || {}
           const processedErrors = (
             withAllErrors.enabled() ? validationErrors : toSimpleValidationErrors(validationErrors)

--- a/packages/vue3/test-app/Pages/BigInt.vue
+++ b/packages/vue3/test-app/Pages/BigInt.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3'
+import { computed } from 'vue'
+
+const props = defineProps<{
+  safe: number
+  big: bigint
+  negative: bigint
+  nested: { deep: bigint[] }
+  huge: bigint
+  collision?: any
+}>()
+
+const collisionValue = computed(() =>
+  typeof props.collision === 'object' ? props.collision.$bigint : String(props.collision),
+)
+
+const loadReloadData = () => router.get('/bigint/reload')
+
+const loadCollisionData = () => router.get('/bigint/collision')
+
+const submitEcho = () => router.post('/bigint/echo', { value: 111222333444555666n })
+</script>
+
+<template>
+  <div>
+    <p>
+      safe: <span id="safe">{{ safe }}</span> (<span id="safe-type">{{ typeof safe }}</span
+      >)
+    </p>
+    <p>
+      big: <span id="big">{{ big }}</span> (<span id="big-type">{{ typeof big }}</span
+      >)
+    </p>
+    <p>
+      negative: <span id="negative">{{ negative }}</span>
+    </p>
+    <p>
+      huge: <span id="huge">{{ huge }}</span>
+    </p>
+    <p>
+      nested: <span id="nested">{{ nested.deep.join(',') }}</span>
+    </p>
+    <p v-if="collision">
+      collision: <span id="collision">{{ collisionValue }}</span> (<span id="collision-type">{{
+        typeof collision
+      }}</span
+      >)
+    </p>
+
+    <button @click="loadReloadData">Load reload data</button>
+    <button @click="loadCollisionData">Load collision data</button>
+    <button @click="submitEcho">Submit echo</button>
+  </div>
+</template>

--- a/packages/vue3/test-app/Pages/SSR/BigInt.vue
+++ b/packages/vue3/test-app/Pages/SSR/BigInt.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+defineProps<{
+  big: bigint
+  nested: { deep: bigint[] }
+}>()
+</script>
+
+<template>
+  <div>
+    <h1 data-testid="ssr-title">SSR Big Integers</h1>
+
+    <p data-testid="big">big: {{ big }}</p>
+    <p data-testid="big-type">type: {{ typeof big }}</p>
+    <p data-testid="nested">nested: {{ nested.deep.join(',') }}</p>
+  </div>
+</template>

--- a/packages/vue3/test-app/app.ts
+++ b/packages/vue3/test-app/app.ts
@@ -52,13 +52,14 @@ createInertiaApp({
     inst.mount(el)
   },
   http: getHttpConfig(),
-  ...(params.has('withAppDefaults') && {
-    defaults: {
+  defaults: {
+    preserveBigIntegers: true,
+    ...(params.has('withAppDefaults') && {
       visitOptions: (href: string, options: VisitOptions) => {
         return { headers: { ...options.headers, 'X-From-App-Defaults': 'test' } }
       },
-    },
-  }),
+    }),
+  },
   ...(params.has('withDefaultLayout') && {
     layout: () => DefaultLayout,
   }),

--- a/playgrounds/react/config/inertia.php
+++ b/playgrounds/react/config/inertia.php
@@ -122,4 +122,17 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Big Integers
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, integers outside JavaScript's safe integer range are
+    | wrapped so the frontend can revive them as native BigInt values
+    | instead of silently losing precision when JSON is parsed.
+    |
+    */
+
+    'preserve_big_integers' => (bool) env('INERTIA_PRESERVE_BIG_INTEGERS', true),
+
 ];

--- a/playgrounds/react/resources/js/Components/Layout.tsx
+++ b/playgrounds/react/resources/js/Components/Layout.tsx
@@ -55,6 +55,9 @@ export default function Layout({ children, padding = true }: { children: React.R
         <Link href="/flash" className="hover:underline">
           Flash
         </Link>
+        <Link href="/big-integers" className="hover:underline">
+          Big Integers
+        </Link>
         <Link href="/error/404" className="hover:underline">
           Errors
         </Link>

--- a/playgrounds/react/resources/js/Pages/BigIntegers.tsx
+++ b/playgrounds/react/resources/js/Pages/BigIntegers.tsx
@@ -1,0 +1,100 @@
+import { Head, router, usePage } from '@inertiajs/react'
+
+const BigIntegers = ({
+  safe,
+  big,
+  negative,
+  maximum,
+  boundary,
+  order,
+  wrapped,
+}: {
+  safe: number
+  big: bigint
+  negative: bigint
+  maximum: bigint
+  boundary: number
+  order: { id: bigint; lines: { sku: string; reference: bigint }[] }
+  wrapped: { id: bigint }
+}) => {
+  const { flash } = usePage()
+
+  const submit = () => {
+    router.post('/big-integers/echo', { id: big })
+  }
+
+  const rows: [string, string, number | bigint][] = [
+    ['safe', 'safe', safe],
+    ['boundary', 'boundary', boundary],
+    ['big', 'big', big],
+    ['negative', 'negative', negative],
+    ['maximum', 'maximum', maximum],
+    ['order.id', 'nested', order.id],
+    ['order.lines[0].reference', 'deep', order.lines[0].reference],
+    ['wrapped.id', 'wrapped', wrapped.id],
+  ]
+
+  return (
+    <>
+      <Head title="Big Integers" />
+      <h1 className="text-3xl">Big Integers</h1>
+
+      <p className="mt-2 max-w-2xl text-gray-600">
+        Integers outside JavaScript's safe range arrive as native BigInt values instead of being rounded while the page
+        is parsed.
+      </p>
+
+      <div className="mt-6 space-y-6">
+        <div>
+          <h2 className="text-lg font-semibold">Props</h2>
+          <table className="mt-2 text-sm">
+            <thead className="text-left text-gray-500">
+              <tr>
+                <th className="pr-8">Prop</th>
+                <th className="pr-8">Value</th>
+                <th>typeof</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono">
+              {rows.map(([label, id, value]) => (
+                <tr key={id}>
+                  <td className="pr-8">{label}</td>
+                  <td className="pr-8" id={id}>
+                    {String(value)}
+                  </td>
+                  <td>{typeof value}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div>
+          <h2 className="text-lg font-semibold">Precision Loss Without BigInt</h2>
+          <pre className="mt-2 rounded-sm bg-gray-100 p-3 text-sm">
+            {`big              ${big}\nNumber(big)      ${Number(big)}\nbig + 1n         ${big + 1n}`}
+          </pre>
+          <p className="mt-2 text-sm text-gray-600">
+            Casting to a number is what happens without this feature enabled. Arithmetic stays exact while both operands
+            are BigInt values.
+          </p>
+        </div>
+
+        <div>
+          <h2 className="text-lg font-semibold">Submitting</h2>
+          <button onClick={submit} className="mt-2 rounded-sm bg-slate-800 px-4 py-2 text-white">
+            Post big to the server
+          </button>
+          <pre className="mt-2 rounded-sm bg-gray-100 p-3 text-sm" id="echo">
+            {Object.keys(flash ?? {}).length ? JSON.stringify(flash, null, 2) : 'Nothing submitted yet'}
+          </pre>
+          <p className="mt-2 text-sm text-gray-600">
+            The value is encoded on submit and decoded by the Inertia middleware, so the controller receives an integer.
+          </p>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default BigIntegers

--- a/playgrounds/react/resources/js/app.tsx
+++ b/playgrounds/react/resources/js/app.tsx
@@ -2,6 +2,9 @@ import { createInertiaApp } from '@inertiajs/react'
 import Layout from './Components/Layout'
 
 createInertiaApp({
+  defaults: {
+    preserveBigIntegers: true,
+  },
   title: (title) => `${title} - React Playground`,
   layout: () => Layout,
 })

--- a/playgrounds/react/routes/web.php
+++ b/playgrounds/react/routes/web.php
@@ -485,3 +485,30 @@ Route::get('/ssr-debug', fn () => inertia('SsrDebug'));
 Route::get('/ssr-debug/window', fn () => inertia('SsrDebug/WindowError'));
 Route::get('/ssr-debug/document', fn () => inertia('SsrDebug/DocumentError'));
 Route::get('/ssr-debug/localstorage', fn () => inertia('SsrDebug/LocalStorageError'));
+
+Route::get('/big-integers', function () {
+    return inertia('BigIntegers', [
+        'safe' => 42,
+        'big' => 900719925474099988,
+        'negative' => -900719925474099988,
+        'maximum' => PHP_INT_MAX,
+        'boundary' => 9007199254740991,
+        'order' => [
+            'id' => 1234567890123456789,
+            'lines' => [
+                ['sku' => 'A-1', 'reference' => 900719925474099988],
+                ['sku' => 'B-2', 'reference' => 900719925474099989],
+            ],
+        ],
+        'wrapped' => (object) ['id' => 900719925474099988],
+    ]);
+});
+
+Route::post('/big-integers/echo', function (Request $request) {
+    $received = $request->input('id');
+
+    return Inertia::flash([
+        'received' => is_int($received) ? number_format($received, 0, '.', '') : $received,
+        'type' => get_debug_type($received),
+    ])->back();
+});

--- a/playgrounds/svelte5/config/inertia.php
+++ b/playgrounds/svelte5/config/inertia.php
@@ -122,4 +122,17 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Big Integers
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, integers outside JavaScript's safe integer range are
+    | wrapped so the frontend can revive them as native BigInt values
+    | instead of silently losing precision when JSON is parsed.
+    |
+    */
+
+    'preserve_big_integers' => (bool) env('INERTIA_PRESERVE_BIG_INTEGERS', true),
+
 ];

--- a/playgrounds/svelte5/resources/js/Components/Layout.svelte
+++ b/playgrounds/svelte5/resources/js/Components/Layout.svelte
@@ -20,6 +20,7 @@
   <a href="/once/1" use:inertia class="hover:underline">Once</a>
   <a href="/optimistic" use:inertia class="hover:underline">Optimistic</a>
   <a href="/flash" use:inertia class="hover:underline">Flash</a>
+  <a href="/big-integers" use:inertia class="hover:underline">Big Integers</a>
   <a href="/error/404" use:inertia class="hover:underline">Errors</a>
   <a href="/ssr-debug" use:inertia class="hover:underline">SSR Debug</a>
   <button use:inertia={{ method: 'post', href: '/logout' }} type="button" class="hover:underline">Logout</button>

--- a/playgrounds/svelte5/resources/js/Pages/BigIntegers.svelte
+++ b/playgrounds/svelte5/resources/js/Pages/BigIntegers.svelte
@@ -1,0 +1,79 @@
+<script>
+  import { router, usePage } from '@inertiajs/svelte'
+
+  let { appName, safe, big, negative, maximum, boundary, order, wrapped } = $props()
+
+  const page = usePage()
+
+  const rows = $derived([
+    { label: 'safe', id: 'safe', value: safe },
+    { label: 'boundary', id: 'boundary', value: boundary },
+    { label: 'big', id: 'big', value: big },
+    { label: 'negative', id: 'negative', value: negative },
+    { label: 'maximum', id: 'maximum', value: maximum },
+    { label: 'order.id', id: 'nested', value: order.id },
+    { label: 'order.lines[0].reference', id: 'deep', value: order.lines[0].reference },
+    { label: 'wrapped.id', id: 'wrapped', value: wrapped.id },
+  ])
+
+  const submit = () => {
+    router.post('/big-integers/echo', { id: big })
+  }
+</script>
+
+<svelte:head>
+  <title>Big Integers - {appName}</title>
+</svelte:head>
+
+<h1 class="text-3xl">Big Integers</h1>
+
+<p class="mt-2 max-w-2xl text-gray-600">
+  Integers outside JavaScript's safe range arrive as native BigInt values instead of being rounded while the page is
+  parsed.
+</p>
+
+<div class="mt-6 space-y-6">
+  <div>
+    <h2 class="text-lg font-semibold">Props</h2>
+    <table class="mt-2 text-sm">
+      <thead class="text-left text-gray-500">
+        <tr>
+          <th class="pr-8">Prop</th>
+          <th class="pr-8">Value</th>
+          <th>typeof</th>
+        </tr>
+      </thead>
+      <tbody class="font-mono">
+        {#each rows as row (row.id)}
+          <tr>
+            <td class="pr-8">{row.label}</td>
+            <td class="pr-8" id={row.id}>{row.value}</td>
+            <td>{typeof row.value}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  <div>
+    <h2 class="text-lg font-semibold">Precision Loss Without BigInt</h2>
+    <pre class="mt-2 rounded-sm bg-gray-100 p-3 text-sm">big              {big}
+Number(big)      {Number(big)}
+big + 1n         {big + 1n}</pre>
+    <p class="mt-2 text-sm text-gray-600">
+      Casting to a number is what happens without this feature enabled. Arithmetic stays exact while both operands are
+      BigInt values.
+    </p>
+  </div>
+
+  <div>
+    <h2 class="text-lg font-semibold">Submitting</h2>
+    <button onclick={submit} class="mt-2 rounded-sm bg-slate-800 px-4 py-2 text-white">Post big to the server</button>
+    <pre class="mt-2 rounded-sm bg-gray-100 p-3 text-sm" id="echo">{Object.keys(page.flash ?? {}).length
+        ? JSON.stringify(page.flash, null, 2)
+        : 'Nothing submitted yet'}</pre>
+    <p class="mt-2 text-sm text-gray-600">
+      The value is encoded on submit and decoded by the Inertia middleware, so the controller receives an integer.
+    </p>
+  </div>
+</div>

--- a/playgrounds/svelte5/resources/js/app.ts
+++ b/playgrounds/svelte5/resources/js/app.ts
@@ -2,5 +2,8 @@ import { createInertiaApp } from '@inertiajs/svelte'
 import Layout from './Components/Layout.svelte'
 
 createInertiaApp({
+  defaults: {
+    preserveBigIntegers: true,
+  },
   layout: () => Layout,
 })

--- a/playgrounds/svelte5/routes/web.php
+++ b/playgrounds/svelte5/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Requests\PrecognitionFormRequest;
 use App\Models\Todo;
 use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
@@ -550,3 +551,30 @@ Route::get('/ssr-debug', fn () => inertia('SsrDebug'));
 Route::get('/ssr-debug/window', fn () => inertia('SsrDebug/WindowError'));
 Route::get('/ssr-debug/document', fn () => inertia('SsrDebug/DocumentError'));
 Route::get('/ssr-debug/localstorage', fn () => inertia('SsrDebug/LocalStorageError'));
+
+Route::get('/big-integers', function () {
+    return inertia('BigIntegers', [
+        'safe' => 42,
+        'big' => 900719925474099988,
+        'negative' => -900719925474099988,
+        'maximum' => PHP_INT_MAX,
+        'boundary' => 9007199254740991,
+        'order' => [
+            'id' => 1234567890123456789,
+            'lines' => [
+                ['sku' => 'A-1', 'reference' => 900719925474099988],
+                ['sku' => 'B-2', 'reference' => 900719925474099989],
+            ],
+        ],
+        'wrapped' => (object) ['id' => 900719925474099988],
+    ]);
+});
+
+Route::post('/big-integers/echo', function (Request $request) {
+    $received = $request->input('id');
+
+    return Inertia::flash([
+        'received' => is_int($received) ? number_format($received, 0, '.', '') : $received,
+        'type' => get_debug_type($received),
+    ])->back();
+});

--- a/playgrounds/vue3/config/inertia.php
+++ b/playgrounds/vue3/config/inertia.php
@@ -122,4 +122,17 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Big Integers
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, integers outside JavaScript's safe integer range are
+    | wrapped so the frontend can revive them as native BigInt values
+    | instead of silently losing precision when JSON is parsed.
+    |
+    */
+
+    'preserve_big_integers' => (bool) env('INERTIA_PRESERVE_BIG_INTEGERS', true),
+
 ];

--- a/playgrounds/vue3/resources/js/Components/Layout.vue
+++ b/playgrounds/vue3/resources/js/Components/Layout.vue
@@ -30,6 +30,7 @@ const appName = computed(() => page.props.appName)
     <Link href="/once/1" class="hover:underline">Once</Link>
     <Link href="/optimistic" class="hover:underline">Optimistic</Link>
     <Link href="/flash" class="hover:underline">Flash</Link>
+    <Link href="/big-integers" class="hover:underline">Big Integers</Link>
     <Link href="/error/404" class="hover:underline">Errors</Link>
     <Link href="/ssr-debug" class="hover:underline">SSR Debug</Link>
   </nav>

--- a/playgrounds/vue3/resources/js/Pages/BigIntegers.vue
+++ b/playgrounds/vue3/resources/js/Pages/BigIntegers.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { Head, router, usePage } from '@inertiajs/vue3'
+import { computed } from 'vue'
+
+const props = defineProps<{
+  safe: number
+  big: bigint
+  negative: bigint
+  maximum: bigint
+  boundary: number
+  order: { id: bigint; lines: { sku: string; reference: bigint }[] }
+  wrapped: { id: bigint }
+}>()
+
+const page = usePage()
+
+const echo = computed(() => (Object.keys(page.flash ?? {}).length ? page.flash : 'Nothing submitted yet'))
+const rounded = computed(() => Number(props.big))
+const incremented = computed(() => props.big + 1n)
+
+const submit = () => {
+  router.post('/big-integers/echo', { id: props.big })
+}
+</script>
+
+<template>
+  <Head title="Big Integers" />
+  <h1 class="text-3xl">Big Integers</h1>
+
+  <p class="mt-2 max-w-2xl text-gray-600">
+    Integers outside JavaScript's safe range arrive as native BigInt values instead of being rounded while the page is
+    parsed.
+  </p>
+
+  <div class="mt-6 space-y-6">
+    <div>
+      <h2 class="text-lg font-semibold">Props</h2>
+      <table class="mt-2 text-sm">
+        <thead class="text-left text-gray-500">
+          <tr>
+            <th class="pr-8">Prop</th>
+            <th class="pr-8">Value</th>
+            <th>typeof</th>
+          </tr>
+        </thead>
+        <tbody class="font-mono">
+          <tr>
+            <td class="pr-8">safe</td>
+            <td class="pr-8" id="safe">{{ safe }}</td>
+            <td>{{ typeof safe }}</td>
+          </tr>
+          <tr>
+            <td class="pr-8">boundary</td>
+            <td class="pr-8" id="boundary">{{ boundary }}</td>
+            <td>{{ typeof boundary }}</td>
+          </tr>
+          <tr>
+            <td class="pr-8">big</td>
+            <td class="pr-8" id="big">{{ big }}</td>
+            <td>{{ typeof big }}</td>
+          </tr>
+          <tr>
+            <td class="pr-8">negative</td>
+            <td class="pr-8" id="negative">{{ negative }}</td>
+            <td>{{ typeof negative }}</td>
+          </tr>
+          <tr>
+            <td class="pr-8">maximum</td>
+            <td class="pr-8" id="maximum">{{ maximum }}</td>
+            <td>{{ typeof maximum }}</td>
+          </tr>
+          <tr>
+            <td class="pr-8">order.id</td>
+            <td class="pr-8" id="nested">{{ order.id }}</td>
+            <td>{{ typeof order.id }}</td>
+          </tr>
+          <tr>
+            <td class="pr-8">order.lines[0].reference</td>
+            <td class="pr-8" id="deep">{{ order.lines[0].reference }}</td>
+            <td>{{ typeof order.lines[0].reference }}</td>
+          </tr>
+          <tr>
+            <td class="pr-8">wrapped.id</td>
+            <td class="pr-8" id="wrapped">{{ wrapped.id }}</td>
+            <td>{{ typeof wrapped.id }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold">Precision Loss Without BigInt</h2>
+      <pre class="mt-2 rounded-sm bg-gray-100 p-3 text-sm">
+big              {{ big }}
+Number(big)      {{ rounded }}
+big + 1n         {{ incremented }}</pre
+      >
+      <p class="mt-2 text-sm text-gray-600">
+        Casting to a number is what happens without this feature enabled. Arithmetic stays exact while both operands are
+        BigInt values.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold">Submitting</h2>
+      <button @click="submit" class="mt-2 rounded-sm bg-slate-800 px-4 py-2 text-white">Post big to the server</button>
+      <pre class="mt-2 rounded-sm bg-gray-100 p-3 text-sm" id="echo">{{ echo }}</pre>
+      <p class="mt-2 text-sm text-gray-600">
+        The value is encoded on submit and decoded by the Inertia middleware, so the controller receives an integer.
+      </p>
+    </div>
+  </div>
+</template>

--- a/playgrounds/vue3/resources/js/app.ts
+++ b/playgrounds/vue3/resources/js/app.ts
@@ -2,6 +2,9 @@ import { createInertiaApp } from '@inertiajs/vue3'
 import Layout from './Components/Layout.vue'
 
 createInertiaApp({
+  defaults: {
+    preserveBigIntegers: true,
+  },
   title: (title) => `${title} - Vue 3 Playground`,
   layout: () => Layout,
 })

--- a/playgrounds/vue3/routes/web.php
+++ b/playgrounds/vue3/routes/web.php
@@ -623,3 +623,30 @@ Route::get('/ssr-debug/document', fn () => inertia('SsrDebug/DocumentError'));
 Route::get('/ssr-debug/localstorage', fn () => inertia('SsrDebug/LocalStorageError'));
 Route::get('/ssr-debug/render', fn () => inertia('SsrDebug/RenderError'));
 Route::get('/ssr-debug/non-existent', fn () => inertia('SsrDebug/NonExistentComponent'));
+
+Route::get('/big-integers', function () {
+    return inertia('BigIntegers', [
+        'safe' => 42,
+        'big' => 900719925474099988,
+        'negative' => -900719925474099988,
+        'maximum' => PHP_INT_MAX,
+        'boundary' => 9007199254740991,
+        'order' => [
+            'id' => 1234567890123456789,
+            'lines' => [
+                ['sku' => 'A-1', 'reference' => 900719925474099988],
+                ['sku' => 'B-2', 'reference' => 900719925474099989],
+            ],
+        ],
+        'wrapped' => (object) ['id' => 900719925474099988],
+    ]);
+});
+
+Route::post('/big-integers/echo', function (Request $request) {
+    $received = $request->input('id');
+
+    return Inertia::flash([
+        'received' => is_int($received) ? number_format($received, 0, '.', '') : $received,
+        'type' => get_debug_type($received),
+    ])->back();
+});

--- a/tests/app/helpers.js
+++ b/tests/app/helpers.js
@@ -5,20 +5,55 @@ const package = process.env.PACKAGE || 'vue3'
 
 const ssr = require('./ssr')
 
-const buildPageData = (req, data) => ({
-  component: req.path
-    .slice(1)
-    .split('/')
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-    .join('/')
-    .split('-')
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-    .join(''),
-  props: {},
-  url: req.originalUrl,
-  version: null,
-  ...data,
-})
+const encodeBigInts = (value) => {
+  if (typeof value === 'bigint') {
+    return { $bigint: value.toString() }
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(encodeBigInts)
+  }
+
+  if (value !== null && typeof value === 'object' && value.constructor === Object) {
+    return Object.fromEntries(Object.entries(value).map(([key, val]) => [key, encodeBigInts(val)]))
+  }
+
+  return value
+}
+
+const decodeBigInts = (value) => {
+  if (Array.isArray(value)) {
+    return value.map(decodeBigInts)
+  }
+
+  if (value !== null && typeof value === 'object' && value.constructor === Object) {
+    const keys = Object.keys(value)
+
+    if (keys.length === 1 && keys[0] === '$bigint') {
+      return BigInt(value.$bigint)
+    }
+
+    return Object.fromEntries(Object.entries(value).map(([key, val]) => [key, decodeBigInts(val)]))
+  }
+
+  return value
+}
+
+const buildPageData = (req, data) =>
+  encodeBigInts({
+    component: req.path
+      .slice(1)
+      .split('/')
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join('/')
+      .split('-')
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(''),
+    props: {},
+    url: req.originalUrl,
+    version: null,
+    ...data,
+  })
 
 const processPartialProps = (req, data) => {
   const partialDataHeader = req.headers['x-inertia-partial-data'] || ''
@@ -62,6 +97,7 @@ const applyDefaultNonce = (req, html) => {
 
 module.exports = {
   package,
+  decodeBigInts,
   render: (req, res, data) => {
     data = buildPageData(req, data)
 

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -66,6 +66,16 @@ app.get('/ssr/page1', (req, res) =>
   }),
 )
 
+app.get('/ssr/bigint', (req, res) =>
+  inertia.renderSSR(req, res, {
+    component: 'SSR/BigInt',
+    props: {
+      big: 900719925474099988n,
+      nested: { deep: [900719925474099988n, 2n] },
+    },
+  }),
+)
+
 app.get('/ssr/page2', (req, res) =>
   inertia.renderSSR(req, res, {
     component: 'SSR/Page2',
@@ -179,6 +189,59 @@ app.get('/ssr/infinite-scroll', (req, res) => {
 })
 
 // createInertiaApp (unified) test routes
+app.get('/bigint', (req, res) =>
+  inertia.render(req, res, {
+    component: 'BigInt',
+    props: {
+      safe: 42,
+      big: 900719925474099988n,
+      negative: -900719925474099988n,
+      nested: { deep: [900719925474099988n, 2n] },
+      huge: 9223372036854775807n,
+    },
+  }),
+)
+
+app.get('/bigint/reload', (req, res) =>
+  inertia.render(req, res, {
+    component: 'BigInt',
+    props: {
+      safe: 100,
+      big: 123456789012345678n,
+      negative: -900719925474099988n,
+      nested: { deep: [900719925474099988n, 2n] },
+      huge: 9223372036854775807n,
+    },
+  }),
+)
+
+app.get('/bigint/collision', (req, res) =>
+  inertia.render(req, res, {
+    component: 'BigInt',
+    props: {
+      safe: 42,
+      big: 1,
+      negative: -1,
+      huge: 2,
+      nested: { deep: [1, 2] },
+      collision: { $bigint: '123' },
+    },
+  }),
+)
+
+app.post('/bigint/echo', (req, res) =>
+  inertia.render(req, res, {
+    component: 'BigInt',
+    props: {
+      safe: 42,
+      big: inertia.decodeBigInts(req.body).value,
+      negative: -900719925474099988n,
+      nested: { deep: [900719925474099988n, 2n] },
+      huge: 9223372036854775807n,
+    },
+  }),
+)
+
 app.get('/unified', (req, res) =>
   inertia.renderUnified(req, res, {
     component: 'Home',

--- a/tests/app/ssr.js
+++ b/tests/app/ssr.js
@@ -21,6 +21,8 @@ function renderToPort(port, pageData) {
         headers: {
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(postData),
+          // Mirrors the Laravel adapter, which only sends this when the config is enabled
+          'X-Inertia-Preserve-Big-Integers': 'true',
         },
       },
       (res) => {

--- a/tests/bigint.spec.ts
+++ b/tests/bigint.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test'
+import { pageLoads } from './support'
+
+test('it decodes integers beyond the safe range as native BigInt values without losing precision', async ({ page }) => {
+  pageLoads.watch(page)
+
+  await page.goto('/')
+  await page.evaluate(() => (window as any).testing.Inertia.visit('/bigint'))
+
+  await expect(page.locator('#safe')).toHaveText('42')
+  await expect(page.locator('#safe-type')).toHaveText('number')
+
+  await expect(page.locator('#big')).toHaveText('900719925474099988')
+  await expect(page.locator('#big-type')).toHaveText('bigint')
+
+  await expect(page.locator('#negative')).toHaveText('-900719925474099988')
+  await expect(page.locator('#huge')).toHaveText('9223372036854775807')
+  await expect(page.locator('#nested')).toHaveText('900719925474099988,2')
+
+  await page.getByRole('button', { name: 'Load reload data' }).click()
+
+  await expect(page.locator('#safe')).toHaveText('100')
+  await expect(page.locator('#big')).toHaveText('123456789012345678')
+
+  await page.goBack()
+
+  await expect(page.locator('#safe')).toHaveText('42')
+  await expect(page.locator('#big')).toHaveText('900719925474099988')
+
+  await page.getByRole('button', { name: 'Submit echo' }).click()
+
+  await expect(page.locator('#big')).toHaveText('111222333444555666')
+})
+
+test('it treats the marker as a reserved wire shape once big integers are enabled', async ({ page }) => {
+  pageLoads.watch(page)
+
+  await page.goto('/')
+  await page.evaluate(() => (window as any).testing.Inertia.visit('/bigint/collision'))
+
+  await expect(page.locator('#collision-type')).toHaveText('bigint')
+  await expect(page.locator('#collision')).toHaveText('123')
+})

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -35,6 +35,24 @@ test.describe('SSR', () => {
     })
   })
 
+  test('renders big integers on the server and hydrates them without a mismatch', async ({ page }) => {
+    const response = await page.request.get('/ssr/bigint')
+    const html = await response.text()
+
+    expect(html).toMatch(/big:.*900719925474099988/)
+    expect(html).toContain('{"$bigint":"900719925474099988"}')
+
+    consoleMessages.listen(page)
+
+    await page.goto('/ssr/bigint')
+
+    await expect(page.getByTestId('big')).toHaveText('big: 900719925474099988')
+    await expect(page.getByTestId('big-type')).toHaveText('type: bigint')
+    await expect(page.getByTestId('nested')).toHaveText('nested: 900719925474099988,2')
+
+    expect(consoleMessages.errors).toHaveLength(0)
+  })
+
   test('embeds page data in a script element', async ({ page }) => {
     const response = await page.request.get('/ssr/page-with-script-element')
     const html = await response.text()


### PR DESCRIPTION
This PR is the client-side half of big integer support, see inertiajs/inertia-laravel#904.

PHP integers that exceed JavaScript's safe integer range are silently rounded while the page JSON is parsed, so a snowflake identifier or a 64-bit column value reaches your components as a different number than the one you sent. `900719925474099988` becomes `900719925474100000`, with nothing to indicate it happened.

Values wrapped by the server-side adapter are now revived as native `BigInt` values instead, and BigInt values are encoded again on the way out, so they survive a full round trip.

Enable it alongside the server-side configuration.

```js
createInertiaApp({
  defaults: {
    preserveBigIntegers: true,
  },
})
```

Integers within the safe range stay regular numbers, so only the values that need it become a `BigInt`.

```vue
<script setup>
const props = defineProps({ id: BigInt });
</script>

<template>
  <p>Order {{ id }}</p>
  <!-- Order 900719925474099988 -->
</template>
```

Every JSON boundary participates: the initial page, visit responses, partial reloads, encrypted history, remembered state, request bodies, form data, and `useHttp`. Server-side rendering works in both production and development, with no extra configuration in your SSR entry. Because the client configuration cannot be known before the page is parsed there, the server-side adapter signals the SSR server by header instead.

Submitting a `BigInt` is encoded on the way out and decoded by the Inertia middleware, so your controller receives an integer.

```js
router.post("/orders", { id: props.id });
```

Payloads without markers take the same code path as before, so applications that leave the option disabled see no change in behavior. Two things are worth a changelog note though. A `BigInt` in a form data submission is now sent as its digits, where previously the field was silently dropped. And `FormDataConvertibleValue` gained `bigint`, which may require a change in code that exhaustively narrows that union.

The `{ "$bigint": "<digits>" }` marker follows the convention [documented on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json), and is a reserved wire shape while the feature is enabled.