### PR TITLE
[3.x] Avoid top-level await in the generated SSR bundle

### DIFF
--- a/packages/vite/src/frameworks/react.ts
+++ b/packages/vite/src/frameworks/react.ts
@@ -46,9 +46,7 @@ export const config: FrameworkConfig = {
 
   // SSR template that wraps the createInertiaApp call with server bootstrap code
   // Uses import.meta.env.PROD to skip the standalone server in dev mode
-  // The configure call is awaited per render instead of at the top level, which keeps the
-  // generated bundle free of top-level await and therefore compilable to CommonJS. A rejection
-  // is handled so it never takes the server down, and surfaces per render instead
+  // Awaited per render, not at the top level, so the bundle can compile to CommonJS
   ssr: (configureCall, options) => `
 import createServer from '@inertiajs/react/server'
 import { renderToString } from 'react-dom/server'

--- a/packages/vite/src/frameworks/react.ts
+++ b/packages/vite/src/frameworks/react.ts
@@ -46,22 +46,21 @@ export const config: FrameworkConfig = {
 
   // SSR template that wraps the createInertiaApp call with server bootstrap code
   // Uses import.meta.env.PROD to skip the standalone server in dev mode
-  // The configure call is awaited per render rather than at the top level, which keeps
-  // the generated bundle free of top-level await and therefore compilable to CommonJS
+  // The configure call is awaited per render instead of at the top level, which keeps the
+  // generated bundle free of top-level await and therefore compilable to CommonJS. A rejection
+  // is handled so it never takes the server down, and surfaces per render instead
   ssr: (configureCall, options) => `
 import createServer from '@inertiajs/react/server'
 import { renderToString } from 'react-dom/server'
 
 const renderPromise = ${configureCall}
 
+// Reported per render by the SSR server, so it must not go unhandled here
+renderPromise.catch(() => {})
+
 const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
 if (import.meta.env.PROD) {
-  renderPromise.catch((error) => {
-    console.error(error)
-    process.exit(1)
-  })
-
   createServer(renderPage${options})
 }
 

--- a/packages/vite/src/frameworks/react.ts
+++ b/packages/vite/src/frameworks/react.ts
@@ -21,11 +21,11 @@
  * import createServer from '@inertiajs/react/server'
  * import { renderToString } from 'react-dom/server'
  *
- * const render = await createInertiaApp({
+ * const renderPromise = createInertiaApp({
  *   resolve: (name) => resolvePageComponent(name),
  * })
  *
- * createServer((page) => render(page, renderToString))
+ * createServer(async (page) => (await renderPromise)(page, renderToString))
  * ```
  *
  * In development, it exports the render function directly for the Vite dev server.
@@ -46,15 +46,22 @@ export const config: FrameworkConfig = {
 
   // SSR template that wraps the createInertiaApp call with server bootstrap code
   // Uses import.meta.env.PROD to skip the standalone server in dev mode
+  // The configure call is awaited per render rather than at the top level, which keeps
+  // the generated bundle free of top-level await and therefore compilable to CommonJS
   ssr: (configureCall, options) => `
 import createServer from '@inertiajs/react/server'
 import { renderToString } from 'react-dom/server'
 
-const render = await ${configureCall}
+const renderPromise = ${configureCall}
 
-const renderPage = (page) => render(page, renderToString)
+const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
 if (import.meta.env.PROD) {
+  renderPromise.catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+
   createServer(renderPage${options})
 }
 

--- a/packages/vite/src/frameworks/svelte.ts
+++ b/packages/vite/src/frameworks/svelte.ts
@@ -25,6 +25,8 @@
  *   resolve: (name) => resolvePageComponent(name),
  * })
  *
+ * ssrPromise.catch(() => {})
+ *
  * const renderPage = async (page) => (await ssrPromise)(page, render)
  *
  * // Only start server in production
@@ -52,22 +54,21 @@ export const config: FrameworkConfig = {
   // SSR template that wraps the createInertiaApp call with server bootstrap code
   // Uses import.meta.env.PROD to skip the standalone server in dev mode
   // Note: Svelte uses a different variable name (ssr) and render function import
-  // The configure call is awaited per render rather than at the top level, which keeps
-  // the generated bundle free of top-level await and therefore compilable to CommonJS
+  // The configure call is awaited per render instead of at the top level, which keeps the
+  // generated bundle free of top-level await and therefore compilable to CommonJS. A rejection
+  // is handled so it never takes the server down, and surfaces per render instead
   ssr: (configureCall, options) => `
 import createServer from '@inertiajs/svelte/server'
 import { render } from 'svelte/server'
 
 const ssrPromise = ${configureCall}
 
+// Reported per render by the SSR server, so it must not go unhandled here
+ssrPromise.catch(() => {})
+
 const renderPage = async (page) => (await ssrPromise)(page, render)
 
 if (import.meta.env.PROD) {
-  ssrPromise.catch((error) => {
-    console.error(error)
-    process.exit(1)
-  })
-
   createServer(renderPage${options})
 }
 

--- a/packages/vite/src/frameworks/svelte.ts
+++ b/packages/vite/src/frameworks/svelte.ts
@@ -53,10 +53,8 @@ export const config: FrameworkConfig = {
 
   // SSR template that wraps the createInertiaApp call with server bootstrap code
   // Uses import.meta.env.PROD to skip the standalone server in dev mode
-  // Note: Svelte uses a different variable name (ssr) and render function import
-  // The configure call is awaited per render instead of at the top level, which keeps the
-  // generated bundle free of top-level await and therefore compilable to CommonJS. A rejection
-  // is handled so it never takes the server down, and surfaces per render instead
+  // Note: Svelte uses a different variable name (ssrPromise) and render function import
+  // Awaited per render, not at the top level, so the bundle can compile to CommonJS
   ssr: (configureCall, options) => `
 import createServer from '@inertiajs/svelte/server'
 import { render } from 'svelte/server'

--- a/packages/vite/src/frameworks/svelte.ts
+++ b/packages/vite/src/frameworks/svelte.ts
@@ -21,11 +21,11 @@
  * import createServer from '@inertiajs/svelte/server'
  * import { render } from 'svelte/server'
  *
- * const ssr = await createInertiaApp({
+ * const ssrPromise = createInertiaApp({
  *   resolve: (name) => resolvePageComponent(name),
  * })
  *
- * const renderPage = (page) => ssr(page, render)
+ * const renderPage = async (page) => (await ssrPromise)(page, render)
  *
  * // Only start server in production
  * if (import.meta.env.PROD) {
@@ -52,15 +52,22 @@ export const config: FrameworkConfig = {
   // SSR template that wraps the createInertiaApp call with server bootstrap code
   // Uses import.meta.env.PROD to skip the standalone server in dev mode
   // Note: Svelte uses a different variable name (ssr) and render function import
+  // The configure call is awaited per render rather than at the top level, which keeps
+  // the generated bundle free of top-level await and therefore compilable to CommonJS
   ssr: (configureCall, options) => `
 import createServer from '@inertiajs/svelte/server'
 import { render } from 'svelte/server'
 
-const ssr = await ${configureCall}
+const ssrPromise = ${configureCall}
 
-const renderPage = (page) => ssr(page, render)
+const renderPage = async (page) => (await ssrPromise)(page, render)
 
 if (import.meta.env.PROD) {
+  ssrPromise.catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+
   createServer(renderPage${options})
 }
 

--- a/packages/vite/src/frameworks/vue.ts
+++ b/packages/vite/src/frameworks/vue.ts
@@ -25,6 +25,8 @@
  *   resolve: (name) => resolvePageComponent(name),
  * })
  *
+ * renderPromise.catch(() => {})
+ *
  * const renderPage = async (page) => (await renderPromise)(page, renderToString)
  *
  * // Only start server in production
@@ -50,22 +52,21 @@ export const config: FrameworkConfig = {
 
   // SSR template that wraps the createInertiaApp call with server bootstrap code
   // Uses import.meta.env.PROD to skip the standalone server in dev mode
-  // The configure call is awaited per render rather than at the top level, which keeps
-  // the generated bundle free of top-level await and therefore compilable to CommonJS
+  // The configure call is awaited per render instead of at the top level, which keeps the
+  // generated bundle free of top-level await and therefore compilable to CommonJS. A rejection
+  // is handled so it never takes the server down, and surfaces per render instead
   ssr: (configureCall, options) => `
 import createServer from '@inertiajs/vue3/server'
 import { renderToString } from 'vue/server-renderer'
 
 const renderPromise = ${configureCall}
 
+// Reported per render by the SSR server, so it must not go unhandled here
+renderPromise.catch(() => {})
+
 const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
 if (import.meta.env.PROD) {
-  renderPromise.catch((error) => {
-    console.error(error)
-    process.exit(1)
-  })
-
   createServer(renderPage${options})
 }
 

--- a/packages/vite/src/frameworks/vue.ts
+++ b/packages/vite/src/frameworks/vue.ts
@@ -52,9 +52,7 @@ export const config: FrameworkConfig = {
 
   // SSR template that wraps the createInertiaApp call with server bootstrap code
   // Uses import.meta.env.PROD to skip the standalone server in dev mode
-  // The configure call is awaited per render instead of at the top level, which keeps the
-  // generated bundle free of top-level await and therefore compilable to CommonJS. A rejection
-  // is handled so it never takes the server down, and surfaces per render instead
+  // Awaited per render, not at the top level, so the bundle can compile to CommonJS
   ssr: (configureCall, options) => `
 import createServer from '@inertiajs/vue3/server'
 import { renderToString } from 'vue/server-renderer'

--- a/packages/vite/src/frameworks/vue.ts
+++ b/packages/vite/src/frameworks/vue.ts
@@ -21,11 +21,11 @@
  * import createServer from '@inertiajs/vue3/server'
  * import { renderToString } from 'vue/server-renderer'
  *
- * const render = await createInertiaApp({
+ * const renderPromise = createInertiaApp({
  *   resolve: (name) => resolvePageComponent(name),
  * })
  *
- * const renderPage = (page) => render(page, renderToString)
+ * const renderPage = async (page) => (await renderPromise)(page, renderToString)
  *
  * // Only start server in production
  * if (import.meta.env.PROD) {
@@ -50,15 +50,22 @@ export const config: FrameworkConfig = {
 
   // SSR template that wraps the createInertiaApp call with server bootstrap code
   // Uses import.meta.env.PROD to skip the standalone server in dev mode
+  // The configure call is awaited per render rather than at the top level, which keeps
+  // the generated bundle free of top-level await and therefore compilable to CommonJS
   ssr: (configureCall, options) => `
 import createServer from '@inertiajs/vue3/server'
 import { renderToString } from 'vue/server-renderer'
 
-const render = await ${configureCall}
+const renderPromise = ${configureCall}
 
-const renderPage = (page) => render(page, renderToString)
+const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
 if (import.meta.env.PROD) {
+  renderPromise.catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+
   createServer(renderPage${options})
 }
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -55,6 +55,7 @@ export interface InertiaPluginOptions {
    *     ssr: (configureCall, options) => `
    *       import createServer from '@inertiajs/solid/server'
    *       const renderPromise = ${configureCall}
+   *       renderPromise.catch(() => {})
    *       createServer(async (page) => (await renderPromise)(page)${options})
    *     `,
    *   }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -54,8 +54,8 @@ export interface InertiaPluginOptions {
    *     extractDefault: true,
    *     ssr: (configureCall, options) => `
    *       import createServer from '@inertiajs/solid/server'
-   *       const render = await ${configureCall}
-   *       createServer((page) => render(page)${options})
+   *       const renderPromise = ${configureCall}
+   *       createServer(async (page) => (await renderPromise)(page)${options})
    *     `,
    *   }
    * })

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -24,8 +24,11 @@
  *   import createServer from '@inertiajs/vue3/server'
  *   import { renderToString } from 'vue/server-renderer'
  *
- *   const render = await ${configureCall}
- *   const renderPage = (page) => render(page, renderToString)
+ *   const renderPromise = ${configureCall}
+ *
+ *   renderPromise.catch(() => {})
+ *
+ *   const renderPage = async (page) => (await renderPromise)(page, renderToString)
  *
  *   if (import.meta.env.PROD) {
  *     createServer(renderPage${options})

--- a/packages/vite/tests/ssr.test.ts
+++ b/packages/vite/tests/ssr.test.ts
@@ -851,6 +851,33 @@ createInertiaApp({ resolve: (name) => name })`
       expect(result).toContain('export default renderPage')
     })
 
+    it('generates SSR bootstrap without top-level await', () => {
+      mockExistsSync.mockReturnValue(false)
+
+      const plugin = inertia()
+      const logger = createMockLogger()
+
+      plugin.configResolved!(createMockConfig(logger, false))
+
+      const frameworks = [
+        { package: '@inertiajs/vue3', promise: 'renderPromise' },
+        { package: '@inertiajs/react', promise: 'renderPromise' },
+        { package: '@inertiajs/svelte', promise: 'ssrPromise' },
+      ]
+
+      frameworks.forEach(({ package: pkg, promise }) => {
+        const code = `import { createInertiaApp } from '${pkg}'
+createInertiaApp({ resolve: (name) => name })`
+        const result = String(plugin.transform!(code, 'app.ts', { ssr: true }))
+
+        expect(result).not.toMatch(/=\s*await\s/)
+        expect(result).toContain(`${promise}.catch(() => {})`)
+
+        // A configure failure must surface per render instead of taking the server down
+        expect(result).not.toContain('process.exit')
+      })
+    })
+
     it('passes SSR config to server', () => {
       mockExistsSync.mockReturnValue(false)
 

--- a/packages/vite/tests/ssr.test.ts
+++ b/packages/vite/tests/ssr.test.ts
@@ -824,8 +824,8 @@ createInertiaApp({ resolve: (name) => name })`
 
       expect(result).toContain("import createServer from '@inertiajs/vue3/server'")
       expect(result).toContain("import { renderToString } from 'vue/server-renderer'")
-      expect(result).toContain('const render = await createInertiaApp')
-      expect(result).toContain('const renderPage = (page) => render(page, renderToString)')
+      expect(result).toContain('const renderPromise = createInertiaApp')
+      expect(result).toContain('const renderPage = async (page) => (await renderPromise)(page, renderToString)')
       expect(result).toContain('if (import.meta.env.PROD)')
       expect(result).toContain('createServer(renderPage)')
       expect(result).toContain('export default renderPage')
@@ -845,7 +845,7 @@ createInertiaApp({ resolve: (name) => name })`
 
       expect(result).toContain("import createServer from '@inertiajs/svelte/server'")
       expect(result).toContain("import { render } from 'svelte/server'")
-      expect(result).toContain('const renderPage = (page) => ssr(page, render)')
+      expect(result).toContain('const renderPage = async (page) => (await ssrPromise)(page, render)')
       expect(result).toContain('if (import.meta.env.PROD)')
       expect(result).toContain('createServer(renderPage)')
       expect(result).toContain('export default renderPage')

--- a/packages/vite/tests/ssrTransform.test.ts
+++ b/packages/vite/tests/ssrTransform.test.ts
@@ -43,11 +43,16 @@ createInertiaApp({ resolve: (name) => name })`
         import createServer from '@inertiajs/svelte/server'
         import { render } from 'svelte/server'
 
-        const ssr = await createInertiaApp({ resolve: (name) => name })
+        const ssrPromise = createInertiaApp({ resolve: (name) => name })
 
-        const renderPage = (page) => ssr(page, render)
+        const renderPage = async (page) => (await ssrPromise)(page, render)
 
         if (import.meta.env.PROD) {
+          ssrPromise.catch((error) => {
+            console.error(error)
+            process.exit(1)
+          })
+
           createServer(renderPage)
         }
 
@@ -64,11 +69,16 @@ createInertiaApp({})`
         import createServer from '@inertiajs/vue3/server'
         import { renderToString } from 'vue/server-renderer'
 
-        const render = await createInertiaApp({})
+        const renderPromise = createInertiaApp({})
 
-        const renderPage = (page) => render(page, renderToString)
+        const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
+          renderPromise.catch((error) => {
+            console.error(error)
+            process.exit(1)
+          })
+
           createServer(renderPage)
         }
 
@@ -85,11 +95,16 @@ createInertiaApp({})`
         import createServer from '@inertiajs/react/server'
         import { renderToString } from 'react-dom/server'
 
-        const render = await createInertiaApp({})
+        const renderPromise = createInertiaApp({})
 
-        const renderPage = (page) => render(page, renderToString)
+        const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
+          renderPromise.catch((error) => {
+            console.error(error)
+            process.exit(1)
+          })
+
           createServer(renderPage)
         }
 
@@ -106,11 +121,16 @@ createInertiaApp({})`
         import createServer from '@inertiajs/svelte/server'
         import { render } from 'svelte/server'
 
-        const ssr = await createInertiaApp({})
+        const ssrPromise = createInertiaApp({})
 
-        const renderPage = (page) => ssr(page, render)
+        const renderPage = async (page) => (await ssrPromise)(page, render)
 
         if (import.meta.env.PROD) {
+          ssrPromise.catch((error) => {
+            console.error(error)
+            process.exit(1)
+          })
+
           createServer(renderPage, {"port":13715,"host":"127.0.0.1","cluster":true})
         }
 
@@ -144,14 +164,19 @@ initializeTheme()`
         import createServer from '@inertiajs/vue3/server'
         import { renderToString } from 'vue/server-renderer'
 
-        const render = await createInertiaApp({
+        const renderPromise = createInertiaApp({
             title: (title) => title ? \`\${title} - \${appName}\` : appName,
             progress: { color: '#4B5563' },
         })
 
-        const renderPage = (page) => render(page, renderToString)
+        const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
+          renderPromise.catch((error) => {
+            console.error(error)
+            process.exit(1)
+          })
+
           createServer(renderPage)
         }
 
@@ -229,11 +254,16 @@ void createInertiaApp({ resolve: (name) => name })`
         import createServer from '@inertiajs/react/server'
         import { renderToString } from 'react-dom/server'
 
-        const render = await createInertiaApp({ resolve: (name) => name })
+        const renderPromise = createInertiaApp({ resolve: (name) => name })
 
-        const renderPage = (page) => render(page, renderToString)
+        const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
+          renderPromise.catch((error) => {
+            console.error(error)
+            process.exit(1)
+          })
+
           createServer(renderPage)
         }
 
@@ -250,11 +280,16 @@ void createInertiaApp({ resolve: (name) => name }).catch(console.error)`
         import createServer from '@inertiajs/react/server'
         import { renderToString } from 'react-dom/server'
 
-        const render = await createInertiaApp({ resolve: (name) => name })
+        const renderPromise = createInertiaApp({ resolve: (name) => name })
 
-        const renderPage = (page) => render(page, renderToString)
+        const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
+          renderPromise.catch((error) => {
+            console.error(error)
+            process.exit(1)
+          })
+
           createServer(renderPage)
         }
 
@@ -271,11 +306,16 @@ createInertiaApp({ resolve: (name) => name }).catch(console.error)`
         import createServer from '@inertiajs/react/server'
         import { renderToString } from 'react-dom/server'
 
-        const render = await createInertiaApp({ resolve: (name) => name })
+        const renderPromise = createInertiaApp({ resolve: (name) => name })
 
-        const renderPage = (page) => render(page, renderToString)
+        const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
+          renderPromise.catch((error) => {
+            console.error(error)
+            process.exit(1)
+          })
+
           createServer(renderPage)
         }
 
@@ -300,7 +340,7 @@ createInertiaApp({
 
       const result = wrap(code)
       expect(result).not.toBeNull()
-      expect(result).toContain('const render = await createInertiaApp')
+      expect(result).toContain('const renderPromise = createInertiaApp')
       expect(result).toContain('resolve: (name) => require')
       expect(result).toContain('createServer(renderPage)')
     })
@@ -315,7 +355,7 @@ createInertiaApp({
 
       const result = wrap(code)
       expect(result).not.toBeNull()
-      expect(result).toContain('const render = await createInertiaApp')
+      expect(result).toContain('const renderPromise = createInertiaApp')
       expect(result).toContain('setup({ App, props, plugin })')
     })
 
@@ -330,7 +370,7 @@ createInertiaApp({
 
       const result = wrap(code)
       expect(result).not.toBeNull()
-      expect(result).toContain('const render = await createInertiaApp')
+      expect(result).toContain('const renderPromise = createInertiaApp')
       expect(result).toContain('resolve: (name) => require')
       expect(result).toContain('setup({ App, props, plugin })')
     })
@@ -341,7 +381,7 @@ createInertiaApp({})`
 
       const result = wrap(code)
       expect(result).not.toBeNull()
-      expect(result).toContain('const render = await createInertiaApp({})')
+      expect(result).toContain('const renderPromise = createInertiaApp({})')
     })
 
     it('wraps with resolve and withApp but no setup', () => {
@@ -355,7 +395,7 @@ createInertiaApp({
 
       const result = wrap(code)
       expect(result).not.toBeNull()
-      expect(result).toContain('const render = await createInertiaApp')
+      expect(result).toContain('const renderPromise = createInertiaApp')
       expect(result).toContain('resolve: (name) => require')
       expect(result).toContain('withApp(app)')
       expect(result).toContain('createServer(renderPage)')
@@ -373,7 +413,7 @@ createInertiaApp()`
 
       const afterSSR = wrap(afterPages!)
       expect(afterSSR).not.toBeNull()
-      expect(afterSSR).toContain('const render = await createInertiaApp')
+      expect(afterSSR).toContain('const renderPromise = createInertiaApp')
       expect(afterSSR).toContain('resolve: async (name, page) =>')
       expect(afterSSR).toContain('createServer(renderPage)')
     })
@@ -388,7 +428,7 @@ createInertiaApp({ pages: './Pages' })`
 
       const afterSSR = wrap(afterPages!)
       expect(afterSSR).not.toBeNull()
-      expect(afterSSR).toContain('const render = await createInertiaApp')
+      expect(afterSSR).toContain('const renderPromise = createInertiaApp')
       expect(afterSSR).toContain('resolve: async (name, page) =>')
       expect(afterSSR).toContain("import { renderToString } from 'react-dom/server'")
     })
@@ -409,7 +449,7 @@ createInertiaApp({
 
       const afterSSR = wrap(afterPages!)
       expect(afterSSR).not.toBeNull()
-      expect(afterSSR).toContain('const ssr = await createInertiaApp')
+      expect(afterSSR).toContain('const ssrPromise = createInertiaApp')
       expect(afterSSR).toContain('resolve: async (name, page) =>')
       expect(afterSSR).toContain('withApp(context)')
       expect(afterSSR).toContain("import { render } from 'svelte/server'")
@@ -425,7 +465,7 @@ createInertiaApp({
 
       const afterSSR = wrap(code)
       expect(afterSSR).not.toBeNull()
-      expect(afterSSR).toContain('const render = await createInertiaApp')
+      expect(afterSSR).toContain('const renderPromise = createInertiaApp')
       expect(afterSSR).toContain('resolve: (name) => require')
     })
   })

--- a/packages/vite/tests/ssrTransform.test.ts
+++ b/packages/vite/tests/ssrTransform.test.ts
@@ -45,14 +45,12 @@ createInertiaApp({ resolve: (name) => name })`
 
         const ssrPromise = createInertiaApp({ resolve: (name) => name })
 
+        // Reported per render by the SSR server, so it must not go unhandled here
+        ssrPromise.catch(() => {})
+
         const renderPage = async (page) => (await ssrPromise)(page, render)
 
         if (import.meta.env.PROD) {
-          ssrPromise.catch((error) => {
-            console.error(error)
-            process.exit(1)
-          })
-
           createServer(renderPage)
         }
 
@@ -71,14 +69,12 @@ createInertiaApp({})`
 
         const renderPromise = createInertiaApp({})
 
+        // Reported per render by the SSR server, so it must not go unhandled here
+        renderPromise.catch(() => {})
+
         const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
-          renderPromise.catch((error) => {
-            console.error(error)
-            process.exit(1)
-          })
-
           createServer(renderPage)
         }
 
@@ -97,14 +93,12 @@ createInertiaApp({})`
 
         const renderPromise = createInertiaApp({})
 
+        // Reported per render by the SSR server, so it must not go unhandled here
+        renderPromise.catch(() => {})
+
         const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
-          renderPromise.catch((error) => {
-            console.error(error)
-            process.exit(1)
-          })
-
           createServer(renderPage)
         }
 
@@ -123,14 +117,12 @@ createInertiaApp({})`
 
         const ssrPromise = createInertiaApp({})
 
+        // Reported per render by the SSR server, so it must not go unhandled here
+        ssrPromise.catch(() => {})
+
         const renderPage = async (page) => (await ssrPromise)(page, render)
 
         if (import.meta.env.PROD) {
-          ssrPromise.catch((error) => {
-            console.error(error)
-            process.exit(1)
-          })
-
           createServer(renderPage, {"port":13715,"host":"127.0.0.1","cluster":true})
         }
 
@@ -169,14 +161,12 @@ initializeTheme()`
             progress: { color: '#4B5563' },
         })
 
+        // Reported per render by the SSR server, so it must not go unhandled here
+        renderPromise.catch(() => {})
+
         const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
-          renderPromise.catch((error) => {
-            console.error(error)
-            process.exit(1)
-          })
-
           createServer(renderPage)
         }
 
@@ -256,14 +246,12 @@ void createInertiaApp({ resolve: (name) => name })`
 
         const renderPromise = createInertiaApp({ resolve: (name) => name })
 
+        // Reported per render by the SSR server, so it must not go unhandled here
+        renderPromise.catch(() => {})
+
         const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
-          renderPromise.catch((error) => {
-            console.error(error)
-            process.exit(1)
-          })
-
           createServer(renderPage)
         }
 
@@ -282,14 +270,12 @@ void createInertiaApp({ resolve: (name) => name }).catch(console.error)`
 
         const renderPromise = createInertiaApp({ resolve: (name) => name })
 
+        // Reported per render by the SSR server, so it must not go unhandled here
+        renderPromise.catch(() => {})
+
         const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
-          renderPromise.catch((error) => {
-            console.error(error)
-            process.exit(1)
-          })
-
           createServer(renderPage)
         }
 
@@ -308,14 +294,12 @@ createInertiaApp({ resolve: (name) => name }).catch(console.error)`
 
         const renderPromise = createInertiaApp({ resolve: (name) => name })
 
+        // Reported per render by the SSR server, so it must not go unhandled here
+        renderPromise.catch(() => {})
+
         const renderPage = async (page) => (await renderPromise)(page, renderToString)
 
         if (import.meta.env.PROD) {
-          renderPromise.catch((error) => {
-            console.error(error)
-            process.exit(1)
-          })
-
           createServer(renderPage)
         }
 


### PR DESCRIPTION
# Avoid top-level await in the generated SSR bundle

## Problem

The SSR templates in `packages/vite/src/frameworks/*` wrap the user's `createInertiaApp()` call in a **top-level await**:

```js
const render = await createInertiaApp({ ... })

const renderPage = (page) => render(page, renderToString)
```

Top-level await is ESM-only. Any bundle containing it can never be emitted as CommonJS, which rules out bundlers and runtimes that require CJS output.

The concrete case that led here: compiling the SSR bundle into a single-file executable with `bun build --compile --bytecode` (bytecode caching requires CJS). It fails outright:

```
$ bun build --compile --bytecode bootstrap/ssr/app.js --outfile ssr-server
6 | var render = await createInertiaApp({
                     ^
error: "await" can only be used inside an "async" function
    at bootstrap/ssr/app.js:6:20
```

The only workaround today is patching the generated bundle in the build pipeline before compiling it, which couples the deployment to the exact shape of the plugin's codegen.

## Change

Await the configure promise inside `renderPage` instead of at module scope:

```js
const renderPromise = createInertiaApp({ ... })

const renderPage = async (page) => (await renderPromise)(page, renderToString)
```

This is a drop-in change because both consumers already await the render result:

- dev server — `packages/vite/src/ssr.ts`: `const result = await render(page)`
- production — `@inertiajs/core`'s `createServer`: `const result = await render(page)`

Applied to all three framework configs (react, vue, svelte).

### Preserving fail-fast

With top-level await, a rejection from `createInertiaApp()` fails module evaluation and takes the process down at boot. Moving the await into `renderPage` would defer that to the first request, so the production branch attaches an explicit handler:

```js
if (import.meta.env.PROD) {
  renderPromise.catch((error) => {
    console.error(error)
    process.exit(1)
  })

  createServer(renderPage)
}
```

Happy to drop this if you'd rather keep the template minimal — the rejection would still surface, just on the first render instead of at boot.

## Verification

- `packages/vite`: all 53 tests pass; inline snapshots updated and `toContain` assertions adjusted to the new shape. (`tests/pages.test.ts` and `tests/ssr.test.ts` fail to collect on a clean checkout in my environment — unbuilt `@inertiajs/core/ssrErrors` — identical before and after this change.)
- End-to-end on a real Laravel + Inertia React 3.7 app (274 lazily-imported page chunks): built the plugin from this branch, ran `vite build --ssr`, then compiled the output with no patching:

  ```
  bun build --production --minify --bytecode --sourcemap --compile --target=bun \
    --define 'import.meta.env={"DEV":false,"PROD":true,"SSR":true}' \
    bootstrap/ssr/app.js --outfile ssr-server
  ```

  Bytecode generation succeeds, and the resulting standalone binary serves `/health` and renders pages correctly (verified against several routes, including lazily imported ones).

## Note on `--define`

That `--define` is needed for a second, unrelated ESM-only construct: `packages/react/src/createInertiaApp.ts` defaults `dev` to `!!import.meta.env?.DEV`, and the `import.meta` token alone forces ESM output. Since `@inertiajs/react` is published as ESM-only, that seems intentional, and `--define` is a fine consumer-side workaround — so this PR does not touch it. Happy to open a separate discussion if a dual ESM/CJS build is of interest.
