### PR TITLE
3.x] Add preventNavigationWhenDirty to useForm and <Form>

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -75,6 +75,8 @@ export const config = new Config<InertiaAppConfig>({
     recentlySuccessfulDuration: 2_000,
     forceIndicesArrayFormatInFormData: true,
     withAllErrors: false,
+    preventNavigationWhenDirty: false,
+    unsavedChangesMessage: 'Changes you made may not be saved.',
   },
   prefetch: {
     cacheFor: 30_000,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -76,7 +76,7 @@ export const config = new Config<InertiaAppConfig>({
     forceIndicesArrayFormatInFormData: true,
     withAllErrors: false,
     preventNavigationWhenDirty: false,
-    unsavedChangesMessage: 'Changes you made may not be saved.',
+    unsavedChangesMessage: 'You have unsaved changes. Are you sure you want to navigate away?',
   },
   prefetch: {
     cacheFor: 30_000,

--- a/packages/core/src/dirtyFormGuard.ts
+++ b/packages/core/src/dirtyFormGuard.ts
@@ -1,0 +1,84 @@
+import { config } from './config'
+import { eventHandler } from './eventHandler'
+import { GlobalEvent } from './types'
+
+export type DirtyFormEntry = {
+  isDirty: () => boolean
+  isSubmitting: () => boolean
+  message?: string
+}
+
+class DirtyFormGuard {
+  protected forms = new Set<DirtyFormEntry>()
+  protected removeBeforeListener: VoidFunction | null = null
+  protected beforeUnloadListener: ((event: BeforeUnloadEvent) => void) | null = null
+
+  public register(entry: DirtyFormEntry): VoidFunction {
+    this.forms.add(entry)
+    this.setupListeners()
+
+    return () => {
+      this.forms.delete(entry)
+      this.teardownListeners()
+    }
+  }
+
+  public hasDirtyForms(): boolean {
+    return [...this.forms].some((entry) => entry.isDirty() && !entry.isSubmitting())
+  }
+
+  public confirmNavigation(): boolean {
+    if (!this.hasDirtyForms()) {
+      return true
+    }
+
+    const dirtyEntry = [...this.forms].find((entry) => entry.isDirty() && !entry.isSubmitting())
+    const message = dirtyEntry?.message ?? config.get('form.unsavedChangesMessage')
+
+    return window.confirm(message)
+  }
+
+  protected setupListeners(): void {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (!this.removeBeforeListener) {
+      this.removeBeforeListener = eventHandler.onGlobalEvent('before', (event: GlobalEvent<'before'>) => {
+        if (event.detail.visit.prefetch) {
+          return
+        }
+
+        if (!this.confirmNavigation()) {
+          return false
+        }
+      })
+    }
+
+    if (!this.beforeUnloadListener) {
+      this.beforeUnloadListener = (event: BeforeUnloadEvent) => {
+        if (this.hasDirtyForms()) {
+          event.preventDefault()
+        }
+      }
+
+      window.addEventListener('beforeunload', this.beforeUnloadListener)
+    }
+  }
+
+  protected teardownListeners(): void {
+    if (this.forms.size > 0) {
+      return
+    }
+
+    this.removeBeforeListener?.()
+    this.removeBeforeListener = null
+
+    if (this.beforeUnloadListener && typeof window !== 'undefined') {
+      window.removeEventListener('beforeunload', this.beforeUnloadListener)
+      this.beforeUnloadListener = null
+    }
+  }
+}
+
+export const dirtyFormGuard = new DirtyFormGuard()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export { UseFormUtils } from './useFormUtils'
 
 export { axiosAdapter } from './axiosHttpClient'
 export { config } from './config'
+export { dirtyFormGuard } from './dirtyFormGuard'
 export { getInitialPageFromDOM, getScrollableParent } from './domUtils'
 export { hasFiles } from './files'
 export { objectToFormData } from './formData'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -676,6 +676,8 @@ export type InertiaAppConfig = {
     recentlySuccessfulDuration: number
     forceIndicesArrayFormatInFormData: boolean
     withAllErrors: boolean
+    preventNavigationWhenDirty: boolean
+    unsavedChangesMessage: string
   }
   prefetch: {
     cacheFor: CacheForOption | CacheForOption[]
@@ -825,6 +827,8 @@ export type FormComponentProps<TForm = Record<string, FormDataConvertible>> = Pa
   validateFiles?: boolean
   validationTimeout?: number
   withAllErrors?: boolean | null
+  preventNavigationWhenDirty?: boolean | null
+  unsavedChangesMessage?: string
 }
 
 export type FormComponentMethods<TForm extends object = Record<string, any>> = {

--- a/packages/core/tests/dirtyFormGuard.test.ts
+++ b/packages/core/tests/dirtyFormGuard.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { config } from '../src/config'
+import { dirtyFormGuard } from '../src/dirtyFormGuard'
+
+describe('dirtyFormGuard', () => {
+  const unregisters: VoidFunction[] = []
+
+  beforeEach(() => {
+    config.replace({})
+
+    vi.stubGlobal('confirm', vi.fn(() => true))
+    vi.stubGlobal('window', {
+      confirm: vi.fn(() => true),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+    vi.stubGlobal('document', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    unregisters.splice(0).forEach((unregister) => unregister())
+    vi.unstubAllGlobals()
+  })
+
+  const register = (...args: Parameters<typeof dirtyFormGuard.register>) => {
+    const unregister = dirtyFormGuard.register(...args)
+    unregisters.push(unregister)
+
+    return unregister
+  }
+
+  it('returns true from confirmNavigation when no forms are registered', () => {
+    expect(dirtyFormGuard.confirmNavigation()).toBe(true)
+    expect(window.confirm).not.toHaveBeenCalled()
+  })
+
+  it('returns true from confirmNavigation when registered forms are clean', () => {
+    register({
+      isDirty: () => false,
+      isSubmitting: () => false,
+    })
+
+    expect(dirtyFormGuard.confirmNavigation()).toBe(true)
+    expect(window.confirm).not.toHaveBeenCalled()
+  })
+
+  it('prompts when a registered form is dirty', () => {
+    register({
+      isDirty: () => true,
+      isSubmitting: () => false,
+      message: 'Custom unsaved changes message',
+    })
+
+    expect(dirtyFormGuard.confirmNavigation()).toBe(true)
+    expect(window.confirm).toHaveBeenCalledWith('Custom unsaved changes message')
+  })
+
+  it('returns false when the user dismisses the confirmation dialog', () => {
+    vi.mocked(window.confirm).mockReturnValue(false)
+
+    register({
+      isDirty: () => true,
+      isSubmitting: () => false,
+    })
+
+    expect(dirtyFormGuard.confirmNavigation()).toBe(false)
+  })
+
+  it('does not prompt when a dirty form is submitting', () => {
+    register({
+      isDirty: () => true,
+      isSubmitting: () => true,
+    })
+
+    expect(dirtyFormGuard.hasDirtyForms()).toBe(false)
+    expect(dirtyFormGuard.confirmNavigation()).toBe(true)
+    expect(window.confirm).not.toHaveBeenCalled()
+  })
+
+  it('uses the configured default message when no custom message is provided', () => {
+    config.set('form.unsavedChangesMessage', 'Default unsaved message')
+
+    register({
+      isDirty: () => true,
+      isSubmitting: () => false,
+    })
+
+    dirtyFormGuard.confirmNavigation()
+
+    expect(window.confirm).toHaveBeenCalledWith('Default unsaved message')
+  })
+})

--- a/packages/react/src/Form.ts
+++ b/packages/react/src/Form.ts
@@ -1,5 +1,6 @@
 import {
   config,
+  dirtyFormGuard,
   FormComponentProps,
   FormComponentRef,
   FormComponentResetSymbol,
@@ -72,6 +73,8 @@ const Form = forwardRef<FormComponentRef, FormProps>(
       onSubmitComplete = noop,
       disableWhileProcessing = false,
       cancelOnUnmount = false,
+      preventNavigationWhenDirty = null,
+      unsavedChangesMessage,
       resetOnError = false,
       resetOnSuccess = false,
       setDefaultsOnSuccess = false,
@@ -127,10 +130,28 @@ const Form = forwardRef<FormComponentRef, FormProps>(
     }, [component, instant, action])
 
     const [isDirty, setIsDirty] = useState(false)
+    const isDirtyRef = useRef(isDirty)
+    isDirtyRef.current = isDirty
+    const isSubmittingRef = useRef(false)
     const defaultData = useRef<FormData>(new FormData())
 
     const cancelOnUnmountRef = useRef(cancelOnUnmount)
     cancelOnUnmountRef.current = cancelOnUnmount
+
+    const preventNavigationEnabled =
+      preventNavigationWhenDirty ?? config.get('form.preventNavigationWhenDirty')
+
+    useEffect(() => {
+      if (!preventNavigationEnabled) {
+        return
+      }
+
+      return dirtyFormGuard.register({
+        isDirty: () => isDirtyRef.current,
+        isSubmitting: () => isSubmittingRef.current,
+        message: unsavedChangesMessage,
+      })
+    }, [preventNavigationEnabled, unsavedChangesMessage])
 
     const getFormData = (submitter?: FormSubmitter): FormData =>
       formElement.current ? new FormData(formElement.current, submitter) : new FormData()
@@ -240,10 +261,18 @@ const Form = forwardRef<FormComponentRef, FormProps>(
         component: resolvedComponent,
         optimistic: optimistic ? (pageProps) => optimistic(pageProps, data) : undefined,
         onCancelToken,
-        onBefore,
+        onBefore: (visit) => {
+          isSubmittingRef.current = true
+
+          return onBefore(visit)
+        },
         onStart,
         onProgress,
-        onFinish,
+        onFinish: (visit) => {
+          isSubmittingRef.current = false
+
+          return onFinish(visit)
+        },
         onCancel,
         onSuccess: async (...args) => {
           const result = await onSuccess(...args)

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -64,6 +64,7 @@ export interface InertiaFormProps<TForm extends Record<string, any>> {
   cancel: () => void
   dontRemember: <K extends FormDataKeys<TForm>>(...fields: K[]) => InertiaFormProps<TForm>
   optimistic: <TProps>(callback: OptimisticCallback<TProps>) => InertiaFormProps<TForm>
+  preventNavigationWhenDirty: (message?: string) => InertiaFormProps<TForm>
   withPrecognition: (...args: UseFormWithPrecognitionArguments) => InertiaPrecognitiveFormProps<TForm>
 }
 
@@ -145,6 +146,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
     defaultsCalledInOnSuccessRef,
     resetBeforeSubmit,
     finishProcessing,
+    isSubmittingRef,
   } = useFormState<TForm>({
     data,
     precognitionEndpoint,
@@ -166,6 +168,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
           return options.onCancelToken?.(token)
         },
         onBefore: (visit) => {
+          isSubmittingRef.current = true
           resetBeforeSubmit()
 
           return options.onBefore?.(visit)
@@ -208,6 +211,8 @@ export default function useForm<TForm extends FormDataType<TForm>>(
           return options.onCancel?.()
         },
         onFinish: (visit) => {
+          isSubmittingRef.current = false
+
           if (isMounted.current) {
             finishProcessing()
           }

--- a/packages/react/src/useFormState.ts
+++ b/packages/react/src/useFormState.ts
@@ -9,6 +9,7 @@ import {
   UseFormTransformCallback,
   UseFormUtils,
   UseFormWithPrecognitionArguments,
+  dirtyFormGuard,
 } from '@inertiajs/core'
 import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
@@ -61,6 +62,7 @@ export interface FormStateProps<TForm extends object> {
     (errors: FormDataErrors<TForm>): void
   }
   withPrecognition: (...args: UseFormWithPrecognitionArguments) => FormStateWithPrecognition<TForm>
+  preventNavigationWhenDirty: (message?: string) => FormState<TForm>
 }
 
 export interface FormStateValidationProps<TForm extends object> {
@@ -111,6 +113,8 @@ export interface UseFormStateReturn<TForm extends object> {
   resetBeforeSubmit: () => void
   finishProcessing: () => void
   withAllErrors: { enabled: () => boolean; enable: () => void }
+  isSubmittingRef: React.MutableRefObject<boolean>
+  preventNavigationWhenDirty: { enabled: () => boolean; enable: (message?: string) => void; message: () => string | undefined }
 }
 
 export default function useFormState<TForm extends object>(
@@ -145,12 +149,34 @@ export default function useFormState<TForm extends object>(
   const [validFields, setValidFields] = useState<string[]>([])
   const withAllErrorsRef = useRef<boolean | null>(null)
   const withAllErrorsEnabled = () => withAllErrorsRef.current ?? config.get('form.withAllErrors')
+  const preventNavigationWhenDirtyRef = useRef<{ enabled: boolean; message?: string } | null>(null)
+  const preventNavigationWhenDirtyEnabled = () =>
+    preventNavigationWhenDirtyRef.current?.enabled ?? config.get('form.preventNavigationWhenDirty')
+  const isSubmittingRef = useRef(false)
+  const [preventNavigationVersion, setPreventNavigationVersion] = useState(0)
 
   const dataRef = useRef(data)
+  const defaultsRef = useRef(defaults)
 
   useEffect(() => {
     dataRef.current = data
   })
+
+  useEffect(() => {
+    defaultsRef.current = defaults
+  })
+
+  useEffect(() => {
+    if (!preventNavigationWhenDirtyEnabled()) {
+      return
+    }
+
+    return dirtyFormGuard.register({
+      isDirty: () => !isEqual(dataRef.current, defaultsRef.current),
+      isSubmitting: () => isSubmittingRef.current,
+      message: preventNavigationWhenDirtyRef.current?.message,
+    })
+  }, [preventNavigationVersion, defaults])
 
   useEffect(() => {
     isMounted.current = true
@@ -358,6 +384,11 @@ export default function useFormState<TForm extends object>(
     setError,
     clearErrors,
     resetAndClearErrors,
+    preventNavigationWhenDirty: (message?: string) => {
+      preventNavigationWhenDirtyRef.current = { enabled: true, message }
+      setPreventNavigationVersion((version) => version + 1)
+      return form
+    },
   } as FormState<TForm>
 
   const validate = (field?: string | NamedInputEvent | ValidationConfig, config?: ValidationConfig) => {
@@ -475,6 +506,15 @@ export default function useFormState<TForm extends object>(
       enable: () => {
         withAllErrorsRef.current = true
       },
+    },
+    isSubmittingRef,
+    preventNavigationWhenDirty: {
+      enabled: preventNavigationWhenDirtyEnabled,
+      enable: (message?: string) => {
+        preventNavigationWhenDirtyRef.current = { enabled: true, message }
+        setPreventNavigationVersion((version) => version + 1)
+      },
+      message: () => preventNavigationWhenDirtyRef.current?.message,
     },
   }
 }

--- a/packages/react/src/useFormState.ts
+++ b/packages/react/src/useFormState.ts
@@ -21,7 +21,7 @@ import {
   ValidationConfig,
   Validator,
 } from 'laravel-precognition'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { config } from '.'
 
 export type SetDataByObject<TForm> = (data: Partial<TForm>) => void
@@ -166,7 +166,7 @@ export default function useFormState<TForm extends object>(
     defaultsRef.current = defaults
   })
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!preventNavigationWhenDirtyEnabled()) {
       return
     }
@@ -176,7 +176,7 @@ export default function useFormState<TForm extends object>(
       isSubmitting: () => isSubmittingRef.current,
       message: preventNavigationWhenDirtyRef.current?.message,
     })
-  }, [preventNavigationVersion, defaults])
+  }, [preventNavigationVersion])
 
   useEffect(() => {
     isMounted.current = true
@@ -386,7 +386,7 @@ export default function useFormState<TForm extends object>(
     resetAndClearErrors,
     preventNavigationWhenDirty: (message?: string) => {
       preventNavigationWhenDirtyRef.current = { enabled: true, message }
-      setPreventNavigationVersion((version) => version + 1)
+
       return form
     },
   } as FormState<TForm>

--- a/packages/react/test-app/Pages/FormHelper/PreventNavigationWhenDirty.tsx
+++ b/packages/react/test-app/Pages/FormHelper/PreventNavigationWhenDirty.tsx
@@ -1,0 +1,50 @@
+import { Form, Link, useForm } from '@inertiajs/react'
+
+export default () => {
+  const form = useForm({ name: 'foo' }).preventNavigationWhenDirty()
+
+  return (
+    <div>
+      <div id="dirty-status">Form is {form.isDirty ? 'dirty' : 'clean'}</div>
+
+      <label>
+        Name
+        <input
+          type="text"
+          id="name"
+          value={form.data.name}
+          onChange={(e) => form.setData('name', e.target.value)}
+        />
+      </label>
+
+      <button type="button" className="submit" onClick={() => form.post('/form-helper/prevent-navigation-when-dirty')}>
+        Submit form
+      </button>
+
+      <Link href="/form-helper/data" id="navigate-away">
+        Navigate away
+      </Link>
+
+      <Form
+        action="/form-helper/prevent-navigation-when-dirty"
+        method="post"
+        preventNavigationWhenDirty
+        id="guarded-form"
+      >
+        {({ isDirty, processing }) => (
+          <>
+            <div id="form-component-dirty-status">Form component is {isDirty ? 'dirty' : 'clean'}</div>
+            <input type="text" name="title" id="form-title" defaultValue="initial" />
+            <button type="submit" disabled={processing}>
+              Submit guarded form
+            </button>
+          </>
+        )}
+      </Form>
+
+      <Link href="/form-helper/data" id="navigate-away-from-form">
+        Navigate away from form
+      </Link>
+    </div>
+  )
+}

--- a/packages/svelte/src/components/Form.svelte
+++ b/packages/svelte/src/components/Form.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    dirtyFormGuard,
     formDataToObject,
     FormComponentResetSymbol,
     resetFormFields,
@@ -52,6 +53,8 @@
     validationTimeout?: FormComponentProps['validationTimeout']
     optimistic?: FormComponentProps['optimistic']
     withAllErrors?: FormComponentProps['withAllErrors']
+    preventNavigationWhenDirty?: FormComponentProps['preventNavigationWhenDirty']
+    unsavedChangesMessage?: FormComponentProps['unsavedChangesMessage']
     component?: FormComponentProps['component']
     instant?: FormComponentProps['instant']
     children?: import('svelte').Snippet<[FormComponentSlotProps]>
@@ -86,6 +89,8 @@
     validationTimeout = 1500,
     optimistic,
     withAllErrors = null,
+    preventNavigationWhenDirty = null,
+    unsavedChangesMessage,
     component = undefined,
     instant = false,
     children,
@@ -109,7 +114,12 @@
 
   let formElement: HTMLFormElement = $state(null!)
   let isDirty = $state(false)
+  let isSubmitting = false
   let defaultData: FormData = new FormData()
+
+  const preventNavigationEnabled = $derived(
+    preventNavigationWhenDirty ?? config.get('form.preventNavigationWhenDirty'),
+  )
 
   const _method = $derived(isUrlMethodPair(action) ? action.method : ((method ?? 'get').toLowerCase() as Method))
   const _action = $derived(isUrlMethodPair(action) ? action.url : (action as string))
@@ -171,10 +181,18 @@
       component: resolvedComponent,
       optimistic: optimistic ? (pageProps) => optimistic(pageProps, data) : undefined,
       onCancelToken,
-      onBefore,
+      onBefore: (visit) => {
+        isSubmitting = true
+
+        return onBefore(visit)
+      },
       onStart,
       onProgress,
-      onFinish,
+      onFinish: (visit) => {
+        isSubmitting = false
+
+        return onFinish(visit)
+      },
       onCancel,
       onSuccess: async (...args) => {
         const result = await onSuccess?.(...args)
@@ -292,6 +310,18 @@
         form.cancel()
       }
     }
+  })
+
+  $effect(() => {
+    if (!preventNavigationEnabled) {
+      return
+    }
+
+    return dirtyFormGuard.register({
+      isDirty: () => isDirty,
+      isSubmitting: () => isSubmitting,
+      message: unsavedChangesMessage,
+    })
   })
 
   $effect(() => {

--- a/packages/svelte/src/useForm.svelte.ts
+++ b/packages/svelte/src/useForm.svelte.ts
@@ -89,6 +89,7 @@ export interface InertiaFormProps<TForm extends object> {
   cancel(): void
   dontRemember<K extends FormDataKeys<TForm>>(...fields: K[]): this
   optimistic<TProps>(callback: OptimisticCallback<TProps>): this
+  preventNavigationWhenDirty(message?: string): this
   withPrecognition: (...args: UseFormWithPrecognitionArguments) => InertiaPrecognitiveFormStore<TForm>
 }
 
@@ -162,6 +163,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
     setRememberExcludeKeys,
     resetBeforeSubmit,
     finishProcessing,
+    setSubmitting,
   } = useFormState<TForm>({
     data,
     rememberKey,
@@ -186,6 +188,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
         return options.onCancelToken?.(token)
       },
       onBefore: (visit: PendingVisit) => {
+        setSubmitting(true)
         resetBeforeSubmit()
 
         return options.onBefore?.(visit)
@@ -220,6 +223,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
         return options.onCancel?.()
       },
       onFinish: (visit: ActiveVisit) => {
+        setSubmitting(false)
         finishProcessing()
         cancelToken = null
 

--- a/packages/svelte/src/useFormState.svelte.ts
+++ b/packages/svelte/src/useFormState.svelte.ts
@@ -9,7 +9,7 @@ import type {
   UseFormTransformCallback,
   UseFormWithPrecognitionArguments,
 } from '@inertiajs/core'
-import { router, UseFormUtils } from '@inertiajs/core'
+import { router, UseFormUtils, dirtyFormGuard } from '@inertiajs/core'
 import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
 import type { NamedInputEvent, ValidationConfig, Validator } from 'laravel-precognition'
@@ -42,6 +42,7 @@ export interface FormStateProps<TForm extends object> {
   resetAndClearErrors<K extends FormDataKeys<TForm>>(...fields: K[]): this
   setError<K extends FormDataKeys<TForm>>(field: K, value: ErrorValue): this
   setError(errors: FormDataErrors<TForm>): this
+  preventNavigationWhenDirty(message?: string): this
   withPrecognition: (...args: UseFormWithPrecognitionArguments) => FormStateWithPrecognition<TForm>
 }
 
@@ -99,6 +100,8 @@ export interface UseFormStateReturn<TForm extends object> {
   resetBeforeSubmit: () => void
   finishProcessing: () => void
   withAllErrors: { enabled: () => boolean; enable: () => void }
+  setSubmitting: (value: boolean) => void
+  preventNavigationWhenDirty: { enabled: () => boolean; enable: (message?: string) => void; message: () => string | undefined }
 }
 
 export default function useFormState<TForm extends object>(
@@ -119,6 +122,12 @@ export default function useFormState<TForm extends object>(
   let validatorRef: Validator | null = null
   let withAllErrors: boolean | null = null
   const withAllErrorsEnabled = () => withAllErrors ?? config.get('form.withAllErrors')
+  let preventNavigationWhenDirtyEnabled: boolean | null = null
+  let preventNavigationMessage: string | undefined
+  const preventNavigationEnabled = () =>
+    preventNavigationWhenDirtyEnabled ?? config.get('form.preventNavigationWhenDirty')
+  let isSubmitting = false
+  let preventNavigationVersion = $state(0)
   let precognitionEndpoint = initialPrecognitionEndpoint ?? null
   let recentlySuccessfulTimeoutId: ReturnType<typeof setTimeout> | null = null
   let defaultsCalledInOnSuccess = false
@@ -258,6 +267,12 @@ export default function useFormState<TForm extends object>(
     },
     transform(callback: TransformCallback<TForm>) {
       transform = callback
+      return this
+    },
+    preventNavigationWhenDirty(message?: string) {
+      preventNavigationWhenDirtyEnabled = true
+      preventNavigationMessage = message
+      preventNavigationVersion++
       return this
     },
     defaults(fieldOrFields?: FormDataKeys<TForm> | Partial<TForm>, maybeValue?: unknown) {
@@ -402,6 +417,20 @@ export default function useFormState<TForm extends object>(
     form.withPrecognition(precognitionEndpoint)
   }
 
+  $effect(() => {
+    preventNavigationVersion
+
+    if (!preventNavigationEnabled()) {
+      return
+    }
+
+    return dirtyFormGuard.register({
+      isDirty: () => form.isDirty,
+      isSubmitting: () => isSubmitting,
+      message: preventNavigationMessage,
+    })
+  })
+
   return {
     form: form as FormState<TForm> & InternalRememberState<TForm>,
     setDefaults: (newDefaults: TForm) => {
@@ -444,6 +473,18 @@ export default function useFormState<TForm extends object>(
       enable: () => {
         withAllErrors = true
       },
+    },
+    setSubmitting: (value: boolean) => {
+      isSubmitting = value
+    },
+    preventNavigationWhenDirty: {
+      enabled: preventNavigationEnabled,
+      enable: (message?: string) => {
+        preventNavigationWhenDirtyEnabled = true
+        preventNavigationMessage = message
+        preventNavigationVersion++
+      },
+      message: () => preventNavigationMessage,
     },
   }
 }

--- a/packages/svelte/test-app/Pages/FormHelper/PreventNavigationWhenDirty.svelte
+++ b/packages/svelte/test-app/Pages/FormHelper/PreventNavigationWhenDirty.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { Form, Link, useForm } from '@inertiajs/svelte'
+
+  const form = useForm({ name: 'foo' }).preventNavigationWhenDirty()
+</script>
+
+<div>
+  <div id="dirty-status">Form is {form.isDirty ? 'dirty' : 'clean'}</div>
+
+  <label>
+    Name
+    <input type="text" id="name" bind:value={form.name} />
+  </label>
+
+  <button type="button" class="submit" onclick={() => form.post('/form-helper/prevent-navigation-when-dirty')}>
+    Submit form
+  </button>
+
+  <Link href="/form-helper/data" id="navigate-away">Navigate away</Link>
+
+  <Form
+    action="/form-helper/prevent-navigation-when-dirty"
+    method="post"
+    preventNavigationWhenDirty={true}
+    id="guarded-form"
+  >
+    {#snippet children({ isDirty, processing })}
+      <div id="form-component-dirty-status">Form component is {isDirty ? 'dirty' : 'clean'}</div>
+      <input type="text" name="title" id="form-title" value="initial" />
+      <button type="submit" disabled={processing}>Submit guarded form</button>
+    {/snippet}
+  </Form>
+
+  <Link href="/form-helper/data" id="navigate-away-from-form">Navigate away from form</Link>
+</div>

--- a/packages/vue3/src/form.ts
+++ b/packages/vue3/src/form.ts
@@ -1,5 +1,6 @@
 import {
   config,
+  dirtyFormGuard,
   Errors,
   FormComponentProps,
   FormComponentRef,
@@ -154,6 +155,14 @@ const Form = defineComponent({
       type: Boolean as PropType<FormComponentProps['withAllErrors']>,
       default: null,
     },
+    preventNavigationWhenDirty: {
+      type: Boolean as PropType<FormComponentProps['preventNavigationWhenDirty']>,
+      default: null,
+    },
+    unsavedChangesMessage: {
+      type: String as PropType<FormComponentProps['unsavedChangesMessage']>,
+      default: undefined,
+    },
     component: {
       type: String as PropType<FormComponentProps['component']>,
       default: null,
@@ -204,6 +213,27 @@ const Form = defineComponent({
 
     // Can't use computed because FormData is not reactive
     const isDirty = ref(false)
+    let isSubmitting = false
+    let unregisterDirtyFormGuard: VoidFunction | null = null
+
+    const preventNavigationEnabled = computed(
+      () => props.preventNavigationWhenDirty ?? config.get('form.preventNavigationWhenDirty'),
+    )
+
+    const setupDirtyFormGuard = () => {
+      unregisterDirtyFormGuard?.()
+      unregisterDirtyFormGuard = null
+
+      if (!preventNavigationEnabled.value) {
+        return
+      }
+
+      unregisterDirtyFormGuard = dirtyFormGuard.register({
+        isDirty: () => isDirty.value,
+        isSubmitting: () => isSubmitting,
+        message: props.unsavedChangesMessage,
+      })
+    }
 
     const defaultData = ref(new FormData())
 
@@ -219,12 +249,16 @@ const Form = defineComponent({
     const formEvents: Array<keyof HTMLElementEventMap> = ['input', 'change', 'reset']
 
     onMounted(() => {
+      setupDirtyFormGuard()
       defaultData.value = getFormData()
 
       form.defaults(getData())
 
       formEvents.forEach((e) => formElement.value.addEventListener(e, onFormUpdate))
     })
+
+    watch(preventNavigationEnabled, setupDirtyFormGuard)
+    watch(() => props.unsavedChangesMessage, setupDirtyFormGuard)
 
     watch(
       () => props.validateFiles,
@@ -237,6 +271,7 @@ const Form = defineComponent({
     )
 
     onBeforeUnmount(() => {
+      unregisterDirtyFormGuard?.()
       formEvents.forEach((e) => formElement.value?.removeEventListener(e, onFormUpdate))
 
       if (props.cancelOnUnmount) {
@@ -291,10 +326,18 @@ const Form = defineComponent({
         component: resolvedComponent.value,
         optimistic: props.optimistic ? (pageProps) => props.optimistic!(pageProps, data) : undefined,
         onCancelToken: props.onCancelToken,
-        onBefore: props.onBefore,
+        onBefore: (visit) => {
+          isSubmitting = true
+
+          return props.onBefore?.(visit)
+        },
         onStart: props.onStart,
         onProgress: props.onProgress,
-        onFinish: props.onFinish,
+        onFinish: (visit) => {
+          isSubmitting = false
+
+          return props.onFinish?.(visit)
+        },
         onCancel: props.onCancel,
         onSuccess: async (...args) => {
           const result = await props.onSuccess?.(...args)

--- a/packages/vue3/src/useForm.ts
+++ b/packages/vue3/src/useForm.ts
@@ -74,6 +74,7 @@ export interface InertiaFormProps<TForm extends object> {
   cancel(): void
   dontRemember<K extends FormDataKeys<TForm>>(...fields: K[]): this
   optimistic<TProps>(callback: OptimisticCallback<TProps>): this
+  preventNavigationWhenDirty(message?: string): this
   withPrecognition(...args: UseFormWithPrecognitionArguments): InertiaPrecognitiveForm<TForm>
 }
 
@@ -156,6 +157,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
     setRememberExcludeKeys,
     resetBeforeSubmit,
     finishProcessing,
+    setSubmitting,
   } = useFormState<TForm>({
     data,
     rememberKey,
@@ -185,6 +187,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
           return options.onCancelToken?.(token)
         },
         onBefore: (visit) => {
+          setSubmitting(true)
           resetBeforeSubmit()
 
           return options.onBefore?.(visit)
@@ -220,6 +223,7 @@ export default function useForm<TForm extends FormDataType<TForm>>(
           return options.onCancel?.()
         },
         onFinish: (visit) => {
+          setSubmitting(false)
           finishProcessing()
           cancelToken = null
 

--- a/packages/vue3/src/useFormState.ts
+++ b/packages/vue3/src/useFormState.ts
@@ -10,6 +10,7 @@ import {
   UseFormTransformCallback,
   UseFormUtils,
   UseFormWithPrecognitionArguments,
+  dirtyFormGuard,
 } from '@inertiajs/core'
 import { cloneDeep, isEqual } from 'es-toolkit'
 import { get, has, set } from 'es-toolkit/compat'
@@ -21,7 +22,7 @@ import {
   ValidationConfig,
   Validator,
 } from 'laravel-precognition'
-import { reactive, watch } from 'vue'
+import { onMounted, onUnmounted, reactive, watch } from 'vue'
 import { config } from '.'
 
 type PrecognitionValidationConfig<TKeys> = ValidationConfig & {
@@ -46,6 +47,7 @@ export interface FormStateProps<TForm extends object> {
   resetAndClearErrors<K extends FormDataKeys<TForm>>(...fields: K[]): this
   setError<K extends FormDataKeys<TForm>>(field: K, value: ErrorValue): this
   setError(errors: FormDataErrors<TForm>): this
+  preventNavigationWhenDirty(message?: string): this
   withPrecognition(...args: UseFormWithPrecognitionArguments): this & FormStateValidationProps<TForm>
 }
 
@@ -102,6 +104,8 @@ export interface UseFormStateReturn<TForm extends object> {
   resetBeforeSubmit: () => void
   finishProcessing: () => void
   withAllErrors: { enabled: () => boolean; enable: () => void }
+  setSubmitting: (value: boolean) => void
+  preventNavigationWhenDirty: { enabled: () => boolean; enable: (message?: string) => void; message: () => string | undefined }
 }
 
 export default function useFormState<TForm extends object>(
@@ -123,6 +127,12 @@ export default function useFormState<TForm extends object>(
   let validatorRef: Validator | null = null
   let withAllErrors: boolean | null = null
   const withAllErrorsEnabled = () => withAllErrors ?? config.get('form.withAllErrors')
+  let preventNavigationWhenDirtyEnabled: boolean | null = null
+  let preventNavigationMessage: string | undefined
+  const preventNavigationEnabled = () =>
+    preventNavigationWhenDirtyEnabled ?? config.get('form.preventNavigationWhenDirty')
+  let isSubmitting = false
+  let unregisterDirtyFormGuard: VoidFunction | null = null
   let recentlySuccessfulTimeoutId: ReturnType<typeof setTimeout> | undefined
   let defaultsCalledInOnSuccess = false
   let rememberExcludeKeys: FormDataKeys<TForm>[] = []
@@ -136,6 +146,10 @@ export default function useFormState<TForm extends object>(
     progress: null as Progress | null,
     wasSuccessful: false,
     recentlySuccessful: false,
+
+    preventNavigationWhenDirty(_message?: string) {
+      return this
+    },
 
     withPrecognition(...args: UseFormWithPrecognitionArguments): FormStateWithPrecognition<TForm> {
       precognitionEndpoint = UseFormUtils.createWayfinderCallback(...args)
@@ -357,6 +371,29 @@ export default function useFormState<TForm extends object>(
 
   const typedForm = form as any as FormState<TForm> & InternalRememberState<TForm>
 
+  const setupDirtyFormGuard = () => {
+    unregisterDirtyFormGuard?.()
+    unregisterDirtyFormGuard = null
+
+    if (!preventNavigationEnabled()) {
+      return
+    }
+
+    unregisterDirtyFormGuard = dirtyFormGuard.register({
+      isDirty: () => typedForm.isDirty,
+      isSubmitting: () => isSubmitting,
+      message: preventNavigationMessage,
+    })
+  }
+
+  typedForm.preventNavigationWhenDirty = function (message?: string) {
+    preventNavigationWhenDirtyEnabled = true
+    preventNavigationMessage = message
+    setupDirtyFormGuard()
+
+    return this
+  }
+
   // Set restored errors if any
   if (restored?.errors) {
     typedForm.setError(restored.errors as FormDataErrors<TForm>)
@@ -391,6 +428,14 @@ export default function useFormState<TForm extends object>(
   if (precognitionEndpoint) {
     typedForm.withPrecognition(precognitionEndpoint)
   }
+
+  onMounted(() => {
+    setupDirtyFormGuard()
+  })
+
+  onUnmounted(() => {
+    unregisterDirtyFormGuard?.()
+  })
 
   return {
     form: typedForm,
@@ -430,6 +475,18 @@ export default function useFormState<TForm extends object>(
       enable: () => {
         withAllErrors = true
       },
+    },
+    setSubmitting: (value: boolean) => {
+      isSubmitting = value
+    },
+    preventNavigationWhenDirty: {
+      enabled: preventNavigationEnabled,
+      enable: (message?: string) => {
+        preventNavigationWhenDirtyEnabled = true
+        preventNavigationMessage = message
+        setupDirtyFormGuard()
+      },
+      message: () => preventNavigationMessage,
     },
   }
 }

--- a/packages/vue3/test-app/Pages/FormHelper/PreventNavigationWhenDirty.vue
+++ b/packages/vue3/test-app/Pages/FormHelper/PreventNavigationWhenDirty.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { Form, Link, useForm } from '@inertiajs/vue3'
+
+const form = useForm({ name: 'foo' }).preventNavigationWhenDirty()
+</script>
+
+<template>
+  <div>
+    <div id="dirty-status">Form is <span v-if="form.isDirty">dirty</span><span v-else>clean</span></div>
+
+    <label>
+      Name
+      <input type="text" id="name" v-model="form.name" />
+    </label>
+
+    <button type="button" class="submit" @click="form.post('/form-helper/prevent-navigation-when-dirty')">
+      Submit form
+    </button>
+
+    <Link href="/form-helper/data" id="navigate-away">Navigate away</Link>
+
+    <Form
+      action="/form-helper/prevent-navigation-when-dirty"
+      method="post"
+      :prevent-navigation-when-dirty="true"
+      id="guarded-form"
+    >
+      <template #default="{ isDirty, processing }">
+        <div id="form-component-dirty-status">
+          Form component is <span v-if="isDirty">dirty</span><span v-else>clean</span>
+        </div>
+        <input type="text" name="title" id="form-title" value="initial" />
+        <button type="submit" :disabled="processing">Submit guarded form</button>
+      </template>
+    </Form>
+
+    <Link href="/form-helper/data" id="navigate-away-from-form">Navigate away from form</Link>
+  </div>
+</template>

--- a/playgrounds/react/resources/js/Components/Layout.tsx
+++ b/playgrounds/react/resources/js/Components/Layout.tsx
@@ -19,6 +19,9 @@ export default function Layout({ children, padding = true }: { children: React.R
         <Link href="/form" className="hover:underline" prefetch={['mount', 'click']} stale-after="1m">
           useForm
         </Link>
+        <Link href="/form/prevent-navigation-when-dirty" className="hover:underline">
+          Unsaved Changes
+        </Link>
         <Link href="/form-component" className="hover:underline">
           {'<Form>'}
         </Link>

--- a/playgrounds/react/resources/js/Pages/PreventNavigationWhenDirty.tsx
+++ b/playgrounds/react/resources/js/Pages/PreventNavigationWhenDirty.tsx
@@ -1,0 +1,117 @@
+import { Form, Head, Link, useForm } from '@inertiajs/react'
+
+export default function PreventNavigationWhenDirty() {
+  const form = useForm({ name: '' }).preventNavigationWhenDirty()
+
+  return (
+    <>
+      <Head title="Unsaved Changes" />
+      <h1 className="text-3xl">Unsaved Changes</h1>
+
+      <div className="mt-6 max-w-2xl space-y-8">
+        <section className="space-y-4">
+          <h2 className="text-xl font-medium">useForm</h2>
+          <p className="text-sm text-gray-600">
+            Form is{' '}
+            <span className={form.isDirty ? 'font-medium text-amber-700' : 'font-medium text-gray-500'}>
+              {form.isDirty ? 'dirty' : 'clean'}
+            </span>
+          </p>
+
+          {form.isDirty && (
+            <div className="rounded-sm border border-amber-100 bg-amber-50 p-3 text-amber-800">
+              There are unsaved changes!
+            </div>
+          )}
+
+          <div>
+            <label className="block" htmlFor="name">
+              Name
+            </label>
+            <input
+              id="name"
+              type="text"
+              value={form.data.name}
+              onChange={(e) => form.setData('name', e.target.value)}
+              className="mt-1 w-full appearance-none rounded-sm border border-gray-200 px-2 py-1 shadow-xs"
+            />
+          </div>
+
+          <div className="flex gap-4">
+            <button
+              type="button"
+              className="rounded-sm bg-slate-800 px-6 py-2 text-white"
+              disabled={form.processing}
+              onClick={() => form.post('/form/prevent-navigation-when-dirty')}
+            >
+              Submit
+            </button>
+            <Link href="/users" className="rounded-sm border border-gray-200 px-6 py-2 hover:bg-gray-50">
+              Navigate away
+            </Link>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-medium">&lt;Form&gt; component</h2>
+
+          <Form action="/form/prevent-navigation-when-dirty" method="post" preventNavigationWhenDirty>
+            {({ isDirty, processing }) => (
+              <>
+                <p className="text-sm text-gray-600">
+                  Form component is{' '}
+                  <span className={isDirty ? 'font-medium text-amber-700' : 'font-medium text-gray-500'}>
+                    {isDirty ? 'dirty' : 'clean'}
+                  </span>
+                </p>
+
+                {isDirty && (
+                  <div className="rounded-sm border border-amber-100 bg-amber-50 p-3 text-amber-800">
+                    There are unsaved changes!
+                  </div>
+                )}
+
+                <div>
+                  <label className="block" htmlFor="title">
+                    Title
+                  </label>
+                  <input
+                    id="title"
+                    name="title"
+                    type="text"
+                    defaultValue="initial"
+                    className="mt-1 w-full appearance-none rounded-sm border border-gray-200 px-2 py-1 shadow-xs"
+                  />
+                </div>
+
+                <div className="flex gap-4">
+                  <button
+                    type="submit"
+                    className="rounded-sm bg-slate-800 px-6 py-2 text-white"
+                    disabled={processing}
+                  >
+                    Submit
+                  </button>
+                  <Link href="/users" className="rounded-sm border border-gray-200 px-6 py-2 hover:bg-gray-50">
+                    Navigate away
+                  </Link>
+                </div>
+              </>
+            )}
+          </Form>
+        </section>
+
+        <section className="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+          <h2 className="mb-2 font-medium">How to test</h2>
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>Edit a field so the form becomes dirty.</li>
+            <li>Click “Navigate away” — a browser confirmation should appear.</li>
+            <li>Dismiss to stay on this page, or accept to go to Users.</li>
+            <li>Submit while dirty — no confirmation should appear.</li>
+            <li>Refresh or close the tab while dirty — a beforeunload warning should appear.</li>
+          </ol>
+        </section>
+      </div>
+    </>
+  )
+}

--- a/playgrounds/react/routes/web.php
+++ b/playgrounds/react/routes/web.php
@@ -87,6 +87,19 @@ Route::get('/form', function () {
     return inertia('Form');
 });
 
+Route::get('/form/prevent-navigation-when-dirty', function () {
+    return inertia('PreventNavigationWhenDirty');
+});
+
+Route::post('/form/prevent-navigation-when-dirty', function () {
+    request()->validate([
+        'name' => ['nullable', 'string', 'max:255'],
+        'title' => ['nullable', 'string', 'max:255'],
+    ]);
+
+    return back();
+});
+
 Route::get('/form-component', function () {
     return inertia('FormComponent', [
         'foo' => fn () => now()->getTimestampMs(),

--- a/playgrounds/svelte5/resources/js/Components/Layout.svelte
+++ b/playgrounds/svelte5/resources/js/Components/Layout.svelte
@@ -12,6 +12,7 @@
   <a href="/users" use:inertia class="hover:underline">Users</a>
   <a href="/article" use:inertia class="hover:underline">Article</a>
   <a href="/form" use:inertia class="hover:underline">useForm</a>
+  <a href="/form/prevent-navigation-when-dirty" use:inertia class="hover:underline">Unsaved Changes</a>
   <a href="/form-component" use:inertia class="hover:underline">{'<Form>'}</a>
   <a href="/form-component/precognition" use:inertia class="hover:underline">Precognition</a>
   <a href="/photo-grid" use:inertia class="hover:underline">Photo Grid</a>

--- a/playgrounds/svelte5/resources/js/Pages/PreventNavigationWhenDirty.svelte
+++ b/playgrounds/svelte5/resources/js/Pages/PreventNavigationWhenDirty.svelte
@@ -1,0 +1,103 @@
+<script>
+  import { Form, Link, useForm } from '@inertiajs/svelte'
+
+  let { appName } = $props()
+
+  let form = useForm({ name: '' }).preventNavigationWhenDirty()
+</script>
+
+<svelte:head>
+  <title>Unsaved Changes - {appName}</title>
+</svelte:head>
+
+<h1 class="text-3xl">Unsaved Changes</h1>
+
+<div class="mt-6 max-w-2xl space-y-8">
+  <section class="space-y-4">
+    <h2 class="text-xl font-medium">useForm</h2>
+    <p class="text-sm text-gray-600">
+      Form is
+      {#if form.isDirty}
+        <span class="font-medium text-amber-700">dirty</span>
+      {:else}
+        <span class="font-medium text-gray-500">clean</span>
+      {/if}
+    </p>
+
+    {#if form.isDirty}
+      <div class="rounded-sm border border-amber-100 bg-amber-50 p-3 text-amber-800">There are unsaved changes!</div>
+    {/if}
+
+    <div>
+      <label class="block" for="name">Name</label>
+      <input
+        id="name"
+        type="text"
+        bind:value={form.name}
+        class="mt-1 w-full appearance-none rounded-sm border border-gray-200 px-2 py-1 shadow-xs"
+      />
+    </div>
+
+    <div class="flex gap-4">
+      <button
+        type="button"
+        class="rounded-sm bg-slate-800 px-6 py-2 text-white"
+        disabled={form.processing}
+        onclick={() => form.post('/form/prevent-navigation-when-dirty')}
+      >
+        Submit
+      </button>
+      <Link href="/users" class="rounded-sm border border-gray-200 px-6 py-2 hover:bg-gray-50">Navigate away</Link>
+    </div>
+  </section>
+
+  <section class="space-y-4">
+    <h2 class="text-xl font-medium">&lt;Form&gt; component</h2>
+
+    <Form action="/form/prevent-navigation-when-dirty" method="post" preventNavigationWhenDirty>
+      {#snippet children({ isDirty, processing })}
+        <p class="text-sm text-gray-600">
+          Form component is
+          {#if isDirty}
+            <span class="font-medium text-amber-700">dirty</span>
+          {:else}
+            <span class="font-medium text-gray-500">clean</span>
+          {/if}
+        </p>
+
+        {#if isDirty}
+          <div class="rounded-sm border border-amber-100 bg-amber-50 p-3 text-amber-800">There are unsaved changes!</div>
+        {/if}
+
+        <div>
+          <label class="block" for="title">Title</label>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            value="initial"
+            class="mt-1 w-full appearance-none rounded-sm border border-gray-200 px-2 py-1 shadow-xs"
+          />
+        </div>
+
+        <div class="flex gap-4">
+          <button type="submit" class="rounded-sm bg-slate-800 px-6 py-2 text-white" disabled={processing}>
+            Submit
+          </button>
+          <Link href="/users" class="rounded-sm border border-gray-200 px-6 py-2 hover:bg-gray-50">Navigate away</Link>
+        </div>
+      {/snippet}
+    </Form>
+  </section>
+
+  <section class="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+    <h2 class="mb-2 font-medium">How to test</h2>
+    <ol class="list-decimal space-y-1 pl-5">
+      <li>Edit a field so the form becomes dirty.</li>
+      <li>Click “Navigate away” — a browser confirmation should appear.</li>
+      <li>Dismiss to stay on this page, or accept to go to Users.</li>
+      <li>Submit while dirty — no confirmation should appear.</li>
+      <li>Refresh or close the tab while dirty — a beforeunload warning should appear.</li>
+    </ol>
+  </section>
+</div>

--- a/playgrounds/svelte5/routes/web.php
+++ b/playgrounds/svelte5/routes/web.php
@@ -133,6 +133,19 @@ Route::get('/form', function () {
     return inertia('Form');
 });
 
+Route::get('/form/prevent-navigation-when-dirty', function () {
+    return inertia('PreventNavigationWhenDirty');
+});
+
+Route::post('/form/prevent-navigation-when-dirty', function () {
+    request()->validate([
+        'name' => ['nullable', 'string', 'max:255'],
+        'title' => ['nullable', 'string', 'max:255'],
+    ]);
+
+    return back();
+});
+
 Route::post('/user', function () {
     return inertia('User', [
         'user' => request()->validate([

--- a/playgrounds/vue3/resources/js/Components/Layout.vue
+++ b/playgrounds/vue3/resources/js/Components/Layout.vue
@@ -16,6 +16,7 @@ const appName = computed(() => page.props.appName)
     <Link href="/users" class="hover:underline" prefetch :cache-for="['2s', '1m']">Users</Link>
     <Link href="/article" class="hover:underline" prefetch="click">Article</Link>
     <Link href="/form" class="hover:underline" :prefetch="['mount', 'click']" cache-for="1m">useForm</Link>
+    <Link href="/form/prevent-navigation-when-dirty" class="hover:underline">Unsaved Changes</Link>
     <Link href="/form-component" class="hover:underline">{{ '<' + 'Form' + '>' }}</Link>
     <Link href="/form-component/precognition" class="hover:underline">Precognition</Link>
     <Link href="/logout" method="post" class="hover:underline">Logout</Link>

--- a/playgrounds/vue3/resources/js/Pages/PreventNavigationWhenDirty.vue
+++ b/playgrounds/vue3/resources/js/Pages/PreventNavigationWhenDirty.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { Form, Head, Link, useForm } from '@inertiajs/vue3'
+
+const form = useForm({ name: '' }).preventNavigationWhenDirty()
+</script>
+
+<template>
+  <Head title="Unsaved Changes" />
+  <h1 class="text-3xl">Unsaved Changes</h1>
+
+  <div class="mt-6 max-w-2xl space-y-8">
+    <section class="space-y-4">
+      <h2 class="text-xl font-medium">useForm</h2>
+      <p class="text-sm text-gray-600">
+        Form is
+        <span v-if="form.isDirty" class="font-medium text-amber-700">dirty</span>
+        <span v-else class="font-medium text-gray-500">clean</span>
+      </p>
+
+      <div v-if="form.isDirty" class="rounded-sm border border-amber-100 bg-amber-50 p-3 text-amber-800">
+        There are unsaved changes!
+      </div>
+
+      <div>
+        <label class="block" for="name">Name</label>
+        <input
+          id="name"
+          v-model="form.name"
+          type="text"
+          class="mt-1 w-full appearance-none rounded-sm border border-gray-200 px-2 py-1 shadow-xs"
+        />
+      </div>
+
+      <div class="flex gap-4">
+        <button
+          type="button"
+          class="rounded-sm bg-slate-800 px-6 py-2 text-white"
+          :disabled="form.processing"
+          @click="form.post('/form/prevent-navigation-when-dirty')"
+        >
+          Submit
+        </button>
+        <Link href="/users" class="rounded-sm border border-gray-200 px-6 py-2 hover:bg-gray-50">Navigate away</Link>
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-medium">&lt;Form&gt; component</h2>
+
+      <Form action="/form/prevent-navigation-when-dirty" method="post" prevent-navigation-when-dirty>
+        <template #default="{ isDirty, processing }">
+          <p class="text-sm text-gray-600">
+            Form component is
+            <span v-if="isDirty" class="font-medium text-amber-700">dirty</span>
+            <span v-else class="font-medium text-gray-500">clean</span>
+          </p>
+
+          <div v-if="isDirty" class="rounded-sm border border-amber-100 bg-amber-50 p-3 text-amber-800">
+            There are unsaved changes!
+          </div>
+
+          <div>
+            <label class="block" for="title">Title</label>
+            <input
+              id="title"
+              name="title"
+              type="text"
+              value="initial"
+              class="mt-1 w-full appearance-none rounded-sm border border-gray-200 px-2 py-1 shadow-xs"
+            />
+          </div>
+
+          <div class="flex gap-4">
+            <button type="submit" class="rounded-sm bg-slate-800 px-6 py-2 text-white" :disabled="processing">
+              Submit
+            </button>
+            <Link href="/users" class="rounded-sm border border-gray-200 px-6 py-2 hover:bg-gray-50">
+              Navigate away
+            </Link>
+          </div>
+        </template>
+      </Form>
+    </section>
+
+    <section class="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+      <h2 class="mb-2 font-medium">How to test</h2>
+      <ol class="list-decimal space-y-1 pl-5">
+        <li>Edit a field so the form becomes dirty.</li>
+        <li>Click “Navigate away” — a browser confirmation should appear.</li>
+        <li>Dismiss to stay on this page, or accept to go to Users.</li>
+        <li>Submit while dirty — no confirmation should appear.</li>
+        <li>Refresh or close the tab while dirty — a beforeunload warning should appear.</li>
+      </ol>
+    </section>
+  </div>
+</template>

--- a/playgrounds/vue3/routes/web.php
+++ b/playgrounds/vue3/routes/web.php
@@ -142,6 +142,19 @@ Route::get('/form', function () {
     return inertia('Form');
 });
 
+Route::get('/form/prevent-navigation-when-dirty', function () {
+    return inertia('PreventNavigationWhenDirty');
+});
+
+Route::post('/form/prevent-navigation-when-dirty', function () {
+    request()->validate([
+        'name' => ['nullable', 'string', 'max:255'],
+        'title' => ['nullable', 'string', 'max:255'],
+    ]);
+
+    return back();
+});
+
 Route::get('/form-component', function () {
     return inertia('FormComponent', [
         'foo' => fn () => now()->getTimestampMs(),

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -589,6 +589,9 @@ app.post('/form-helper/effect-count', (req, res) =>
 
 app.post('/form-helper/dirty', (req, res) => res.redirect(303, '/form-helper/dirty'))
 app.post('/form-helper/dirty/redirect-back', (req, res) => res.redirect(303, '/form-helper/dirty'))
+app.post('/form-helper/prevent-navigation-when-dirty', (req, res) =>
+  res.redirect(303, '/form-helper/prevent-navigation-when-dirty'),
+)
 
 app.post('/form-helper/errors', (req, res) =>
   inertia.render(req, res, {

--- a/tests/form-helper.spec.ts
+++ b/tests/form-helper.spec.ts
@@ -444,6 +444,79 @@ test.describe('Form Helper', () => {
     })
   })
 
+  test.describe('Prevent navigation when dirty', () => {
+    test.beforeEach(async ({ page }) => {
+      pageLoads.watch(page)
+      await page.goto('/form-helper/prevent-navigation-when-dirty')
+    })
+
+    test('does not navigate when the user dismisses the confirmation dialog', async ({ page }) => {
+      await page.fill('#name', 'changed')
+      await expect(page.locator('#dirty-status')).toHaveText('Form is dirty')
+
+      page.once('dialog', (dialog) => {
+        expect(dialog.type()).toBe('confirm')
+        dialog.dismiss()
+      })
+
+      await page.locator('#navigate-away').click()
+
+      await expect(page).toHaveURL(/\/form-helper\/prevent-navigation-when-dirty$/)
+      await expect(page.locator('#dirty-status')).toHaveText('Form is dirty')
+    })
+
+    test('navigates when the user accepts the confirmation dialog', async ({ page }) => {
+      await page.fill('#name', 'changed')
+      await expect(page.locator('#dirty-status')).toHaveText('Form is dirty')
+
+      page.once('dialog', (dialog) => dialog.accept())
+
+      await page.locator('#navigate-away').click()
+
+      await expect(page).toHaveURL(/\/form-helper\/data$/)
+    })
+
+    test('does not prompt when submitting a dirty form', async ({ page }) => {
+      let dialogShown = false
+
+      page.on('dialog', () => {
+        dialogShown = true
+      })
+
+      await page.fill('#name', 'changed')
+      await page.getByRole('button', { name: 'Submit form', exact: true }).click()
+
+      await expect(page).toHaveURL(/\/form-helper\/prevent-navigation-when-dirty$/)
+      expect(dialogShown).toBe(false)
+    })
+
+    test('does not navigate from the Form component when the user dismisses the dialog', async ({ page }) => {
+      await page.fill('#form-title', 'changed')
+      await expect(page.locator('#form-component-dirty-status')).toHaveText('Form component is dirty')
+
+      page.once('dialog', (dialog) => dialog.dismiss())
+
+      await page.locator('#navigate-away-from-form').click()
+
+      await expect(page).toHaveURL(/\/form-helper\/prevent-navigation-when-dirty$/)
+      await expect(page.locator('#form-component-dirty-status')).toHaveText('Form component is dirty')
+    })
+
+    test('does not prompt when submitting a dirty Form component', async ({ page }) => {
+      let dialogShown = false
+
+      page.on('dialog', () => {
+        dialogShown = true
+      })
+
+      await page.fill('#form-title', 'changed')
+      await page.getByRole('button', { name: 'Submit guarded form', exact: true }).click()
+
+      await expect(page).toHaveURL(/\/form-helper\/prevent-navigation-when-dirty$/)
+      expect(dialogShown).toBe(false)
+    })
+  })
+
   test.describe('Data', () => {
     test.beforeEach(async ({ page }) => {
       pageLoads.watch(page)


### PR DESCRIPTION
This PR adds an opt-in guard that warns users before they navigate away from a page with unsaved form changes.

Inertia already tracks `isDirty` on `useForm()` and `<Form>`, but nothing stopped a user from clicking a `<Link>` and losing their work. This wires dirty state into navigation blocking so apps get a standard “unsaved changes” flow without every team reimplementing it.

The guard lives in `@inertiajs/core` (`dirtyFormGuard`) and is exposed consistently across React, Vue, and Svelte.

## What end users get

- **Fewer accidental data loss moments.** If someone edits a profile, starts a long form, or tweaks settings and then clicks away, they get a chance to stay on the page instead of silently losing input.
- **A clear, consistent prompt.** Inertia visits show a confirm dialog with a sensible default message: *“You have unsaved changes. Are you sure you want to navigate away?”*
- **Protection when leaving the site entirely.** Tab close, refresh, and external navigations trigger the browser’s native `beforeunload` prompt when a guarded form is dirty (browsers show their own generic text there - custom copy isn’t supported on that path).
- **No friction when saving.** Submitting a dirty form does not show the confirmation dialog - the guard treats an in-flight submit as intentional navigation.

## API

**Per form (recommended):**

```js
// useForm
const form = useForm({ name: '' }).preventNavigationWhenDirty()
// optional custom message:
const form = useForm({ name: '' }).preventNavigationWhenDirty('Your draft will be lost.')

// <Form> component
<Form prevent-navigation-when-dirty ... />
<Form prevent-navigation-when-dirty unsaved-changes-message="..." ... />
```

**Globally (optional):**

```js
config.form.preventNavigationWhenDirty = true
config.form.unsavedChangesMessage = '...'
```

Per-form settings override the global defaults. The fluent `preventNavigationWhenDirty()` method on `useForm()` is the primary opt-in - same pattern as other form configuration helpers.

## Why this doesn’t break existing apps

- **Opt-in by default.** `config.form.preventNavigationWhenDirty` defaults to `false`. No form is guarded unless you explicitly enable it on that form or turn it on globally.
- **Listeners are lazy.** The `inertia:before` and `beforeunload` handlers are only registered while at least one guarded form is mounted. Apps that don’t use the feature pay no runtime cost.
- **Prefetch visits are ignored.** Hover/prefetch navigation is not blocked - only real navigations prompt the user.
- **Submitting still works.** While a form is submitting, it is not considered “dirty” for guard purposes, so save flows aren’t interrupted by a confirmation dialog.
- **No changes to existing form behavior.** Dirty tracking, validation, submission, reset, and error handling are untouched. This only adds an optional layer on top of existing `isDirty` state.
- **Adapter parity.** React, Vue, and Svelte all use the same core guard, so behavior is consistent and covered by shared Playwright tests.

## How this makes building web apps easier

Before this, blocking navigation on dirty forms meant wiring `router.on('before')`, tracking which forms were dirty, handling `beforeunload` separately, making sure submits were exempt, and duplicating that logic in every adapter. Easy to get wrong, and easy for one framework to behave differently from another.

## Implementation notes

- **Core:** `dirtyFormGuard` registers forms in a lightweight registry and hooks `inertia:before` to call `window.confirm()` when any registered form is dirty and not submitting.
- **Adapters:** `useForm` and `<Form>` register/unregister with the guard on mount/unmount and pass through optional custom messages.
- **Tests:** unit tests in `packages/core/tests/dirtyFormGuard.test.ts`; E2E coverage in `tests/form-helper.spec.ts` (dismiss/accept dialog, submit exemption, `<Form>` component).
- **Playgrounds:** demo pages added at `/form/prevent-navigation-when-dirty` in the Vue, React, and Svelte Laravel playgrounds for manual testing.

## Known limitations

| Scenario | Covered? |
|----------|----------|
| `<Link>` clicks, `router.visit()`, programmatic Inertia visits | Yes - via `inertia:before` + `window.confirm()` |
| Tab close / refresh / leaving the origin | Yes - via `beforeunload` (browser-controlled message) |
| Browser back / forward buttons | No - not reliably interceptable in SPAs |
| Client-side `router.push()` / `router.replace()` | No - these manipulate history without an Inertia visit |
