### PR TITLE
[3.x] Preserve URL changes made while the page is mounting

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -163,7 +163,11 @@ class History {
     return window.history.state?.documentScrollPosition || { top: 0, left: 0 }
   }
 
-  public replaceState(page: Page, cb: (() => void) | null = null): void {
+  public replaceState(
+    page: Page,
+    cb: (() => void) | null = null,
+    { preserveCurrentUrl = false }: { preserveCurrentUrl?: boolean } = {},
+  ): void {
     if (isEqual(this.current, page)) {
       cb && cb()
       return
@@ -189,7 +193,14 @@ class History {
       return this.getPageData(page).then((data) => {
         // Defer history.replaceState to the next event loop tick to prevent timing conflicts.
         // Ensure any previous history.pushState completes before replaceState is executed.
-        const doReplace = () => this.doReplaceState({ page: data }, page.url).then(() => cb?.())
+        //
+        // With `preserveCurrentUrl` the write only stores the page state on the
+        // existing entry: omitting the URL keeps whatever is in the address bar by
+        // the time this queued write flushes, so URL changes made via the History
+        // API while the page was mounting (query params added by the app or a
+        // third-party library) are not reverted to the server-provided URL.
+        const doReplace = () =>
+          this.doReplaceState({ page: data }, preserveCurrentUrl ? undefined : page.url).then(() => cb?.())
 
         if (isChromeIOS) {
           return new Promise((resolve) => {

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -96,13 +96,17 @@ class CurrentPage {
       const isServer = typeof window === 'undefined'
       const location = !isServer ? window.location : new URL(page.url)
       const scrollRegions = !isServer && preserveScroll ? Scroll.getScrollRegions() : []
-      replace = replace || isSameUrlWithoutHash(hrefToUrl(page.url), location)
+      // The initial render must always replace: the browser already has an
+      // entry for the requested URL, so pushing would add a duplicate one.
+      replace = replace || initialRender || isSameUrlWithoutHash(hrefToUrl(page.url), location)
 
       // Clear flash data from the page object, we don't want it when navigating back/forward...
       const pageForHistory = { ...page, flash: {} }
 
       return new Promise<void>((resolve) =>
-        replace ? history.replaceState(pageForHistory, resolve) : history.pushState(pageForHistory, resolve),
+        replace
+          ? history.replaceState(pageForHistory, resolve, { preserveCurrentUrl: initialRender })
+          : history.pushState(pageForHistory, resolve),
       ).then(() => {
         const isNewComponent = !this.isTheSame(page)
 

--- a/packages/react/test-app/Pages/UrlOnMount.tsx
+++ b/packages/react/test-app/Pages/UrlOnMount.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+
+let mutated = false
+
+export default () => {
+  const [settled, setSettled] = useState(false)
+  const [historyDelta, setHistoryDelta] = useState<number | null>(null)
+  const [search, setSearch] = useState('')
+
+  if (typeof window !== 'undefined' && !mutated) {
+    mutated = true
+
+    // Simulate an app (or third-party library) that adds a query param via the
+    // History API while the page is mounting, before Inertia's queued initial
+    // history write has flushed.
+    const historyLengthAtMount = window.history.length
+    window.history.replaceState(window.history.state, '', '/url-on-mount?step=1')
+
+    document.addEventListener(
+      'inertia:navigate',
+      () => {
+        setHistoryDelta(window.history.length - historyLengthAtMount)
+        setSearch(window.location.search)
+        setSettled(true)
+      },
+      { once: true },
+    )
+  }
+
+  return (
+    <div>
+      <h1>Url On Mount</h1>
+      {settled && (
+        <div id="settled">
+          <span className="search">{search}</span>
+          <span className="history-delta">{historyDelta}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/svelte/test-app/Pages/UrlOnMount.svelte
+++ b/packages/svelte/test-app/Pages/UrlOnMount.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  let settled = $state(false)
+  let historyDelta: number | null = $state(null)
+  let search = $state('')
+
+  if (typeof window !== 'undefined') {
+    // Simulate an app (or third-party library) that adds a query param via the
+    // History API while the page is mounting, before Inertia's queued initial
+    // history write has flushed.
+    const historyLengthAtMount = window.history.length
+    window.history.replaceState(window.history.state, '', '/url-on-mount?step=1')
+
+    document.addEventListener(
+      'inertia:navigate',
+      () => {
+        historyDelta = window.history.length - historyLengthAtMount
+        search = window.location.search
+        settled = true
+      },
+      { once: true },
+    )
+  }
+</script>
+
+<div>
+  <h1>Url On Mount</h1>
+  {#if settled}
+    <div id="settled">
+      <span class="search">{search}</span>
+      <span class="history-delta">{historyDelta}</span>
+    </div>
+  {/if}
+</div>

--- a/packages/vue3/test-app/Pages/UrlOnMount.vue
+++ b/packages/vue3/test-app/Pages/UrlOnMount.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const settled = ref(false)
+const historyDelta = ref<number | null>(null)
+const search = ref('')
+
+if (typeof window !== 'undefined') {
+  // Simulate an app (or third-party library) that adds a query param via the
+  // History API while the page is mounting, before Inertia's queued initial
+  // history write has flushed.
+  const historyLengthAtMount = window.history.length
+  window.history.replaceState(window.history.state, '', '/url-on-mount?step=1')
+
+  document.addEventListener(
+    'inertia:navigate',
+    () => {
+      historyDelta.value = window.history.length - historyLengthAtMount
+      search.value = window.location.search
+      settled.value = true
+    },
+    { once: true },
+  )
+}
+</script>
+
+<template>
+  <div>
+    <h1>Url On Mount</h1>
+    <div v-if="settled" id="settled">
+      <span class="search">{{ search }}</span>
+      <span class="history-delta">{{ historyDelta }}</span>
+    </div>
+  </div>
+</template>

--- a/tests/initial-visit.spec.ts
+++ b/tests/initial-visit.spec.ts
@@ -47,3 +47,19 @@ test('it handles back/forward navigation between Inertia and non-Inertia pages c
   )
   expect(inertiaRequests.length).toBe(0)
 })
+
+test('it preserves URL changes made via the History API while the page is mounting', async ({ page }) => {
+  await page.goto('/url-on-mount')
+
+  // The page adds `?step=1` via history.replaceState during mount, before
+  // Inertia's queued initial history write flushes. `#settled` appears once
+  // the initial visit has completed (on `inertia:navigate`).
+  await expect(page.locator('#settled')).toBeVisible()
+
+  // The query param must survive Inertia's initial history write...
+  await expect(page).toHaveURL('/url-on-mount?step=1')
+  await expect(page.locator('.search')).toHaveText('?step=1')
+
+  // ...and the initial page must not push an extra history entry.
+  await expect(page.locator('.history-delta')).toHaveText('0')
+})


### PR DESCRIPTION
Fixes #3243

## Problem

During the initial page load, `InitialVisit` → `page.set()` queues a history write that carries the **server-provided page URL** captured at enqueue time. The queue flushes asynchronously (component resolution, `structuredClone` of the props, optional history encryption), so any URL change made through the History API while the page is mounting — a query param synced by the app on mount, or one added by a third-party library — is silently reverted once the write flushes.

It gets worse: because the modified URL no longer matches `page.url`, `isSameUrlWithoutHash()` returns `false` and `page.set()` takes the `pushState` branch, so the initial page load also adds a **duplicate history entry**, breaking `history.back()`.

Since the race depends on how long the mount-time queue takes to drain, in real apps this surfaces as flaky behavior — for us it reliably reproduced on loaded CI machines (an onboarding page normalizing `?step=1` on mount) and intermittently on slow devices.

This is the same bug class as #2233, where the *scroll-position* writes reverted externally-added query params, fixed in #2280 by omitting the URL from those writes. The initial-visit write is the remaining URL-carrying async write that can revert the address bar.

## Fix

Two changes to `page.set()`, applied only to the initial render (`initialRender: true`, passed by `InitialVisit.handleDefault` / `handleLocation`):

1. **Always replace.** The browser already has a history entry for the requested URL, so pushing can only ever create a duplicate entry. (Previously `replace` was inferred from URL equality, which is exactly what broke when the URL had legitimately changed during mount.)
2. **Omit the URL from the write.** The initial write's purpose is to store the page object on the *existing* entry so back/forward restores work — not to navigate. `history.replaceState()` now accepts a `preserveCurrentUrl` option that skips passing a URL to `window.history.replaceState()`, keeping whatever is in the address bar by the time the queued write flushes. This mirrors what #2280 did for the scroll-position writes.

On a normal initial load (nobody touched the URL) the written entry is byte-for-byte what it was before — the address bar already shows `page.url` — so behavior is unchanged. Only when the URL was deliberately changed during mount does the outcome differ: the change now survives, and no duplicate entry is pushed.

## End-user benefit

Apps can keep using the documented escape hatch of the History API for cosmetic query-string updates (analytics params, step/wizard params, filter state) without their URL being nondeterministically reverted on page load, and without a stray extra history entry breaking the back button. This class of bug is particularly nasty to diagnose because it only loses the race on slow machines — several of us have chased it as CI-only test flakiness.

## Tests

Added a `UrlOnMount` page to all three test apps plus a shared Playwright test. The page adds `?step=1` via `history.replaceState` synchronously while mounting, then reports `location.search` and the `history.length` delta once the initial visit settles (`inertia:navigate`). The test asserts the param survives and no extra entry was pushed.

Before the fix (Vue/Svelte, where mount timing is synchronous and the race is lost deterministically):

```
1) [chromium] › tests/initial-visit.spec.ts › it preserves URL changes made via the History API while the page is mounting
   Expected string: "?step=1"
   Received string: ""
```

After the fix: passes on all three adapters, and the full suite is green (`pnpm test:vue`: 1190 passed / 18 skipped; the history/scroll/manual-visits/client-side-visits/events suites also pass on React and Svelte).
