### PR TITLE
[3.x] Prevent a stale optimistic response from reverting a newer optimistic update

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -25,7 +25,7 @@ class CurrentPage {
   protected optimisticBaseline: Partial<Page['props']> = {}
   protected pendingOptimistics: { id: number; callback: (props: Page['props']) => Partial<Page['props']> | void }[] = []
   protected optimisticCounter = 0
-  protected settledOptimisticId = 0
+  protected confirmedOptimisticId = 0
 
   public init<ComponentType = Component>({
     initialPage,
@@ -284,12 +284,12 @@ class CurrentPage {
     return ++this.optimisticCounter
   }
 
-  public markOptimisticSettled(id: number): void {
-    this.settledOptimisticId = Math.max(this.settledOptimisticId, id)
+  public markOptimisticConfirmed(id: number): void {
+    this.confirmedOptimisticId = Math.max(this.confirmedOptimisticId, id)
   }
 
-  public hasSettledOptimisticAfter(id: number): boolean {
-    return this.settledOptimisticId > id
+  public hasConfirmedOptimisticAfter(id: number): boolean {
+    return this.confirmedOptimisticId > id
   }
 
   public setBaseline(key: string, value: unknown): void {
@@ -353,7 +353,7 @@ class CurrentPage {
   public clearOptimisticState(): void {
     this.optimisticBaseline = {}
     this.pendingOptimistics = []
-    this.settledOptimisticId = 0
+    this.confirmedOptimisticId = 0
   }
 
   public isTheSame(page: Page): boolean {

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -25,6 +25,7 @@ class CurrentPage {
   protected optimisticBaseline: Partial<Page['props']> = {}
   protected pendingOptimistics: { id: number; callback: (props: Page['props']) => Partial<Page['props']> | void }[] = []
   protected optimisticCounter = 0
+  protected settledOptimisticId = 0
 
   public init<ComponentType = Component>({
     initialPage,
@@ -283,6 +284,14 @@ class CurrentPage {
     return ++this.optimisticCounter
   }
 
+  public markOptimisticSettled(id: number): void {
+    this.settledOptimisticId = Math.max(this.settledOptimisticId, id)
+  }
+
+  public hasSettledOptimisticAfter(id: number): boolean {
+    return this.settledOptimisticId > id
+  }
+
   public setBaseline(key: string, value: unknown): void {
     if (!(key in this.optimisticBaseline)) {
       this.optimisticBaseline[key] = value
@@ -344,6 +353,7 @@ class CurrentPage {
   public clearOptimisticState(): void {
     this.optimisticBaseline = {}
     this.pendingOptimistics = []
+    this.settledOptimisticId = 0
   }
 
   public isTheSame(page: Page): boolean {

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -21,19 +21,19 @@ export class Request {
   protected cancelToken!: AbortController
   protected requestParams: RequestParams
   protected requestHasFinished = false
-  protected optimistic: boolean
+  protected optimisticId: number | null
 
   constructor(
     params: ActiveVisit,
     protected page: Page,
-    { optimistic = false }: { optimistic?: boolean } = {},
+    { optimisticId = null }: { optimisticId?: number | null } = {},
   ) {
     this.requestParams = RequestParams.create(params)
     this.cancelToken = new AbortController()
-    this.optimistic = optimistic
+    this.optimisticId = optimisticId
   }
 
-  public static create(params: ActiveVisit, page: Page, options?: { optimistic?: boolean }): Request {
+  public static create(params: ActiveVisit, page: Page, options?: { optimisticId?: number | null }): Request {
     return new Request(params, page, options)
   }
 
@@ -46,7 +46,7 @@ export class Request {
   }
 
   public isOptimistic(): boolean {
-    return this.optimistic
+    return this.optimisticId !== null
   }
 
   public isPendingOptimistic(): boolean {
@@ -91,14 +91,14 @@ export class Request {
       .getClient()
       .request(processedConfig)
       .then((response) => {
-        this.response = Response.create(this.requestParams, response, this.page)
+        this.response = Response.create(this.requestParams, response, this.page, this.optimisticId)
 
         return this.response.handle()
       })
       .catch((error) => {
         // Handle HTTP error responses (4xx/5xx)
         if (error instanceof HttpResponseError) {
-          this.response = Response.create(this.requestParams, error.response, this.page)
+          this.response = Response.create(this.requestParams, error.response, this.page, this.optimisticId)
 
           return this.response.handle()
         }

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -344,7 +344,7 @@ export class Response {
 
     // An optimistic request that started later has already been confirmed, so these
     // props were read before that write and would roll it back on screen
-    return this.optimisticId !== null && currentPage.hasSettledOptimisticAfter(this.optimisticId)
+    return this.optimisticId !== null && currentPage.hasConfirmedOptimisticAfter(this.optimisticId)
   }
 
   protected preserveEqualProps(pageResponse: Page): void {

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -31,10 +31,16 @@ export class Response {
     protected requestParams: RequestParams,
     protected response: HttpResponse,
     protected originatingPage: Page,
+    protected optimisticId: number | null = null,
   ) {}
 
-  public static create(params: RequestParams, response: HttpResponse, originatingPage: Page): Response {
-    return new Response(params, response, originatingPage)
+  public static create(
+    params: RequestParams,
+    response: HttpResponse,
+    originatingPage: Page,
+    optimisticId: number | null = null,
+  ): Response {
+    return new Response(params, response, originatingPage, optimisticId)
   }
 
   public isProcessed(): boolean {
@@ -319,7 +325,7 @@ export class Response {
   }
 
   protected preserveOptimisticProps(pageResponse: Page): void {
-    if (!router.hasPendingOptimistic()) {
+    if (!this.shouldPreserveOptimisticProps()) {
       return
     }
 
@@ -329,6 +335,16 @@ export class Response {
         pageResponse.props[key] = currentPage.get().props[key]
       }
     }
+  }
+
+  protected shouldPreserveOptimisticProps(): boolean {
+    if (router.hasPendingOptimistic()) {
+      return true
+    }
+
+    // An optimistic request that started later has already been confirmed, so these
+    // props were read before that write and would roll it back on screen
+    return this.optimisticId !== null && currentPage.hasSettledOptimisticAfter(this.optimisticId)
   }
 
   protected preserveEqualProps(pageResponse: Page): void {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -302,8 +302,12 @@ export class Router {
       this.syncRequestStream.interruptInFlight()
     }
 
+    let optimisticId: number | null = null
+
     if (options.optimistic) {
-      this.applyOptimisticUpdate(options.optimistic, events)
+      optimisticId = currentPage.nextOptimisticId()
+
+      this.applyOptimisticUpdate(options.optimistic, events, optimisticId)
     }
 
     if (!currentPage.isCleared() && !visit.preserveUrl) {
@@ -325,7 +329,7 @@ export class Router {
       } else {
         progress.reveal(true)
         const requestStream = visit.async ? this.asyncRequestStream : this.syncRequestStream
-        requestStream.send(Request.create(requestParams, currentPage.get(), { optimistic: !!options.optimistic }))
+        requestStream.send(Request.create(requestParams, currentPage.get(), { optimisticId }))
       }
     }
 
@@ -798,7 +802,7 @@ export class Router {
     }
   }
 
-  protected applyOptimisticUpdate(optimistic: OptimisticCallback, events: VisitCallbacks): void {
+  protected applyOptimisticUpdate(optimistic: OptimisticCallback, events: VisitCallbacks, id: number): void {
     const currentProps = currentPage.get().props
     const optimisticProps = optimistic(cloneDeep(currentProps))
 
@@ -818,7 +822,6 @@ export class Router {
       return
     }
 
-    const id = currentPage.nextOptimisticId()
     const component = currentPage.get().component
 
     for (const key of changedKeys) {
@@ -833,6 +836,8 @@ export class Router {
     const originalOnSuccess = events.onSuccess
     events.onSuccess = (page) => {
       shouldRestore = false
+      currentPage.markOptimisticSettled(id)
+
       return originalOnSuccess(page)
     }
 

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -836,7 +836,7 @@ export class Router {
     const originalOnSuccess = events.onSuccess
     events.onSuccess = (page) => {
       shouldRestore = false
-      currentPage.markOptimisticSettled(id)
+      currentPage.markOptimisticConfirmed(id)
 
       return originalOnSuccess(page)
     }

--- a/packages/react/test-app/Pages/Optimistic/Rollback.tsx
+++ b/packages/react/test-app/Pages/Optimistic/Rollback.tsx
@@ -9,14 +9,14 @@ interface Contact {
 export default ({ contacts, errors }: { contacts: Contact[]; errors?: Record<string, string> }) => {
   const toggleFavorite = (
     contact: Contact,
-    { delay = 500, error = false }: { delay?: number; error?: boolean } = {},
+    { delay = 500, error = false, hold = 0 }: { delay?: number; error?: boolean; hold?: number } = {},
   ) => {
     router
       .optimistic<{ contacts: Contact[] }>((props) => ({
         contacts: props.contacts.map((c) => (c.id === contact.id ? { ...c, is_favorite: !c.is_favorite } : c)),
       }))
       .post(
-        `/optimistic/rollback/toggle/${contact.id}?delay=${delay}&error=${error ? '1' : '0'}`,
+        `/optimistic/rollback/toggle/${contact.id}?delay=${delay}&error=${error ? '1' : '0'}&hold=${hold}`,
         {},
         { preserveScroll: true },
       )
@@ -49,6 +49,9 @@ export default ({ contacts, errors }: { contacts: Contact[]; errors?: Record<str
               onClick={() => toggleFavorite(contact, { delay: 1000, error: true })}
             >
               Toggle (Slow Error)
+            </button>
+            <button className="toggle-held-btn" onClick={() => toggleFavorite(contact, { hold: 1000 })}>
+              Toggle (Held)
             </button>
           </div>
         ))}

--- a/packages/svelte/test-app/Pages/Optimistic/Rollback.svelte
+++ b/packages/svelte/test-app/Pages/Optimistic/Rollback.svelte
@@ -16,14 +16,14 @@
 
   const toggleFavorite = (
     contact: Contact,
-    { delay = 500, error = false }: { delay?: number; error?: boolean } = {},
+    { delay = 500, error = false, hold = 0 }: { delay?: number; error?: boolean; hold?: number } = {},
   ) => {
     router
       .optimistic<{ contacts: Contact[] }>((props) => ({
         contacts: props.contacts.map((c) => (c.id === contact.id ? { ...c, is_favorite: !c.is_favorite } : c)),
       }))
       .post(
-        `/optimistic/rollback/toggle/${contact.id}?delay=${delay}&error=${error ? '1' : '0'}`,
+        `/optimistic/rollback/toggle/${contact.id}?delay=${delay}&error=${error ? '1' : '0'}&hold=${hold}`,
         {},
         { preserveScroll: true },
       )
@@ -49,6 +49,7 @@
         <button class="toggle-slow-error-btn" onclick={() => toggleFavorite(contact, { delay: 1000, error: true })}
           >Toggle (Slow Error)</button
         >
+        <button class="toggle-held-btn" onclick={() => toggleFavorite(contact, { hold: 1000 })}>Toggle (Held)</button>
       </div>
     {/each}
   </div>

--- a/packages/vue3/test-app/Pages/Optimistic/Rollback.vue
+++ b/packages/vue3/test-app/Pages/Optimistic/Rollback.vue
@@ -12,13 +12,16 @@ defineProps<{
   errors?: Record<string, string>
 }>()
 
-const toggleFavorite = (contact: Contact, { delay = 500, error = false }: { delay?: number; error?: boolean } = {}) => {
+const toggleFavorite = (
+  contact: Contact,
+  { delay = 500, error = false, hold = 0 }: { delay?: number; error?: boolean; hold?: number } = {},
+) => {
   router
     .optimistic<{ contacts: Contact[] }>((props) => ({
       contacts: props.contacts.map((c) => (c.id === contact.id ? { ...c, is_favorite: !c.is_favorite } : c)),
     }))
     .post(
-      `/optimistic/rollback/toggle/${contact.id}?delay=${delay}&error=${error ? '1' : '0'}`,
+      `/optimistic/rollback/toggle/${contact.id}?delay=${delay}&error=${error ? '1' : '0'}&hold=${hold}`,
       {},
       { preserveScroll: true },
     )
@@ -43,6 +46,7 @@ const reset = () => {
         <button class="toggle-slow-error-btn" @click="toggleFavorite(contact, { delay: 1000, error: true })">
           Toggle (Slow Error)
         </button>
+        <button class="toggle-held-btn" @click="toggleFavorite(contact, { hold: 1000 })">Toggle (Held)</button>
       </div>
     </div>
 

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -3474,7 +3474,31 @@ app.get('/optimistic/rollback', (req, res) => {
 
 app.post('/optimistic/rollback/toggle/:id', (req, res) => {
   const delay = parseInt(req.query.delay || '500')
+  const hold = parseInt(req.query.hold || '0')
   const simulateError = req.query.error === '1'
+
+  if (hold > 0) {
+    // Commit the write and snapshot the props right away, but hold the
+    // response on the wire so it lands after later requests have settled
+    const session = getOptimisticSession(req)
+    const contact = session.contacts.find((c) => c.id === parseInt(req.params.id))
+
+    if (contact) {
+      contact.is_favorite = !contact.is_favorite
+    }
+
+    const contacts = session.contacts.map((c) => ({ ...c }))
+
+    setTimeout(() => {
+      inertia.render(req, res, {
+        component: 'Optimistic/Rollback',
+        url: '/optimistic/rollback',
+        props: { contacts },
+      })
+    }, hold)
+
+    return
+  }
 
   setTimeout(() => {
     if (simulateError) {

--- a/tests/optimistic-rollback.spec.ts
+++ b/tests/optimistic-rollback.spec.ts
@@ -69,4 +69,28 @@ test.describe('Optimistic Rollback', () => {
     await expect(page.locator('.contact-status').nth(1)).toContainText('Favorite')
     await expect(page.locator('.contact-status').nth(2)).toContainText('Not Favorite')
   })
+
+  test('it does not let a stale optimistic response revert a newer optimistic update', async ({ page }) => {
+    pageLoads.watch(page)
+
+    // Request 1: toggle John. The server commits and snapshots its props right
+    // away, but holds the response until after request 2 has settled
+    await page.locator('.toggle-held-btn').nth(0).click()
+
+    // Request 2: toggle Jane, settles first
+    await page.locator('.toggle-btn').nth(1).click()
+
+    await expect(page.locator('.contact-status').nth(0)).toHaveText('Favorite')
+    await expect(page.locator('.contact-status').nth(1)).toHaveText('Favorite')
+
+    await page.waitForTimeout(700)
+    await expect(page.locator('.contact-status').nth(0)).toHaveText('Favorite')
+    await expect(page.locator('.contact-status').nth(1)).toHaveText('Favorite')
+
+    // Request 1 lands last with props that predate Jane's write, and nothing
+    // else is pending. Jane should not be reverted by it
+    await page.waitForTimeout(800)
+    await expect(page.locator('.contact-status').nth(0)).toHaveText('Favorite')
+    await expect(page.locator('.contact-status').nth(1)).toHaveText('Favorite')
+  })
 })

--- a/tests/optimistic.spec.ts
+++ b/tests/optimistic.spec.ts
@@ -127,9 +127,9 @@ test.describe('Optimistic', () => {
     await page.locator('#reset-likes-btn').click()
     await expect(page.locator('#likes-count')).toContainText('Likes: 0')
 
-    // Server responds with likes=5 (slow) and likes=3 (fast)
-    await page.locator('#like-controlled-slow-btn').click()
+    // Server responds with likes=3 (fast) and likes=5 (slow)
     await page.locator('#like-controlled-fast-btn').click()
+    await page.locator('#like-controlled-slow-btn').click()
 
     await expect(page.locator('#likes-count')).toContainText('Likes: 2')
 
@@ -157,6 +157,27 @@ test.describe('Optimistic', () => {
     await page.waitForTimeout(300)
     await expect(page.locator('#likes-count')).toContainText('Likes: 1')
 
+    await page.waitForTimeout(800)
+    await expect(page.locator('#likes-count')).toContainText('Likes: 5')
+  })
+
+  test('it applies the last server response when a newer optimistic request errored first', async ({ page }) => {
+    pageLoads.watch(page)
+
+    await page.locator('#reset-likes-btn').click()
+    await expect(page.locator('#likes-count')).toContainText('Likes: 0')
+
+    await page.locator('#like-controlled-slow-btn').click()
+    await page.locator('#like-error-btn').click()
+
+    await expect(page.locator('#likes-count')).toContainText('Likes: 2')
+
+    // The newer request errors and rolls back, leaving the older pending +1 replayed
+    await page.waitForTimeout(300)
+    await expect(page.locator('#likes-count')).toContainText('Likes: 1')
+
+    // The newer request never wrote anything, so the older response is still the
+    // freshest server state and should reconcile
     await page.waitForTimeout(800)
     await expect(page.locator('#likes-count')).toContainText('Likes: 5')
   })


### PR DESCRIPTION
When two optimistic requests are in flight and the first one's response arrives last, its props predate the second request's write and roll that update back on screen. There's no error, and the UI disagrees with the server until the next navigation. The shield in `preserveOptimisticProps()` only holds optimistic props while other optimistic requests are still pending, so once the last request is the only one left, its props are applied raw even when it was the first one sent and carries the oldest snapshot.

Optimistic requests now carry an id, and the page tracks the highest id the server has confirmed. A response is shielded when an optimistic write that started later has already succeeded, since its props were read before that write. Failed requests don't count as confirmed, so an older successful response still reconciles with the server after a newer request errored and rolled back.

Fixes #3241.